### PR TITLE
Support websockets client TLS

### DIFF
--- a/examples/polkadot.rs
+++ b/examples/polkadot.rs
@@ -43,8 +43,7 @@ struct Header {
 
 fn main() {
     async_std::task::block_on(async move {
-        //        let mut raw_client = jsonrpsee::ws_raw_client("ws://127.0.0.1:9944")
-        let mut raw_client = jsonrpsee::ws_raw_client("wss://kusama-rpc.polkadot.io:443")
+        let mut raw_client = jsonrpsee::ws_raw_client("wss://kusama-rpc.polkadot.io")
             .await
             .unwrap();
         let v = System::system_name(&mut raw_client).await.unwrap();

--- a/examples/polkadot.rs
+++ b/examples/polkadot.rs
@@ -43,7 +43,7 @@ struct Header {
 
 fn main() {
     async_std::task::block_on(async move {
-        let mut raw_client = jsonrpsee::ws_raw_client("canary-5.kusama.network:443").await.unwrap();
+        let mut raw_client = jsonrpsee::ws_raw_client("kusama-rpc.polkadot.io:443").await.unwrap();
         let v = System::system_name(&mut raw_client).await.unwrap();
         println!("{:?}", v);
 

--- a/examples/polkadot.rs
+++ b/examples/polkadot.rs
@@ -43,7 +43,8 @@ struct Header {
 
 fn main() {
     async_std::task::block_on(async move {
-        let mut raw_client = jsonrpsee::ws_raw_client("kusama-rpc.polkadot.io:443")
+//        let mut raw_client = jsonrpsee::ws_raw_client("ws://127.0.0.1:9944")
+        let mut raw_client = jsonrpsee::ws_raw_client("wss://kusama-rpc.polkadot.io:443")
             .await
             .unwrap();
         let v = System::system_name(&mut raw_client).await.unwrap();

--- a/examples/polkadot.rs
+++ b/examples/polkadot.rs
@@ -43,7 +43,7 @@ struct Header {
 
 fn main() {
     async_std::task::block_on(async move {
-        let mut raw_client = jsonrpsee::ws_raw_client("127.0.0.1:9944").await.unwrap();
+        let mut raw_client = jsonrpsee::ws_raw_client("canary-5.kusama.network:443").await.unwrap();
         let v = System::system_name(&mut raw_client).await.unwrap();
         println!("{:?}", v);
 

--- a/examples/polkadot.rs
+++ b/examples/polkadot.rs
@@ -43,7 +43,9 @@ struct Header {
 
 fn main() {
     async_std::task::block_on(async move {
-        let mut raw_client = jsonrpsee::ws_raw_client("kusama-rpc.polkadot.io:443").await.unwrap();
+        let mut raw_client = jsonrpsee::ws_raw_client("kusama-rpc.polkadot.io:443")
+            .await
+            .unwrap();
         let v = System::system_name(&mut raw_client).await.unwrap();
         println!("{:?}", v);
 

--- a/examples/polkadot.rs
+++ b/examples/polkadot.rs
@@ -43,7 +43,7 @@ struct Header {
 
 fn main() {
     async_std::task::block_on(async move {
-//        let mut raw_client = jsonrpsee::ws_raw_client("ws://127.0.0.1:9944")
+        //        let mut raw_client = jsonrpsee::ws_raw_client("ws://127.0.0.1:9944")
         let mut raw_client = jsonrpsee::ws_raw_client("wss://kusama-rpc.polkadot.io:443")
             .await
             .unwrap();

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -22,4 +22,5 @@ pin-utils = "0.1.0-alpha.4"
 serde = { version = "1.0.40", features = ["derive"] }
 serde_json = "1.0.40"
 soketto = "0.3.1"
+url = "2.1.1"
 webpki = "0.21"

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 async-std = "1.2.0"
+async-tls = "0.6"
 bytes = "0.4"
 err-derive = "0.1.5"
 fnv = "1.0"
@@ -19,4 +20,4 @@ log = "0.4"
 pin-utils = "0.1.0-alpha.4"
 serde = { version = "1.0.40", features = ["derive"] }
 serde_json = "1.0.40"
-soketto = { git = "https://github.com/paritytech/soketto", rev = "a09bfb69af5650f9294e0e21bdda707e7d124b2c" }
+soketto = "0.3.1"

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -23,3 +23,4 @@ soketto = "0.3.1"
 # todo: add TLS feature for these?
 webpki = "0.21"
 async-tls = "0.6"
+pin-project = "0.4.6"

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 async-std = "1.2.0"
+async-tls = "0.6"
 bytes = "0.4"
 err-derive = "0.1.5"
 fnv = "1.0"
@@ -16,11 +17,9 @@ futures-timer = "2.0.2"
 jsonrpsee-core = { path = "../core" }
 lazy_static = "1.4.0"
 log = "0.4"
+pin-project = "0.4.6"
 pin-utils = "0.1.0-alpha.4"
 serde = { version = "1.0.40", features = ["derive"] }
 serde_json = "1.0.40"
 soketto = "0.3.1"
-# todo: add TLS feature for these?
 webpki = "0.21"
-async-tls = "0.6"
-pin-project = "0.4.6"

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 async-std = "1.2.0"
-async-tls = "0.6"
 bytes = "0.4"
 err-derive = "0.1.5"
 fnv = "1.0"
@@ -21,3 +20,6 @@ pin-utils = "0.1.0-alpha.4"
 serde = { version = "1.0.40", features = ["derive"] }
 serde_json = "1.0.40"
 soketto = "0.3.1"
+# todo: add TLS feature for these?
+webpki = "0.21"
+async-tls = "0.6"

--- a/ws/src/client.rs
+++ b/ws/src/client.rs
@@ -95,6 +95,10 @@ pub enum WsNewError {
 /// Error that can happen during the initial handshake.
 #[derive(Debug, Error)]
 pub enum WsNewDnsError {
+    /// Invalid URL.
+    #[error(display = "Invalid url: {}", 0)]
+    Url(Cow<'static, str>),
+
     /// Error when trying to connect.
     ///
     /// If multiple IP addresses are attempted, only the last error is returned, similar to how
@@ -146,9 +150,8 @@ impl WsTransportClient {
     }
 
     /// Initializes a new HTTP client from a URL.
-    pub async fn new(target: &str) -> Result<Self, WsNewDnsError> {
+    pub async fn new(target: &str, mode: Mode) -> Result<Self, WsNewDnsError> {
         let mut error = None;
-        let mode = Mode::Tls; // TODO parse protocol from url?
 
         for url in target
             .to_socket_addrs()

--- a/ws/src/client.rs
+++ b/ws/src/client.rs
@@ -224,10 +224,12 @@ impl<'a> WsTransportClientBuilder<'a> {
                     // TODO: construct Either a TLS or Plain socket
                     let connector = async_tls::TlsConnector::default();
                     let host = self.host.split(':').next().unwrap();
-                    let dns_name = webpki::DNSNameRef::try_from_ascii_str(host).unwrap().to_owned();
+                    let dns_name = webpki::DNSNameRef::try_from_ascii_str(host)
+                        .unwrap()
+                        .to_owned();
                     println!("dns_name {:?}", dns_name);
                     connector.connect(&dns_name, socket?)?.await?
-                },
+                }
                 future::Either::Right((_, _)) => return Err(WsNewError::Timeout),
             }
         };

--- a/ws/src/client.rs
+++ b/ws/src/client.rs
@@ -248,8 +248,8 @@ impl<'a> WsTransportClientBuilder<'a> {
             pin_utils::pin_mut!(timeout);
             match future::select(socket, timeout).await {
                 future::Either::Left((socket, _)) => match self.mode {
-                    Plain => TlsOrPlain::Plain(socket?),
-                    Tls => {
+                    Mode::Plain => TlsOrPlain::Plain(socket?),
+                    Mode::Tls => {
                         let connector = async_tls::TlsConnector::default();
                         let host = self.host.split(':').next().unwrap();
                         let dns_name = webpki::DNSNameRef::try_from_ascii_str(host)

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -41,6 +41,7 @@ pub use crate::client::{WsConnecError, WsNewDnsError, WsNewError, WsTransportCli
 pub type WsRawClient = RawClient<WsTransportClient>;
 
 mod client;
+mod stream;
 
 /// Returns an object that lets you perform JSON-RPC queries towards the given HTTP server.
 pub async fn ws_raw_client(target: &str) -> Result<WsRawClient, WsNewDnsError> {

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -33,7 +33,7 @@
 
 use jsonrpsee_core::client::RawClient;
 
-pub use crate::client::{WsConnecError, WsNewDnsError, WsNewError, WsTransportClient};
+pub use crate::client::{Mode, WsConnecError, WsNewDnsError, WsNewError, WsTransportClient};
 
 // TODO: server
 
@@ -45,5 +45,18 @@ mod stream;
 
 /// Returns an object that lets you perform JSON-RPC queries towards the given HTTP server.
 pub async fn ws_raw_client(target: &str) -> Result<WsRawClient, WsNewDnsError> {
-    WsTransportClient::new(target).await.map(RawClient::new)
+    let url = url::Url::parse(target)
+        .map_err(|e| WsNewDnsError::Url(format!("Invalid URL: {}", e).into()))?;
+    let mode =
+        match url.scheme() {
+            "ws" => Mode::Plain,
+            "wss" => Mode::Tls,
+            _ => return Err(WsNewDnsError::Url("URL scheme not supported, expects 'ws' or 'wss'".into())),
+        };
+    let host = url.host_str().ok_or(WsNewDnsError::Url("No host in URL".into()))?;
+    let target = match url.port_or_known_default() {
+        Some(port) => format!("{}:{}", host, port),
+        None => host.to_string(),
+    };
+    WsTransportClient::new(&target, mode).await.map(RawClient::new)
 }

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -47,16 +47,23 @@ mod stream;
 pub async fn ws_raw_client(target: &str) -> Result<WsRawClient, WsNewDnsError> {
     let url = url::Url::parse(target)
         .map_err(|e| WsNewDnsError::Url(format!("Invalid URL: {}", e).into()))?;
-    let mode =
-        match url.scheme() {
-            "ws" => Mode::Plain,
-            "wss" => Mode::Tls,
-            _ => return Err(WsNewDnsError::Url("URL scheme not supported, expects 'ws' or 'wss'".into())),
-        };
-    let host = url.host_str().ok_or(WsNewDnsError::Url("No host in URL".into()))?;
+    let mode = match url.scheme() {
+        "ws" => Mode::Plain,
+        "wss" => Mode::Tls,
+        _ => {
+            return Err(WsNewDnsError::Url(
+                "URL scheme not supported, expects 'ws' or 'wss'".into(),
+            ))
+        }
+    };
+    let host = url
+        .host_str()
+        .ok_or(WsNewDnsError::Url("No host in URL".into()))?;
     let target = match url.port_or_known_default() {
         Some(port) => format!("{}:{}", host, port),
         None => host.to_string(),
     };
-    WsTransportClient::new(&target, mode).await.map(RawClient::new)
+    WsTransportClient::new(&target, mode)
+        .await
+        .map(RawClient::new)
 }

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -45,25 +45,5 @@ mod stream;
 
 /// Returns an object that lets you perform JSON-RPC queries towards the given HTTP server.
 pub async fn ws_raw_client(target: &str) -> Result<WsRawClient, WsNewDnsError> {
-    let url = url::Url::parse(target)
-        .map_err(|e| WsNewDnsError::Url(format!("Invalid URL: {}", e).into()))?;
-    let mode = match url.scheme() {
-        "ws" => Mode::Plain,
-        "wss" => Mode::Tls,
-        _ => {
-            return Err(WsNewDnsError::Url(
-                "URL scheme not supported, expects 'ws' or 'wss'".into(),
-            ))
-        }
-    };
-    let host = url
-        .host_str()
-        .ok_or(WsNewDnsError::Url("No host in URL".into()))?;
-    let target = match url.port_or_known_default() {
-        Some(port) => format!("{}:{}", host, port),
-        None => host.to_string(),
-    };
-    WsTransportClient::new(&target, mode)
-        .await
-        .map(RawClient::new)
+    WsTransportClient::new(target).await.map(RawClient::new)
 }

--- a/ws/src/stream.rs
+++ b/ws/src/stream.rs
@@ -1,0 +1,97 @@
+use futures::{
+    io::{IoSlice, IoSliceMut},
+    prelude::*,
+};
+use pin_project::{pin_project, project};
+use std::{fmt, io::Error as IoError, pin::Pin, task::Context, task::Poll};
+
+#[pin_project]
+#[derive(Debug, Copy, Clone)]
+pub enum EitherStream<S, T> {
+    /// Unencrypted socket stream.
+    Plain(#[pin] S),
+    /// Encrypted socket stream.
+    Tls(#[pin] T),
+}
+
+impl<S, T> AsyncRead for EitherStream<S, T>
+where
+    S: AsyncRead,
+    T: AsyncRead,
+{
+    #[project]
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, IoError>> {
+        #[project]
+        match self.project() {
+            EitherStream::Plain(s) => AsyncRead::poll_read(s, cx, buf),
+            EitherStream::Tls(t) => AsyncRead::poll_read(t, cx, buf),
+        }
+    }
+
+    #[project]
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        bufs: &mut [IoSliceMut],
+    ) -> Poll<Result<usize, IoError>> {
+        #[project]
+        match self.project() {
+            EitherStream::Plain(s) => AsyncRead::poll_read_vectored(s, cx, bufs),
+            EitherStream::Tls(t) => AsyncRead::poll_read_vectored(t, cx, bufs),
+        }
+    }
+}
+
+impl<S, T> AsyncWrite for EitherStream<S, T>
+where
+    S: AsyncWrite,
+    T: AsyncWrite,
+{
+    #[project]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &[u8],
+    ) -> Poll<Result<usize, IoError>> {
+        #[project]
+        match self.project() {
+            EitherStream::Plain(s) => AsyncWrite::poll_write(s, cx, buf),
+            EitherStream::Tls(t) => AsyncWrite::poll_write(t, cx, buf),
+        }
+    }
+
+    #[project]
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        bufs: &[IoSlice],
+    ) -> Poll<Result<usize, IoError>> {
+        #[project]
+        match self.project() {
+            EitherStream::Plain(s) => AsyncWrite::poll_write_vectored(s, cx, bufs),
+            EitherStream::Tls(t) => AsyncWrite::poll_write_vectored(t, cx, bufs),
+        }
+    }
+
+    #[project]
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), IoError>> {
+        #[project]
+        match self.project() {
+            EitherStream::Plain(s) => AsyncWrite::poll_flush(s, cx),
+            EitherStream::Tls(t) => AsyncWrite::poll_flush(t, cx),
+        }
+    }
+
+    #[project]
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), IoError>> {
+        #[project]
+        match self.project() {
+            EitherStream::Plain(s) => AsyncWrite::poll_close(s, cx),
+            EitherStream::Tls(t) => AsyncWrite::poll_close(t, cx),
+        }
+    }
+}

--- a/ws/src/stream.rs
+++ b/ws/src/stream.rs
@@ -1,3 +1,31 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Convenience wrapper for a stream (AsyncRead + AsyncWrite) which can either be plain TCP and TLS.
+
 use futures::{
     io::{IoSlice, IoSliceMut},
     prelude::*,

--- a/ws/src/stream.rs
+++ b/ws/src/stream.rs
@@ -31,7 +31,7 @@ use futures::{
     prelude::*,
 };
 use pin_project::{pin_project, project};
-use std::{fmt, io::Error as IoError, pin::Pin, task::Context, task::Poll};
+use std::{io::Error as IoError, pin::Pin, task::Context, task::Poll};
 
 #[pin_project]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Adds support for TLS over websockets, urls now require scheme prefix: `ws://` for plain TCP and `wss://` for TLS.

- [x] Support both `Tls` and `Plain` streams in connection: requires an enum implementing `AsyncRead + AsyncWrite` e.g. https://github.com/libp2p/rust-libp2p/blob/3f968cbf92d5939238b798d9ab1d5266e3edea20/core/src/either.rs#L62
- [x] Figure out API for choosing TLS or Plain - potentially parse a  `Url` and use the protocol? `ws://` vs `wss://`
~~Add a `tls` feature?~~