### PR TITLE
Tweak RawClient to allow subscriptions

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -53,9 +53,13 @@ where
             id,
         }));
 
-        let result = self
-            .inner
-            .request(request)
+        self.inner
+            .send_request(request)
+            .await
+            .map_err(ClientError::Inner)?;
+        
+        let result = self.inner
+            .next_response()
             .await
             .map_err(ClientError::Inner)?;
 
@@ -63,6 +67,8 @@ where
             common::Response::Single(common::Output::Success(s)) => s,
             _ => return Err(ClientError::WrongResponseKind),
         };
+
+        // TODO: check correspondance for the request ID
 
         Ok(common::from_value(val.result).map_err(ClientError::Deserialize)?)
     }

--- a/core/src/client/raw.rs
+++ b/core/src/client/raw.rs
@@ -5,13 +5,26 @@ use futures::prelude::*;
 use std::{error, pin::Pin};
 
 /// Objects that can act as clients.
+///
+/// > **Note**: Implementations of this trait are allowed (and encouraged, for example for
+/// >           HTTP 1.0) to open multiple simultaneous connections to the same server. However,
+/// >           since this trait doesn't expose the concept of a connection, and since
+/// >           implementations aren't expected to associated requests with responses, we have no
+/// >           way to enforce that the response to a request arrived on the same connection as the
+/// >           one where the request has been sent. In practice, this shouldn't be a problem.
+///
 pub trait RawClient {
     /// Error that can happen during a request.
     type Error: error::Error;
 
-    /// Starts a request. Returns a `Future` that finishes when the request succeeds or fails.
-    fn request<'a>(
+    /// Sends out out a request. Returns a `Future` that finishes when the request has been
+    /// successfully sent.
+    fn send_request<'a>(
         &'a mut self,
         request: common::Request,
-    ) -> Pin<Box<dyn Future<Output = Result<common::Response, Self::Error>> + Send + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'a>>;
+
+    /// Returns a `Future` resolving when the server sent us something back.
+    fn next_response<'a>(&'a mut self)
+        -> Pin<Box<dyn Future<Output = Result<common::Response, Self::Error>> + Send + 'a>>;
 }

--- a/http/src/client.rs
+++ b/http/src/client.rs
@@ -24,6 +24,8 @@ pub struct HttpRawClient {
     /// Sender that sends requests to the background task.
     requests_tx: mpsc::Sender<FrontToBack>,
     url: String,
+    /// Receives responses in any order.
+    responses: stream::FuturesUnordered<oneshot::Receiver<Result<hyper::Response<hyper::Body>, hyper::Error>>>,
 }
 
 /// Message transmitted from the foreground task to the background.
@@ -55,6 +57,7 @@ impl HttpRawClient {
         HttpRawClient {
             requests_tx,
             url: target.to_owned(),
+            responses: stream::FuturesUnordered::new(),
         }
     }
 }
@@ -62,10 +65,10 @@ impl HttpRawClient {
 impl RawClient for HttpRawClient {
     type Error = RequestError;
 
-    fn request<'s>(
+    fn send_request<'s>(
         &'s mut self,
         request: common::Request,
-    ) -> Pin<Box<dyn Future<Output = Result<common::Response, RequestError>> + Send + 's>> {
+    ) -> Pin<Box<dyn Future<Output = Result<(), RequestError>> + Send + 's>> {
         let mut requests_tx = self.requests_tx.clone();
 
         let request = common::to_vec(&request).map(|body| {
@@ -93,10 +96,19 @@ impl RawClient for HttpRawClient {
                 ))));
             }
 
-            let hyper_response = match send_back_rx.await {
-                Ok(Ok(r)) => r,
-                Ok(Err(err)) => return Err(RequestError::Http(Box::new(err))),
-                Err(_) => {
+            self.responses.push(send_back_rx);
+            Ok(())
+        })
+    }
+
+    fn next_response<'s>(&'s mut self)
+        -> Pin<Box<dyn Future<Output = Result<common::Response, RequestError>> + Send + 's>>
+    {
+        Box::pin(async move {
+            let hyper_response = match self.responses.next().await {
+                Some(Ok(Ok(r))) => r,
+                Some(Ok(Err(err))) => return Err(RequestError::Http(Box::new(err))),
+                None | Some(Err(_)) => {
                     log::error!("JSONRPC http client background thread has shut down");
                     return Err(RequestError::Http(Box::new(io::Error::new(
                         io::ErrorKind::Other,


### PR DESCRIPTION
cc #7 

Tweaks the `RawClient` trait to allow for connections that don't close down.
