### PR TITLE
Adds a ws_server function at the root, and remove some async qualifiers

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -55,10 +55,10 @@ fn main() {
             match request {
                 Health::SystemName { respond, foo, bar } => {
                     let value = format!("{}, {}", foo, bar);
-                    respond.ok(value).await;
+                    respond.ok(value);
                 }
                 Health::SystemName2 { respond } => {
-                    respond.ok("hello 2").await;
+                    respond.ok("hello 2");
                 }
                 Health::TestNotif { foo, bar } => {
                     println!("server got notif: {:?} {:?}", foo, bar);

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -239,7 +239,7 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
                                 Ok(v) => v,
                                 Err(_) => {
                                     // TODO: message
-                                    request.respond(Err(jsonrpsee::common::Error::invalid_params(#rpc_param_name))).await;
+                                    request.respond(Err(jsonrpsee::common::Error::invalid_params(#rpc_param_name)));
                                     continue;
                                 }
                             }
@@ -312,7 +312,7 @@ fn build_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStream, sy
 
             match request_outcome {
                 #(#tmp_to_rq)*
-                None => server.request_by_id(&request_id).unwrap().respond(Err(jsonrpsee::common::Error::method_not_found())).await,
+                None => server.request_by_id(&request_id).unwrap().respond(Err(jsonrpsee::common::Error::method_not_found())),
             }
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,9 @@ pub fn http_client(addr: &str) -> Client {
 #[cfg(feature = "ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 pub async fn ws_server(addr: &SocketAddr) -> Result<Server, Box<dyn error::Error + Send + Sync>> {
-    let transport = transport::ws::WsTransportServer::builder(*addr).build().await?;
+    let transport = transport::ws::WsTransportServer::builder(*addr)
+        .build()
+        .await?;
     Ok(From::from(raw::RawServer::new(transport)))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@
 //!     while let Ok(request) = System::next_request(&mut server).await {
 //!         match request {
 //!             System::SystemName { respond } => {
-//!                 respond.ok("my name").await;
+//!                 respond.ok("my name");
 //!             }
 //!         }
 //!     }
@@ -206,6 +206,14 @@ pub async fn http_server(addr: &SocketAddr) -> Result<Server, Box<dyn error::Err
 pub fn http_client(addr: &str) -> Client {
     let transport = transport::http::HttpTransportClient::new(addr);
     Client::from(raw::RawClient::new(transport))
+}
+
+/// Builds a new WebSockets server.
+#[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
+pub async fn ws_server(addr: &SocketAddr) -> Result<Server, Box<dyn error::Error + Send + Sync>> {
+    let transport = transport::ws::WsTransportServer::builder(*addr).build().await?;
+    Ok(From::from(raw::RawServer::new(transport)))
 }
 
 /// Builds a new WebSockets client.

--- a/src/raw/server/core.rs
+++ b/src/raw/server/core.rs
@@ -342,7 +342,7 @@ where
     /// >           method](crate::transport::TransportServer::finish) on the
     /// >           [`TransportServer`](crate::transport::TransportServer) trait.
     ///
-    pub async fn respond(self, response: Result<common::JsonValue, common::Error>) {
+    pub fn respond(self, response: Result<common::JsonValue, common::Error>) {
         self.inner.set_response(response);
         //unimplemented!();
         // TODO: actually send out response?
@@ -370,7 +370,7 @@ where
     /// >           [`subscription_by_id`](RawServer::subscription_by_id) in order to manipulate the
     /// >           subscription.
     // TODO: solve the note
-    pub async fn into_subscription(
+    pub fn into_subscription(
         mut self,
     ) -> Result<RawServerSubscriptionId, IntoSubscriptionErr> {
         let raw_request_id = match self.inner.user_param().clone() {

--- a/src/raw/server/core.rs
+++ b/src/raw/server/core.rs
@@ -370,9 +370,7 @@ where
     /// >           [`subscription_by_id`](RawServer::subscription_by_id) in order to manipulate the
     /// >           subscription.
     // TODO: solve the note
-    pub fn into_subscription(
-        mut self,
-    ) -> Result<RawServerSubscriptionId, IntoSubscriptionErr> {
+    pub fn into_subscription(mut self) -> Result<RawServerSubscriptionId, IntoSubscriptionErr> {
         let raw_request_id = match self.inner.user_param().clone() {
             Some(id) => id,
             None => return Err(IntoSubscriptionErr::Closed),

--- a/src/raw/server/tests.rs
+++ b/src/raw/server/tests.rs
@@ -131,7 +131,7 @@ fn subscriptions_work() {
                     52
                 );
 
-                rq.into_subscription().await.unwrap()
+                rq.into_subscription().unwrap()
             }
             _ => panic!(),
         };

--- a/src/raw/server/typed_rp.rs
+++ b/src/raw/server/typed_rp.rs
@@ -53,23 +53,23 @@ where
     T: serde::Serialize,
 {
     /// Returns a successful response.
-    pub async fn ok(self, response: impl Into<T>) {
-        self.respond(Ok(response)).await
+    pub fn ok(self, response: impl Into<T>) {
+        self.respond(Ok(response))
     }
 
     /// Returns an erroneous response.
-    pub async fn err(self, err: crate::common::Error) {
-        self.respond(Err::<T, _>(err)).await
+    pub fn err(self, err: crate::common::Error) {
+        self.respond(Err::<T, _>(err))
     }
 
     /// Returns a response.
-    pub async fn respond(self, response: Result<impl Into<T>, crate::common::Error>) {
+    pub fn respond(self, response: Result<impl Into<T>, crate::common::Error>) {
         let response = match response {
             Ok(v) => crate::common::to_value(v.into())
                 .map_err(|_| crate::common::Error::internal_error()),
             Err(err) => Err(err),
         };
 
-        self.rq.respond(response).await
+        self.rq.respond(response)
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -142,7 +142,7 @@ impl Server {
     /// Initializes a new server based upon this raw server.
     pub fn new<R, I>(server: RawServer<R, I>) -> Server
     where
-        R: TransportServer<RequestId = I> + Send + Sync + 'static,
+        R: TransportServer<RequestId = I> + Send + 'static,
         I: Clone + PartialEq + Eq + Hash + Send + Sync + 'static,
     {
         // We use an unbounded channel because the only exchanged messages concern registering
@@ -278,7 +278,7 @@ impl RegisteredNotifications {
 /// Initializes a new server based upon this raw server.
 impl<R, I> From<RawServer<R, I>> for Server
 where
-    R: TransportServer<RequestId = I> + Send + Sync + 'static,
+    R: TransportServer<RequestId = I> + Send + 'static,
     I: Clone + PartialEq + Eq + Hash + Send + Sync + 'static,
 {
     fn from(server: RawServer<R, I>) -> Server {
@@ -377,8 +377,7 @@ async fn background_task<R, I>(
                 server
                     .request_by_id(&request_id)
                     .unwrap()
-                    .respond(answer)
-                    .await;
+                    .respond(answer);
             }
             Either::Left(Some(FrontToBack::RegisterNotifications {
                 name,
@@ -445,12 +444,11 @@ async fn background_task<R, I>(
                         Some(Ok(())) => {}
                         Some(Err(_)) | None => {
                             request
-                                .respond(Err(From::from(common::ErrorCode::ServerError(0))))
-                                .await;
+                                .respond(Err(From::from(common::ErrorCode::ServerError(0))));
                         }
                     }
                 } else if let Some(sub_unique_id) = subscribe_methods.get(request.method()) {
-                    if let Ok(sub_id) = request.into_subscription().await {
+                    if let Ok(sub_id) = request.into_subscription() {
                         debug_assert!(subscribed_clients.contains_key(&sub_unique_id));
                         if let Some(clients) = subscribed_clients.get_mut(&sub_unique_id) {
                             debug_assert!(clients.iter().all(|c| *c != sub_id));
@@ -480,8 +478,7 @@ async fn background_task<R, I>(
                     }
                 } else {
                     request
-                        .respond(Err(From::from(common::ErrorCode::InvalidRequest)))
-                        .await;
+                        .respond(Err(From::from(common::ErrorCode::InvalidRequest)));
                 }
             }
             Either::Right(RawServerEvent::SubscriptionsReady(_)) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -374,10 +374,7 @@ async fn background_task<R, I>(
         match outcome {
             Either::Left(None) => return,
             Either::Left(Some(FrontToBack::AnswerRequest { request_id, answer })) => {
-                server
-                    .request_by_id(&request_id)
-                    .unwrap()
-                    .respond(answer);
+                server.request_by_id(&request_id).unwrap().respond(answer);
             }
             Either::Left(Some(FrontToBack::RegisterNotifications {
                 name,
@@ -443,8 +440,7 @@ async fn background_task<R, I>(
                     match handler.send((request.id(), params.clone())).now_or_never() {
                         Some(Ok(())) => {}
                         Some(Err(_)) | None => {
-                            request
-                                .respond(Err(From::from(common::ErrorCode::ServerError(0))));
+                            request.respond(Err(From::from(common::ErrorCode::ServerError(0))));
                         }
                     }
                 } else if let Some(sub_unique_id) = subscribe_methods.get(request.method()) {
@@ -477,8 +473,7 @@ async fn background_task<R, I>(
                         }
                     }
                 } else {
-                    request
-                        .respond(Err(From::from(common::ErrorCode::InvalidRequest)));
+                    request.respond(Err(From::from(common::ErrorCode::InvalidRequest)));
                 }
             }
             Either::Right(RawServerEvent::SubscriptionsReady(_)) => {

--- a/src/transport/local.rs
+++ b/src/transport/local.rs
@@ -47,7 +47,7 @@
 //!     loop {
 //!         match server.next_event().await {
 //!             RawServerEvent::Request(request) => {
-//!                 request.respond(Ok(From::from("hello".to_owned()))).await;
+//!                 request.respond(Ok(From::from("hello".to_owned())));
 //!             },
 //!             _ => {}
 //!         }

--- a/tests/acl.rs
+++ b/tests/acl.rs
@@ -10,7 +10,7 @@ macro_rules! spawn_server {
             while let Ok(request) = Test::next_request(&mut $server).await {
                 match request {
                     Test::Allowed { respond, foo } => {
-                        respond.ok(foo).await;
+                        respond.ok(foo);
                     }
                 }
             }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -37,7 +37,7 @@ macro_rules! spawn_server {
                 match request {
                     Test::Concat { respond, foo, bar } => {
                         let value = format!("{}, {}", foo, bar);
-                        respond.ok(value).await;
+                        respond.ok(value);
                     }
                 }
             }


### PR DESCRIPTION
There was a flaw in the WebSocket server: the transport doesn't implement `Sync`.
But the trick is: there's no fundamental reason why the transport should have to implement `Sync`. In the `Server`, it is completely isolated in a separate task.

It turns out that, since the `RawServerRequest` object borrows `RawServer`, any `await` while a `RawServerRequest` is alive requires `&'a RawServer` to be `Send`, which in turn requires `RawServer` to be `Sync`.

To fix that, I removed the `async` qualifier of the methods on `RawServerRequest`. They were here "just in case, for the future" and not for any actual reason.

I also added a `ws_server` function at the crate root, to prove that the WebSocket server should now compile.
