### PR TITLE
Introduce and use InfiniteFuturesUnordered in HTTP background thread

### DIFF
--- a/src/transport/http/client.rs
+++ b/src/transport/http/client.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{common, raw::client::RawClient, transport::TransportClient};
+use crate::{common, transport::TransportClient};
 
 use futures::{channel::mpsc, channel::oneshot, prelude::*};
 use std::{fmt, io, pin::Pin, thread};
@@ -73,7 +73,16 @@ impl HttpTransportClient {
         // Because hyper can only be polled through tokio, we spawn it in a background thread.
         thread::Builder::new()
             .name("jsonrpsee-hyper-client".to_string())
-            .spawn(move || background_thread(requests_rx))
+            .spawn(move || {
+                let client = hyper::Client::new();
+                background_thread(requests_rx, move |rq| {
+                    // cloning Hyper client = cloning references
+                    let client = client.clone();
+                    async move {
+                        let _ = rq.send_back.send(client.request(rq.request).await);
+                    }
+                })
+            })
             .unwrap();
 
         HttpTransportClient {
@@ -196,9 +205,10 @@ pub enum RequestError {
 }
 
 /// Function that runs in a background thread.
-fn background_thread(mut requests_rx: mpsc::Receiver<FrontToBack>) {
-    let client = hyper::Client::new();
-
+fn background_thread<T, ProcessRequest: Future<Output = ()>>(
+    mut requests_rx: mpsc::Receiver<T>,
+    process_request: impl Fn(T) -> ProcessRequest,
+) {
     let mut runtime = match tokio::runtime::Builder::new()
         .basic_scheduler()
         .enable_all()
@@ -219,24 +229,185 @@ fn background_thread(mut requests_rx: mpsc::Receiver<FrontToBack>) {
     // Running until the channel has been closed, and all requests have been completed.
     runtime.block_on(async move {
         // Collection of futures that process ongoing requests.
-        let mut pending_requests = stream::FuturesUnordered::new();
-
+        let mut pending_requests = InfiniteFuturesUnordered::new();
         loop {
-            let rq = match future::select(requests_rx.next(), pending_requests.next()).await {
-                // We received a request from the foreground.
-                future::Either::Left((Some(rq), _)) => rq,
-                // The channel with the foreground has closed.
-                future::Either::Left((None, _)) => break,
-                // One of the elements of `pending_requests` is finished.
-                future::Either::Right(_) => continue,
+            let rq = {
+                let next_pending_request = pending_requests.next();
+                futures::pin_mut!(next_pending_request);
+                match future::select(requests_rx.next(), next_pending_request).await {
+                    // We received a request from the foreground.
+                    future::Either::Left((Some(rq), _)) => rq,
+                    // The channel with the foreground has closed.
+                    future::Either::Left((None, _)) => break,
+                    // One of the elements of `pending_requests` is finished.
+                    future::Either::Right(_) => continue,
+                }
             };
 
-            pending_requests.push(async {
-                let _ = rq.send_back.send(client.request(rq.request).await);
-            });
+            pending_requests.push(process_request(rq));
         }
 
         // Before returning, complete all pending requests.
-        while let Some(_) = pending_requests.next().await {}
+        if let Some(mut active_requests) = pending_requests.into_active_stream() {
+            while let Some(_) = active_requests.next().await {}
+        }
     });
+}
+
+/// Infinite stream of unordered futures.
+struct InfiniteFuturesUnordered<T, F> {
+    active_count: usize,
+    active_stream: future::Either<stream::Pending<T>, stream::FuturesUnordered<F>>,
+}
+
+impl<T, F> InfiniteFuturesUnordered<T, F>
+where
+    F: Future<Output = T>,
+{
+    /// Returns empty stream.
+    pub fn new() -> Self {
+        InfiniteFuturesUnordered {
+            active_count: 0,
+            active_stream: stream::pending().left_stream(),
+        }
+    }
+
+    /// Extracts active requests stream. Returns None if there's no any pending requests.
+    pub fn into_active_stream(self) -> Option<stream::FuturesUnordered<F>> {
+        match self.active_stream {
+            future::Either::Left(_) => None,
+            future::Either::Right(active_stream) => Some(active_stream),
+        }
+    }
+
+    /// Returns next item of the stream.
+    pub async fn next(&mut self) -> Option<T> {
+        let next_item = self.active_stream.next().await;
+        debug_assert!(next_item.is_some());
+        self.active_count = self.active_count.checked_sub(1).expect(
+            "for every `push`-ed request, `active_count` is incremented by 1;\
+                every request is completed only once (guaranteed by FuturesUnordered);\
+                we only decrease `active_count` when request is completed;\
+                qed",
+        );
+        if self.active_count == 0 {
+            self.active_stream = stream::pending().left_stream();
+        }
+        next_item
+    }
+
+    /// Appends new future to the stream.
+    pub fn push(&mut self, future: F) {
+        match self.active_stream {
+            future::Either::Left(_) => {
+                debug_assert_eq!(self.active_count, 0);
+
+                let active_stream = stream::FuturesUnordered::new();
+                active_stream.push(future);
+                self.active_stream = active_stream.right_stream();
+            }
+            future::Either::Right(ref mut active_stream) => {
+                debug_assert!(self.active_count <= active_stream.len());
+
+                active_stream.push(future);
+            }
+        }
+
+        self.active_count += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{executor::LocalPool, future::Ready, task::LocalSpawnExt};
+
+    #[test]
+    fn inifinite_stream_is_pending_if_stream_is_empty() {
+        let mut executor = LocalPool::new();
+        executor
+            .spawner()
+            .spawn_local(async {
+                let mut stream = InfiniteFuturesUnordered::<u32, Ready<u32>>::new();
+                assert_eq!(stream.active_count, 0);
+                stream.next().await;
+            })
+            .unwrap();
+        assert_eq!(executor.try_run_one(), false);
+    }
+
+    #[test]
+    fn inifinite_stream_returns_item_when_future_completes() {
+        let mut executor = LocalPool::new();
+        executor
+            .spawner()
+            .spawn_local(async move {
+                let mut stream = InfiniteFuturesUnordered::new();
+                stream.push(async { 42 });
+                assert_eq!(stream.active_count, 1);
+                stream.next().await;
+                assert_eq!(stream.active_count, 0);
+            })
+            .unwrap();
+        assert_eq!(executor.try_run_one(), true);
+    }
+
+    #[test]
+    fn inifinite_stream_pending_again_after_returning_item() {
+        let mut executor = LocalPool::new();
+        executor
+            .spawner()
+            .spawn_local(async move {
+                let mut stream = InfiniteFuturesUnordered::new();
+                stream.push(async { 42 });
+                assert_eq!(stream.active_count, 1);
+                stream.next().await;
+                assert_eq!(stream.active_count, 0);
+                stream.next().await;
+            })
+            .unwrap();
+        assert_eq!(executor.try_run_one(), false);
+    }
+
+    #[test]
+    fn background_thread_is_able_to_complete_requests() {
+        // start background thread that returns square(passed_value) after signal
+        // from 'main' thread is received
+        let (mut requests_tx, requests_rx) = mpsc::channel(4);
+        let background_thread = thread::spawn(move || {
+            background_thread(
+                requests_rx,
+                move |(send_when, send_back, value): (
+                    oneshot::Receiver<()>,
+                    oneshot::Sender<u32>,
+                    u32,
+                )| async move {
+                    send_when.await.unwrap();
+                    send_back.send(value * value).unwrap();
+                },
+            )
+        });
+
+        // send two requests - there'll be two simultaneous active requests, waiting for
+        // main thread' signals
+        let mut pool = futures::executor::LocalPool::new();
+        let (send_when_tx1, send_when_rx1) = oneshot::channel();
+        let (send_when_tx2, send_when_rx2) = oneshot::channel();
+        let (send_back_tx1, send_back_rx1) = oneshot::channel();
+        let (send_back_tx2, send_back_rx2) = oneshot::channel();
+        pool.run_until(requests_tx.send((send_when_rx1, send_back_tx1, 32)))
+            .unwrap();
+        pool.run_until(requests_tx.send((send_when_rx2, send_back_tx2, 1024)))
+            .unwrap();
+
+        // send both signals and wait for responses
+        send_when_tx1.send(()).unwrap();
+        send_when_tx2.send(()).unwrap();
+        assert_eq!(pool.run_until(send_back_rx1), Ok(32 * 32));
+        assert_eq!(pool.run_until(send_back_rx2), Ok(1024 * 1024));
+
+        // drop requests sender, asking background thread to exit gently
+        drop(requests_tx);
+        background_thread.join().unwrap();
+    }
 }


### PR DESCRIPTION
closes #107 

I've been trying to find some existing structure that will fix that issue, but failed to accomplish that :( So there's custom solution. The basic idea is to have active requests counter. When it is zero, we are polling `stream::pending()`, meaning that we'll never wake up. When it is non-zero, we're back to polling regular `FuturesUnordered`. When all requests in `FuturesUnordered` are completed (active requests counter is back to zero), we switch to `stream::pending()` again. Since `FuturesUnordered::next()` resolves only when request is completed (unless active requests count is zero), this means that we never wake up without a reason.

The 'bonus issue' from #107 is resolved partially - requests' futures are removed only when active requests count is dropped to zero.