### PR TITLE
Support multiple runtimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-async-std = "1.2.0"
+async-std = { version = "1.2.0", optional = true }
+async-trait = { version = "0.1" }
 bs58 = "0.3.0"
 fnv = "1.0"
 futures = "0.3.4"
@@ -28,6 +29,7 @@ thiserror = "1.0.9"
 # HTTP-related dependencies
 hyper = { version = "0.13.0", features = ["stream"], optional = true }
 tokio = { version = "0.2.4", optional = true }
+tokio-util = { version = "0.3", optional = true }
 unicase = { version = "2.0", optional = true }
 
 # WS-related dependencies
@@ -38,13 +40,14 @@ url = { version = "2.1.1", optional = true }
 webpki = { version = "0.21", optional = true }
 
 [features]
-default = ["http", "ws"]
+default = ["async-std-support", "tokio-support", "http", "ws"]
 http = ["hyper", "tokio", "unicase"]
 ws = ["async-tls", "bytes", "soketto", "url", "webpki"]
+async-std-support = ["async-std"]
+tokio-support = ["tokio/dns", "tokio/tcp", "tokio-util/compat"]
 
 [dev-dependencies]
 async-std = "1.2.0"
 env_logger = "0.7.1"
 rand = "0.7"
 serde = { version = "1.0.40", features = ["derive"] }
-

--- a/src/common.rs
+++ b/src/common.rs
@@ -34,6 +34,7 @@ mod id;
 mod params;
 mod request;
 mod response;
+pub mod runtime;
 mod version;
 
 pub use serde::{de::DeserializeOwned, ser::Serialize};
@@ -50,4 +51,5 @@ pub use self::request::{Call, MethodCall, Notification, Request};
 pub use self::response::{
     Failure, Output, Response, SubscriptionId, SubscriptionNotif, SubscriptionNotifParams, Success,
 };
+pub use self::runtime::Runtime;
 pub use self::version::Version;

--- a/src/common/runtime.rs
+++ b/src/common/runtime.rs
@@ -1,0 +1,73 @@
+use async_trait::async_trait;
+use futures::{AsyncRead, AsyncWrite};
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+/// Common trait that various runtimes should implement.
+#[async_trait]
+pub trait Runtime {
+    /// Runtime's TCP stream type.
+    type TcpStream: AsyncRead + AsyncWrite + Unpin + Send + 'static;
+
+    fn spawn<F: Future<Output = ()> + Send + 'static>(&self, fut: F);
+    async fn sleep(&self, duration: Duration);
+    async fn connect_tcp(&self, target: String) -> io::Result<Self::TcpStream>;
+    async fn resolve(&self, target: String) -> io::Result<Vec<SocketAddr>>;
+}
+
+#[cfg(feature = "async-std-support")]
+pub mod async_std_support {
+    use super::*;
+
+    /// async-std runtime shim
+    pub struct AsyncStdRuntime;
+
+    #[async_trait]
+    impl Runtime for AsyncStdRuntime {
+        type TcpStream = async_std::net::TcpStream;
+
+        fn spawn<F: Future<Output = ()> + Send + 'static>(&self, fut: F) {
+            async_std::task::spawn(fut);
+        }
+        async fn sleep(&self, duration: Duration) {
+            async_std::task::sleep(duration).await
+        }
+        async fn connect_tcp(&self, target: String) -> io::Result<Self::TcpStream> {
+            Ok(async_std::net::TcpStream::connect(target).await?)
+        }
+        async fn resolve(&self, target: String) -> io::Result<Vec<SocketAddr>> {
+            Ok(async_std::net::ToSocketAddrs::to_socket_addrs(&target)
+                .await?
+                .collect())
+        }
+    }
+}
+
+#[cfg(feature = "tokio-support")]
+pub mod tokio_support {
+    use super::*;
+    use tokio_util::compat::*;
+
+    /// Tokio runtime shim.
+    pub struct TokioRuntime;
+
+    #[async_trait]
+    impl Runtime for TokioRuntime {
+        type TcpStream = tokio_util::compat::Compat<tokio::net::TcpStream>;
+
+        fn spawn<F: Future<Output = ()> + Send + 'static>(&self, fut: F) {
+            tokio::spawn(fut);
+        }
+        async fn sleep(&self, duration: Duration) {
+            tokio::time::delay_for(duration).await
+        }
+        async fn connect_tcp(&self, target: String) -> io::Result<Self::TcpStream> {
+            Ok(tokio::net::TcpStream::connect(target).await?.compat_write())
+        }
+        async fn resolve(&self, target: String) -> io::Result<Vec<SocketAddr>> {
+            Ok(tokio::net::lookup_host(target).await?.collect())
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a special shim that encapsulates all runtime facilities used by jsonrpsee. This is to abstract over any async runtime that has I/O, task spawning and TCP networking drivers. `async-std` and `tokio` implementations are provided.