### PR TITLE
Fix panic when dropping subscription

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -401,7 +401,7 @@ where
 
             // Request for the server to unsubscribe us has succeeded.
             Either::Right(Ok(RawClientEvent::Unsubscribed { request_id })) => {
-                active_subscriptions.remove(&request_id).unwrap();
+                active_subscriptions.remove(&request_id);
             }
 
             Either::Right(Err(_)) => {} // TODO: https://github.com/paritytech/jsonrpsee/issues/67

--- a/src/client.rs
+++ b/src/client.rs
@@ -400,9 +400,7 @@ where
             }
 
             // Request for the server to unsubscribe us has succeeded.
-            Either::Right(Ok(RawClientEvent::Unsubscribed { request_id })) => {
-                active_subscriptions.remove(&request_id);
-            }
+            Either::Right(Ok(RawClientEvent::Unsubscribed { request_id: _ })) => {}
 
             Either::Right(Err(_)) => {} // TODO: https://github.com/paritytech/jsonrpsee/issues/67
         }


### PR DESCRIPTION
The subscription is already removed when the channel is closed and unsubscribe triggered: https://github.com/paritytech/jsonrpsee/blob/6f6866fc2da36124cf93f437685daf26758b8c7b/src/client.rs#L343

So panics on the `unwrap()` when unsubscribe confirmed. 

