### PR TITLE
Make it compile again!

### DIFF
--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-async-std = "0.99.5"
+async-std = "=0.99.11"
 bytes = "0.4"
 err-derive = "0.1.5"
 fnv = "1.0"
@@ -19,4 +19,4 @@ log = "0.4"
 pin-utils = "0.1.0-alpha.4"
 serde = { version = "1.0.40", features = ["derive"] }
 serde_json = "1.0.40"
-soketto = { git = "https://github.com/twittner/soketto", rev = "86a4e8063bff6f08809febe76824126744240622" }
+soketto = { git = "https://github.com/paritytech/soketto", rev = "57bdcc3e979f816e011d9930a6ec8c6bd8d46d78" }


### PR DESCRIPTION
async-std 0.99.12 unfortunately uses futures 0.3, which is a breaking change.
We can't upgrade to futures 0.3 right now, as soketto isn't up-to-date just yet.