### PR TITLE
Add correct response on incorrect JSON

### DIFF
--- a/src/transport/http/server/background.rs
+++ b/src/transport/http/server/background.rs
@@ -166,8 +166,14 @@ async fn process_request(
 
             let json_body = match body_to_request(request.into_body()).await {
                 Ok(b) => b,
-                Err(_) => {
-                    unimplemented!() // TODO:
+                Err(e) => {
+                    use std::io::ErrorKind::*;
+                    match (e.kind(), e.into_inner()) {
+                        (InvalidData, _) => return response::parse_error(),
+                        (UnexpectedEof, _) => return response::parse_error(),
+                        (_, Some(inner)) => return response::internal_error(inner.to_string()),
+                        (kind, None) => return response::internal_error(format!("{:?}", kind)),
+                    }
                 }
             };
 

--- a/src/transport/http/server/background.rs
+++ b/src/transport/http/server/background.rs
@@ -167,10 +167,9 @@ async fn process_request(
             let json_body = match body_to_request(request.into_body()).await {
                 Ok(b) => b,
                 Err(e) => {
-                    use std::io::ErrorKind::*;
                     match (e.kind(), e.into_inner()) {
-                        (InvalidData, _) => return response::parse_error(),
-                        (UnexpectedEof, _) => return response::parse_error(),
+                        (io::ErrorKind::InvalidData, _) => return response::parse_error(),
+                        (io::ErrorKind::UnexpectedEof, _) => return response::parse_error(),
                         (_, Some(inner)) => return response::internal_error(inner.to_string()),
                         (kind, None) => return response::internal_error(format!("{:?}", kind)),
                     }

--- a/src/transport/http/server/background.rs
+++ b/src/transport/http/server/background.rs
@@ -166,14 +166,12 @@ async fn process_request(
 
             let json_body = match body_to_request(request.into_body()).await {
                 Ok(b) => b,
-                Err(e) => {
-                    match (e.kind(), e.into_inner()) {
-                        (io::ErrorKind::InvalidData, _) => return response::parse_error(),
-                        (io::ErrorKind::UnexpectedEof, _) => return response::parse_error(),
-                        (_, Some(inner)) => return response::internal_error(inner.to_string()),
-                        (kind, None) => return response::internal_error(format!("{:?}", kind)),
-                    }
-                }
+                Err(e) => match (e.kind(), e.into_inner()) {
+                    (io::ErrorKind::InvalidData, _) => return response::parse_error(),
+                    (io::ErrorKind::UnexpectedEof, _) => return response::parse_error(),
+                    (_, Some(inner)) => return response::internal_error(inner.to_string()),
+                    (kind, None) => return response::internal_error(format!("{:?}", kind)),
+                },
             };
 
             let (tx, rx) = oneshot::channel();

--- a/src/transport/http/server/response.rs
+++ b/src/transport/http/server/response.rs
@@ -69,10 +69,10 @@ pub fn parse_error() -> hyper::Response<hyper::Body> {
         .status(hyper::StatusCode::OK)
         .header("Content-type", "application/json")
         .body(hyper::Body::from(
-            serde_json::to_string(&common::Output::Failure(common::Failure {
-                jsonrpc: common::Version::V2,
-                error: common::Error::parse_error(),
-                id: common::Id::Null,
+            serde_json::to_string(&crate::common::Output::Failure(crate::common::Failure {
+                jsonrpc: crate::common::Version::V2,
+                error: crate::common::Error::parse_error(),
+                id: crate::common::Id::Null,
             }))
             .expect("Unable to serialize parse error"),
         ))

--- a/src/transport/http/server/response.rs
+++ b/src/transport/http/server/response.rs
@@ -65,15 +65,14 @@ pub fn unsupported_content_type() -> hyper::Response<hyper::Body> {
 
 /// Create a response for invalid JSON in request
 pub fn parse_error() -> hyper::Response<hyper::Body> {
-    use crate::common::*;
     hyper::Response::builder()
         .status(hyper::StatusCode::OK)
         .header("Content-type", "application/json")
         .body(hyper::Body::from(
-            serde_json::to_string(&Output::Failure(Failure {
-                jsonrpc: Version::V2,
-                error: Error::parse_error(),
-                id: Id::Null,
+            serde_json::to_string(&common::Output::Failure(common::Failure {
+                jsonrpc: common::Version::V2,
+                error: common::Error::parse_error(),
+                id: common::Id::Null,
             }))
             .expect("Unable to serialize parse error"),
         ))

--- a/src/transport/http/server/response.rs
+++ b/src/transport/http/server/response.rs
@@ -63,6 +63,23 @@ pub fn unsupported_content_type() -> hyper::Response<hyper::Body> {
     )
 }
 
+/// Create a response for invalid JSON in request
+pub fn parse_error() -> hyper::Response<hyper::Body> {
+    use crate::common::*;
+    hyper::Response::builder()
+        .status(hyper::StatusCode::OK)
+        .header("Content-type", "application/json")
+        .body(hyper::Body::from(
+            serde_json::to_string(&Output::Failure(Failure {
+                jsonrpc: Version::V2,
+                error: Error::parse_error(),
+                id: Id::Null,
+            }))
+            .expect("Unable to serialize parse error"),
+        ))
+        .expect("Unable to parse response body for type conversion")
+}
+
 /// Create a response for disallowed method used.
 pub fn method_not_allowed() -> hyper::Response<hyper::Body> {
     from_template(


### PR DESCRIPTION
Implement correct response on requests with incorrect JSON instead of just panic. Errors in `body_to_request` are propagated to response if they occurred before request deserialization