### PR TITLE
Don't just swallow RawClient error, log it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 [dependencies]
 async-std = "1.2.0"
 futures = "0.3.1"
+log = "0.4"
 parking_lot = "0.9"
 jsonrpsee-core = { path = "core" }
 jsonrpsee-http = { path = "http", optional = true }

--- a/src/client.rs
+++ b/src/client.rs
@@ -402,7 +402,10 @@ where
             // Request for the server to unsubscribe us has succeeded.
             Either::Right(Ok(RawClientEvent::Unsubscribed { request_id: _ })) => {}
 
-            Either::Right(Err(_)) => {} // TODO: https://github.com/paritytech/jsonrpsee/issues/67
+            Either::Right(Err(e)) => {
+                // TODO: https://github.com/paritytech/jsonrpsee/issues/67
+                log::error!("Client Error: {:?}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
Logs an error from `RawClient` instead of just swallowing it.

I converted this tool to `jsonrpsee` https://github.com/kianenigma/offline-phragmen/pull/8, and at first it was just waiting indefinitely on a request.

Turns out it was failing to deserialize because of the `serde_json` `arbitrary_precision` feature being enabled. This took me a while to find out, would have been much quicker if it just printed this error.

rel: #67 