### PR TITLE
Add special enum variant for errors from user code

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -52,6 +52,8 @@ pub enum ErrorCode {
     InternalError,
     /// Reserved for implementation-defined server-errors.
     ServerError(i64),
+    /// Error returned by called method
+    MethodError(i64),
 }
 
 impl ErrorCode {
@@ -64,6 +66,7 @@ impl ErrorCode {
             ErrorCode::InvalidParams => -32602,
             ErrorCode::InternalError => -32603,
             ErrorCode::ServerError(code) => code,
+            ErrorCode::MethodError(code) => code,
         }
     }
 
@@ -76,6 +79,7 @@ impl ErrorCode {
             ErrorCode::InvalidParams => "Invalid params",
             ErrorCode::InternalError => "Internal error",
             ErrorCode::ServerError(_) => "Server error",
+            ErrorCode::MethodError(_) => "Method error",
         };
         desc.to_string()
     }
@@ -89,7 +93,8 @@ impl From<i64> for ErrorCode {
             -32601 => ErrorCode::MethodNotFound,
             -32602 => ErrorCode::InvalidParams,
             -32603 => ErrorCode::InternalError,
-            code => ErrorCode::ServerError(code),
+            -32099..=-32000 => ErrorCode::ServerError(code),
+            code => ErrorCode::MethodError(code),
         }
     }
 }


### PR DESCRIPTION
As described in [JSON-RPC specs](https://www.jsonrpc.org/specification), server errors must be used only for errors from server implementation. They can take only values from -32099 to -32000, and library users must not use them to describe business logic errors. I separated them from user code errors, and now users must use MethodError to describe errors from business logic