### PR TITLE
Export client mod for Subscription (and Error) types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,5 @@ ws = ["jsonrpsee-ws"]
 
 [dev-dependencies]
 env_logger = "0.7.1"
+serde = { version = "1.0.40", features = ["derive"] }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use server::Server;
 
 use std::{error, net::SocketAddr};
 
-mod client;
+pub mod client;
 mod server;
 
 /// Builds a new client and a new server that are connected to each other.


### PR DESCRIPTION
`Subscription` and `RequestError` are required for using `Client::subscribe`.

I've just made the `client` mod public so they are still namespaced, but kept the `Client` at the root level still.