### PR TITLE
Support generic params

### DIFF
--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -29,6 +29,7 @@ extern crate proc_macro;
 use inflector::Inflector as _;
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
+use std::collections::HashSet;
 use syn::spanned::Spanned as _;
 
 mod api_def;
@@ -110,6 +111,15 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
             syn::parse_str::<syn::Ident>("I").unwrap(),
         )));
     let (impl_generics, ty_generics, where_clause) = tweaked_generics.split_for_impl();
+    let generics = api.generics.params.iter()
+        .filter_map(|gp| {
+            if let syn::GenericParam::Type(tp) = gp {
+                Some(tp.ident.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<HashSet<_>>();
 
     let visibility = &api.visibility;
 
@@ -172,7 +182,20 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
         let mut notifications_blocks = Vec::new();
         let mut function_blocks = Vec::new();
         let mut tmp_to_rq = Vec::new();
-        let mut params_tys = std::collections::HashSet::new();
+
+        struct GenericParams {
+            generics: HashSet<syn::Ident>,
+            types: HashSet<syn::Ident>,
+        }
+        impl<'ast> syn::visit::Visit<'ast> for GenericParams {
+            fn visit_ident(&mut self, ident: &'ast syn::Ident) {
+                if self.generics.contains(ident) {
+                    self.types.insert(ident.clone());
+                }
+            }
+        }
+
+        let mut generic_params = GenericParams { generics, types: HashSet::new() };
 
         for function in &api.definitions {
             let function_is_notification = function.is_void_ret_type();
@@ -199,7 +222,8 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
                     }
                 };
 
-                params_tys.insert(ty);
+                syn::visit::visit_type(&mut generic_params, &ty);
+
                 params_names_list
                     .push(quote_spanned!(function.signature.span()=> #param_variant_name));
                 if !function_is_notification {
@@ -257,16 +281,26 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
             }
         }
 
+        let params_tys = generic_params.types.iter();
+
+        let tmp_generics = if generic_params.types.is_empty() {
+            quote!()
+        } else {
+            quote_spanned!(api.name.span()=>
+                <#(#params_tys,)*>
+            )
+        };
+
         let on_request = quote_spanned!(api.name.span()=> {
             #[allow(unused)]    // The enum might be empty
-            enum Tmp {
+            enum Tmp #tmp_generics {
                 #(#tmp_variants,)*
             }
 
             let request_id = r.id();
             let method = r.method().to_owned();
 
-            let mut request_outcome: Option<Tmp> = None;
+            let mut request_outcome: Option<Tmp #tmp_generics> = None;
 
             #(#function_blocks)*
 
@@ -282,7 +316,7 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
             // TODO: we received an unknown notification; log this?
         });
 
-        let params_tys = params_tys.into_iter();
+        let params_tys = generic_params.types.iter();
 
         quote_spanned!(api.name.span()=>
             #visibility async fn next_request(server: &'a mut jsonrpsee::core::Server<R, I>) -> core::result::Result<#enum_name #ty_generics, std::io::Error>

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -111,7 +111,10 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
             syn::parse_str::<syn::Ident>("I").unwrap(),
         )));
     let (impl_generics, ty_generics, where_clause) = tweaked_generics.split_for_impl();
-    let generics = api.generics.params.iter()
+    let generics = api
+        .generics
+        .params
+        .iter()
         .filter_map(|gp| {
             if let syn::GenericParam::Type(tp) = gp {
                 Some(tp.ident.clone())
@@ -195,7 +198,10 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
             }
         }
 
-        let mut generic_params = GenericParams { generics, types: HashSet::new() };
+        let mut generic_params = GenericParams {
+            generics,
+            types: HashSet::new(),
+        };
 
         for function in &api.definitions {
             let function_is_notification = function.is_void_ret_type();

--- a/tests/proc-macro-generic.rs
+++ b/tests/proc-macro-generic.rs
@@ -32,8 +32,8 @@ jsonrpsee::rpc_api! {
     }
 }
 
-/* TODO: this doesn't work:
-    Test<B, T> {
-        fn foo(B) -> T;
+jsonrpsee::rpc_api! {
+    Test2<B, T> {
+        fn foo(b: B) -> T;
     }
-*/
+}


### PR DESCRIPTION
Support generic param types e.g.

```
jsonrpsee::rpc_api! {
    Test2<B, T> {
        fn foo(b: B) -> T;
    }
}
```

rel #13 