### PR TITLE
Servers can no longer error

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 bs58 = "0.3.0"
 err-derive = "0.1.5"
 fnv = "1.0"
-futures-preview = "0.3.0-alpha.19"
+futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
 log = "0.4"
 rand = "0.7"
 serde = { version = "1.0.40", features = ["derive"] }

--- a/core/src/local.rs
+++ b/core/src/local.rs
@@ -42,8 +42,8 @@
 //! let mut server = Server::new(raw_server);
 //!
 //! async_std::task::spawn(async move {
-//!     while let Ok(event) = server.next_event().await {
-//!         match event {
+//!     loop {
+//!         match server.next_event().await {
 //!             ServerEvent::Request(request) => {
 //!                 request.respond(Ok(From::from("hello".to_owned()))).await;
 //!             },
@@ -154,10 +154,10 @@ impl RawServer for LocalRawServer {
                     if let Some(rq_id) = self.requests.iter().cloned().next() {
                         self.requests.remove(&rq_id);
                         return RawServerEvent::Closed(rq_id);
-
                     } else {
-                        // TODO: should we really return that? does that event make sense at all?
-                        return RawServerEvent::ServerClosed;
+                        loop {
+                            futures::pending!()
+                        }
                     }
                 },
             };

--- a/core/src/server/raw.rs
+++ b/core/src/server/raw.rs
@@ -43,7 +43,6 @@
 //!     // actual real-world usages.
 //!     loop {
 //!         match server.next_request().await {
-//!             RawServerEvent::ServerClosed => break,
 //!             RawServerEvent::Closed(_) => {},
 //!             RawServerEvent::Request { id, request } => {
 //!                 let response = request_to_response(&request).await;

--- a/core/src/server/raw/join.rs
+++ b/core/src/server/raw/join.rs
@@ -71,17 +71,11 @@ where
                 future::Either::Left((RawServerEvent::Closed(id), _)) => {
                     RawServerEvent::Closed(JoinRequestId::Left(id))
                 }
-                future::Either::Left((RawServerEvent::ServerClosed, _)) => {
-                    RawServerEvent::ServerClosed
-                }
                 future::Either::Right((RawServerEvent::Request { id, request }, _)) => {
                     RawServerEvent::Request { id: JoinRequestId::Right(id), request }
                 }
                 future::Either::Right((RawServerEvent::Closed(id), _)) => {
                     RawServerEvent::Closed(JoinRequestId::Right(id))
-                }
-                future::Either::Right((RawServerEvent::ServerClosed, _)) => {
-                    RawServerEvent::ServerClosed
                 }
             }
         })

--- a/core/src/server/raw/traits.rs
+++ b/core/src/server/raw/traits.rs
@@ -115,9 +115,4 @@ pub enum RawServerEvent<T> {
     ///
     /// The corresponding request is no longer valid to manipulate.
     Closed(T),
-
-    /// The server has been closed and will not produce any more request.
-    // TODO: define the exact semantics of that; can the implementation panic afterwards? is it
-    // even a good idea to have an event?
-    ServerClosed,
 }

--- a/core/src/server/raw/traits.rs
+++ b/core/src/server/raw/traits.rs
@@ -42,6 +42,14 @@ use std::{hash::Hash, pin::Pin};
 /// to insert the new request, and returns, in addition to the body of the request, an identifier
 /// that represents that newly-received request in the context of the server.
 ///
