### PR TITLE
Make notifications work with the proc macro

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -3,6 +3,8 @@ jsonrpsee::rpc_api! {
         /// Test
         fn system_name(foo: String, bar: i32) -> String;
 
+        fn test_notif(foo: String, bar: i32);
+
         /// Test2
         #[rpc(method = "foo")]
         fn system_name2() -> String;
@@ -28,12 +30,18 @@ fn main() {
                 Health::SystemName2 { respond } => {
                     respond.ok("hello 2").await;
                 }
+                Health::TestNotif { foo, bar } => {
+                    println!("server got notif: {:?} {:?}", foo, bar);
+                }
             }
         }
     });
 
     // Client demo.
     let mut client = jsonrpsee::http_client("http://127.0.0.1:8000");
-    let v = async_std::task::block_on(Health::system_name(&mut client, "hello", 5)).unwrap();
+    let v = async_std::task::block_on(async {
+        Health::test_notif(&mut client, "notif_string", 192).await.unwrap();
+        Health::system_name(&mut client, "hello", 5).await.unwrap()
+    });
     println!("{:?}", v);
 }

--- a/proc-macros/src/api_def.rs
+++ b/proc-macros/src/api_def.rs
@@ -38,6 +38,25 @@ pub struct ApiMethodAttrs {
     pub method: Option<String>,
 }
 
+impl ApiMethod {
+    /// Returns true if this method has a `()` return type.
+    ///
+    /// This is used to determine whether this should be a notification or a method call.
+    pub fn is_void_ret_type(&self) -> bool {
+        let ret_ty = match &self.signature.output {
+            syn::ReturnType::Default => return true,
+            syn::ReturnType::Type(_, ty) => ty,
+        };
+
+        let tuple_ret_ty = match &**ret_ty {
+            syn::Type::Tuple(tuple) => tuple,
+            _ => return false,
+        };
+
+        tuple_ret_ty.elems.is_empty()
+    }
+}
+
 /// Implementation detail of `ApiDefinition`.
 /// Parses one single block of function definitions.
 #[derive(Debug)]


### PR DESCRIPTION
Fixes the proc macro to make notifications properly work.
From the server side, notifications are the same as requests except without the `respond` parameter.

The code of the proc macro is getting kind of messy after this PR and will need to be cleaned up.