### PR TITLE
Distinguish null result from error

### DIFF
--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -346,3 +346,23 @@ fn should_parse_empty_response_as_batch() {
     );
     assert_eq!(deserialized2.unwrap(), Response::Batch(vec![]));
 }
+
+#[test]
+fn single_response_with_nulls_deserialize() {
+    use serde_json;
+    use serde_json::Value;
+
+    let dbr = r#"{"jsonrpc":"2.0","result":null,"id":1}"#;
+
+    let deserialized: Response = serde_json::from_str(dbr).unwrap();
+    assert_eq!(
+        deserialized,
+        Response::Single(
+            Output::Success(Success {
+                jsonrpc: Version::V2,
+                result: Value::Null,
+                id: Id::Num(1)
+            }),
+        )
+    );
+}


### PR DESCRIPTION
Closes https://github.com/paritytech/jsonrpsee/issues/117

When a remote endpoint replies with e.g. `{"jsonrpc":"2.0","result":null,"id":1}` we get a `None` from `next_repsponse()`. This is not an error so the current implementation is a bit confusing.
`common::Response` (and Serde) doesn't parse `null` as a valid JSON document (see https://stackoverflow.com/questions/8526995/is-null-valid-json-4-bytes-nothing-else) so this PR replaces `null` with `[]` which does parse. Not elegant but perhaps better than the status quo?