### PR TITLE
implement simple error propagation for subscriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-async-std = "1.6.2"
-bs58 = "0.3.0"
+async-std = "1.2.0"
+bs58 = "0.3.1"
 fnv = "1.0"
 futures = "0.3.4"
 futures-timer = "3.0.2"

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -27,7 +27,7 @@
 //! Implementation of [`TransportClient`](crate::transport::TransportClient) and
 //! [`TransportServer`](crate::transport::TransportServer) for the WebSocket protocol.
 
-pub use client::{Mode, WsConnecError, WsNewDnsError, WsNewError, WsTransportClient};
+pub use client::{Mode, WsConnectError, WsNewDnsError, WsNewError, WsTransportClient};
 pub use server::{WsRequestId, WsTransportServer, WsTransportServerBuilder};
 
 mod client;

--- a/src/transport/ws/client.rs
+++ b/src/transport/ws/client.rs
@@ -124,7 +124,7 @@ pub enum WsNewDnsError {
 
 /// Error that can happen during a request.
 #[derive(Debug, Error)]
-pub enum WsConnecError {
+pub enum WsConnectError {
     /// Error while serializing the request.
     // TODO: can that happen?
     #[error("error while serializing the request")]
@@ -201,14 +201,14 @@ impl WsTransportClient {
 }
 
 impl TransportClient for WsTransportClient {
-    type Error = WsConnecError;
+    type Error = WsConnectError;
 
     fn send_request<'a>(
         &'a mut self,
         request: common::Request,
     ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'a>> {
         Box::pin(async move {
-            let request = common::to_vec(&request).map_err(WsConnecError::Serialization)?;
+            let request = common::to_vec(&request).map_err(WsConnectError::Serialization)?;
             self.sender.send_binary(request).await?;
             self.sender.flush().await?;
             Ok(())
@@ -221,7 +221,7 @@ impl TransportClient for WsTransportClient {
         Box::pin(async move {
             let mut message = Vec::new();
             self.receiver.receive_data(&mut message).await?;
-            let response = common::from_slice(&message).map_err(WsConnecError::ParseError)?;
+            let response = common::from_slice(&message).map_err(WsConnectError::ParseError)?;
             Ok(response)
         })
     }
@@ -326,8 +326,8 @@ impl From<WsNewError> for WsNewDnsError {
     }
 }
 
-impl From<soketto::connection::Error> for WsConnecError {
-    fn from(err: soketto::connection::Error) -> WsConnecError {
-        WsConnecError::Ws(err)
+impl From<soketto::connection::Error> for WsConnectError {
+    fn from(err: soketto::connection::Error) -> WsConnectError {
+        WsConnectError::Ws(err)
     }
 }


### PR DESCRIPTION
Propagating errors is currently not implemented.  This PR tries to enable Client Subscriptions to signal downstream that a channel has been closed due to errors in the inner RawClient.

- On RawClient error, clear all active subscriptions, which drops all the mpsc senders.
- Implement future's Stream trait for Client::Subscription so that the inner mpsc receiver can be polled to completion. ```Ready::(None)``` when the mpsc sender is dropped.

The stream trait was implemented such that current libs depending on the Subscription.next() API, such as substrate-subxt, wont break.  Users can choose to poll the Subscription as a wrapped stream to get notified of the closed internal mpsc receiver or use subscription.next() future, which will loop with "pending" forever on error.