### PR TITLE
Refactor RawServer to return RawServerEvent

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,7 +7,7 @@ use std::{error, fmt};
 pub use crate::client::raw::RawClient;
 pub use crate::client::Client;
 pub use crate::local::local_raw;
-pub use crate::server::raw::RawServer;
+pub use crate::server::raw::{RawServer, RawServerEvent};
 pub use crate::server::{Server, ServerEvent, ServerRequestId, ServerSubscriptionId};
 
 pub mod client;

--- a/core/src/server/raw.rs
+++ b/core/src/server/raw.rs
@@ -7,7 +7,7 @@
 //! ## Example usage
 //!
 //! ```
-//! use jsonrpsee_core::server::raw::RawServer;
+//! use jsonrpsee_core::server::raw::{RawServer, RawServerEvent};
 //! use jsonrpsee_core::common::{Error, Request, Response, Version};
 //!
 //! async fn run_server(server: &mut impl RawServer) {
@@ -15,9 +15,15 @@
 //!     // server while `request_to_response` is running. This is fine as long as building the
 //!     // response is instantaneous (which is the case in this exampe), but probably isn't for
 //!     // actual real-world usages.
-//!     while let Ok((rq_id, rq_body)) = server.next_request().await {
-//!         let response = request_to_response(&rq_body).await;
-//!         let _ = server.finish(&rq_id, Some(&response)).await;
+//!     loop {
+//!         match server.next_request().await {
+//!             RawServerEvent::ServerClosed => break,
+//!             RawServerEvent::Closed(_) => {},
+//!             RawServerEvent::Request { id, request } => {
+//!                 let response = request_to_response(&request).await;
+//!                 let _ = server.finish(&id, Some(&response)).await;
+//!             },
+//!         }
 //!     }
 //! }
 //!
@@ -29,7 +35,7 @@
 //!
 
 pub use self::join::{join, Join, JoinRequestId};
-pub use self::traits::RawServer;
+pub use self::traits::{RawServer, RawServerEvent};
 
 mod join;
 mod traits;

--- a/core/src/server/raw/traits.rs
+++ b/core/src/server/raw/traits.rs
@@ -76,8 +76,8 @@ pub enum RawServerEvent<T> {
     /// A new request has arrived on the wire.
     ///
     /// This generates a new "request object" within the state of the [`RawServer`] that is
-    /// identified through the returned [`id`](RawServerEvent::Request::id). You can then use the
-    /// other methods of the [`RawServer`] trait in order to manipulate that request.
+    /// identified through the returned `id`. You can then use the other methods of the
+    /// [`RawServer`] trait in order to manipulate that request.
     Request {
         /// Identifier of the request within the state of the [`RawServer`].
         id: T,

--- a/core/src/server/raw/traits.rs
+++ b/core/src/server/raw/traits.rs
@@ -20,14 +20,9 @@ pub trait RawServer {
     /// Identifier for a request in the context of this server.
     type RequestId: Clone + PartialEq + Eq + Hash + Send + Sync;
 
-    /// Returns the next request, or an error if the server has closed.
-    ///
-    /// This generates a new "request object" within the state of the `RawServer` that is
-    /// identified through the returned `RequestId`. You can then use the other methods of this
-    /// trait in order to manipulate that request.
-    fn next_request<'a>(
-        &'a mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<(Self::RequestId, common::Request), ()>> + Send + 'a>>;
+    /// Returns the next event that the raw server wants to notify us.
+    fn next_request<'a>(&'a mut self)
+        -> Pin<Box<dyn Future<Output = RawServerEvent<Self::RequestId>> + Send + 'a>>;
 
     /// Sends back a response and destroys the request.
     ///
@@ -73,4 +68,30 @@ pub trait RawServer {
         request_id: &'a Self::RequestId,
         response: &'a common::Response,
     ) -> Pin<Box<dyn Future<Output = Result<(), ()>> + Send + 'a>>;
+}
+
+/// Event that the [`RawServer`] can generate.
+#[derive(Debug, PartialEq)]
+pub enum RawServerEvent<T> {
+    /// A new request has arrived on the wire.
+    ///
+    /// This generates a new "request object" within the state of the [`RawServer`] that is
+    /// identified through the returned [`id`](RawServerEvent::Request::id). You can then use the
+    /// other methods of the [`RawServer`] trait in order to manipulate that request.
+    Request {
+        /// Identifier of the request within the state of the [`RawServer`].
+        id: T,
+        /// Body of the request.
+        request: common::Request,
+    },
+
+    /// A request has been cancelled, most likely because the client has closed the connection.
+    ///
+    /// The corresponding request is no longer valid to manipulate.
+    Closed(T),
+
+    /// The server has been closed and will not produce any more request.
+    // TODO: define the exact semantics of that; can the implementation panic afterwards? is it
+    // even a good idea to have an event?
+    ServerClosed,
 }


### PR DESCRIPTION
Instead of producing a `Result<(RequestId, Request), ()>` (where `Err` means "server closed"), we now produce a `RawServerEvent` with the variants `Request`, `Closed` (new!) and `ServerClosed`.
The `Closed` variant is used to notify when the client closes a connection. This is necessary in order to be able to stop subscriptions.