+/// ## What to do in case of an error?
+///
+/// In order to avoid introducing ambiguities in the API, this trait has no way to notify the user
+/// of a problem happening on the server side (e.g. the TCP listener being closed).
+///
+/// Instead, implementations are encouraged to try to maintain the server alive as much as
+/// possible. If an unrecoverable error happens, implementations should become permanently idle.
+///
 pub trait RawServer {
     /// Identifier for a request in the context of this server.
     type RequestId: Clone + PartialEq + Eq + Hash + Send + Sync;

--- a/core/src/server/tests.rs
+++ b/core/src/server/tests.rs
@@ -50,7 +50,7 @@ fn notifications_work() {
     });
 
     async_std::task::block_on(async move {
-        match server.next_event().await.unwrap() {
+        match server.next_event().await {
             ServerEvent::Notification(n) => {
                 assert_eq!(n.method(), "foo");
                 assert_eq!({ let v: String = n.params().get(0).unwrap(); v }, "bar");
@@ -105,7 +105,7 @@ fn subscriptions_work() {
     });
 
     async_std::task::block_on(async move {
-        let sub_id = match server.next_event().await.unwrap() {
+        let sub_id = match server.next_event().await {
             ServerEvent::Request(rq) => {
                 assert_eq!(rq.method(), "foo");
                 assert_eq!({ let v: String = rq.params().get(0).unwrap(); v }, "bar");
@@ -116,7 +116,7 @@ fn subscriptions_work() {
             _ => panic!()
         };
 
-        match server.next_event().await.unwrap() {
+        match server.next_event().await {
             ServerEvent::SubscriptionsReady(ready) => {
                 assert_eq!(ready, vec![sub_id]);
             },
@@ -126,7 +126,7 @@ fn subscriptions_work() {
         server.subscription_by_id(sub_id).unwrap().push("hey there!").await;
         server.subscription_by_id(sub_id).unwrap().push("notif #2").await;
 
-        match server.next_event().await.unwrap() {
+        match server.next_event().await {
             ServerEvent::SubscriptionsClosed(closed) => {
                 assert_eq!(closed, vec![sub_id]);
             },

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -11,7 +11,7 @@ async-std = "0.99.5"
 derive_more = "0.13.0"
 err-derive = "0.1.5"
 fnv = "1.0"
-futures-preview = "0.3.0-alpha.19"
+futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
 futures-timer = "0.3.0"
 hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 jsonrpsee-core = { path = "../core" }

--- a/http/src/server/background.rs
+++ b/http/src/server/background.rs
@@ -34,7 +34,7 @@ use std::{io, net::SocketAddr, thread};
 /// Background thread that serves HTTP requests.
 pub(super) struct BackgroundHttp {
     /// Receiver for requests coming from the background thread.
-    rx: mpsc::Receiver<Request>,
+    rx: stream::Fuse<mpsc::Receiver<Request>>,
 }
 
 /// Request generated from the background thread.
@@ -90,7 +90,7 @@ impl BackgroundHttp {
             })
             .unwrap();
 
-        Ok((BackgroundHttp { rx }, local_addr))
+        Ok((BackgroundHttp { rx: rx.fuse() }, local_addr))
     }
 
     /// Returns the next request, or an error if the background thread has unexpectedly closed.

--- a/http/src/server/server.rs
+++ b/http/src/server/server.rs
@@ -89,7 +89,7 @@ impl RawServer for HttpRawServer {
         Box::pin(async move {
             let request = match self.background_thread.next().await {
                 Ok(r) => r,
-                Err(_) => return RawServerEvent::ServerClosed,
+                Err(_) => loop { futures::pending!() },
             };
 
             let request_id = {
@@ -98,7 +98,7 @@ impl RawServer for HttpRawServer {
                     Some(i) => i,
                     None => {
                         log::error!("Overflow in HttpRawServer request ID assignment");
-                        return RawServerEvent::ServerClosed;
+                        loop { futures::pending!() }
                     }
                 };
                 id

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -267,7 +267,7 @@ fn build_api(mut api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream
                         I: Clone + PartialEq + Eq + std::hash::Hash + Send + Sync,
             {
                 loop {
-                    match server.next_event().await {        // TODO: don't unwrap
+                    match server.next_event().await {
                         jsonrpsee::core::ServerEvent::Notification(n) => #on_notification,
                         jsonrpsee::core::ServerEvent::SubscriptionsClosed(_) => unimplemented!(),       // TODO:
                         jsonrpsee::core::ServerEvent::SubscriptionsReady(_) => unimplemented!(),       // TODO:

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -267,7 +267,7 @@ fn build_api(mut api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream
                         I: Clone + PartialEq + Eq + std::hash::Hash + Send + Sync,
             {
                 loop {
-                    match server.next_event().await.unwrap() {        // TODO: don't unwrap
+                    match server.next_event().await {        // TODO: don't unwrap
                         jsonrpsee::core::ServerEvent::Notification(n) => #on_notification,
                         jsonrpsee::core::ServerEvent::SubscriptionsClosed(_) => unimplemented!(),       // TODO:
                         jsonrpsee::core::ServerEvent::SubscriptionsReady(_) => unimplemented!(),       // TODO:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,8 @@
 //! // Should run forever
 //! async_std::task::block_on(async {
 //!     let mut server = jsonrpsee::http_server(&"localhost:8000".parse().unwrap()).await.unwrap();
-//!     while let Ok(event) = server.next_event().await {
-//!         match event {
+//!     loop {
+//!         match server.next_event().await {
 //!             jsonrpsee::core::server::ServerEvent::Notification(notif) => {
 //!                 println!("received notification: {:?}", notif);
 //!             }


### PR DESCRIPTION
At the moment, servers produce events of the type `Result<ServerEvent, ()>`.
Similarly, the raw server trait can produce a `ServerClosed` event.

However, in practice, there's a lot of ambiguity in this API:

- What do we do if we have multiple servers? (e.g. two HTTP servers) Does any of them closing closes the entire stack? (which is the case right now)
- What does it actually mean for a `Server` to return an error? Can I continue using the `Server` struct, or is it then in some sort of poisoned state? What happens to the existing requests? Can I still respond to them?

This PR instead makes it impossible for servers to produce errors.
