### PR TITLE
Expose the server module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,9 +163,8 @@ use std::{error, net::SocketAddr};
 pub mod client;
 pub mod common;
 pub mod raw;
+pub mod server;
 pub mod transport;
-
-mod server;
 
 #[cfg(feature = "http")]
 mod server_utils;


### PR DESCRIPTION
There are quite a lot of types in the `server` module, and it doesn't really make sense to re-export them at the crate root. Instead, let's just make `server` publicly visible.