### PR TITLE
[tests]: extract test helpers to a separate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0.20"
 
 # used for tests and HTTP/hyper
 # the features are used only for tests but enabled because `dev-depedencies` are leaked into dependencies.
-tokio = { version = "0.2.22", features = ["dns", "stream", "tcp", "rt-threaded", "macros"], optional = true }
+tokio = { version = "0.2.22", features = ["stream", "rt-threaded", "macros"], optional = true }
 
 # HTTP-related dependencies
 hyper = { version = "0.13.8", features = ["stream"], optional = true }
@@ -46,4 +46,4 @@ ws = ["async-tls", "bytes", "soketto", "url", "webpki"]
 
 [dev-dependencies]
 env_logger = "0.7.1"
-tokio-util = { version = "0.3", features = ["compat"] }
+jsonrpsee-test-utils = { path = "test-utils" }

--- a/src/http/tests.rs
+++ b/src/http/tests.rs
@@ -1,40 +1,13 @@
 #![cfg(test)]
 
-use crate::common::{Id, JsonValue};
+use crate::common::JsonValue;
 use crate::http::HttpServer;
 use futures::channel::oneshot::{self, Sender};
 use futures::future::FutureExt;
 use futures::{pin_mut, select};
-use hyper::{Body, HeaderMap, StatusCode, Uri};
+use jsonrpsee_test_utils::types::{Id, StatusCode};
+use jsonrpsee_test_utils::helpers::*;
 use std::net::SocketAddr;
-
-#[derive(Debug)]
-struct Response {
-    status: StatusCode,
-    header: HeaderMap,
-    body: String,
-}
-
-async fn request(body: Body, uri: Uri) -> Result<Response, String> {
-    let client = hyper::Client::new();
-    let r = hyper::Request::post(uri)
-        .header(
-            hyper::header::CONTENT_TYPE,
-            hyper::header::HeaderValue::from_static("application/json"),
-        )
-        .body(body)
-        .expect("uri and request headers are valid; qed");
-    let res = client.request(r).await.map_err(|e| format!("{:?}", e))?;
-
-    let (parts, body) = res.into_parts();
-    let bytes = hyper::body::to_bytes(body).await.unwrap();
-
-    Ok(Response {
-        status: parts.status,
-        header: parts.headers,
-        body: String::from_utf8(bytes.to_vec()).unwrap(),
-    })
-}
 
 async fn server(server_started_tx: Sender<SocketAddr>) {
     let server = HttpServer::new("127.0.0.1:0").await.unwrap();
@@ -79,53 +52,6 @@ async fn server(server_started_tx: Sender<SocketAddr>) {
     }
 }
 
-fn to_http_uri(sockaddr: SocketAddr) -> Uri {
-    let s = sockaddr.to_string();
-
-    Uri::builder()
-        .scheme("http")
-        .authority(s.as_str())
-        .path_and_query("/")
-        .build()
-        .unwrap()
-}
-
-fn ok_response(result: JsonValue, id: Id) -> String {
-    format!(
-        r#"{{"jsonrpc":"2.0","result":{},"id":{}}}"#,
-        result,
-        serde_json::to_string(&id).unwrap()
-    )
-}
-
-fn method_not_found(id: Id) -> String {
-    format!(
-        r#"{{"jsonrpc":"2.0","error":{{"code":-32601,"message":"Method not found"}},"id":{}}}"#,
-        serde_json::to_string(&id).unwrap()
-    )
-}
-
-fn parse_error(id: Id) -> String {
-    format!(
-        r#"{{"jsonrpc":"2.0","error":{{"code":-32700,"message":"Parse error"}},"id":{}}}"#,
-        serde_json::to_string(&id).unwrap()
-    )
-}
-
-fn invalid_request(id: Id) -> String {
-    format!(
-        r#"{{"jsonrpc":"2.0","error":{{"code":-32600,"message":"Invalid request"}},"id":{}}}"#,
-        serde_json::to_string(&id).unwrap()
-    )
-}
-
-fn invalid_params(id: Id) -> String {
-    format!(
-        r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid params"}},"id":{}}}"#,
-        serde_json::to_string(&id).unwrap()
-    )
-}
-
 #[tokio::test]
 async fn single_method_call_works() {
     let (server_started_tx, server_started_rx) = oneshot::channel::<SocketAddr>();
@@ -135,7 +61,7 @@ async fn single_method_call_works() {
 
     for i in 0..10 {
         let req = format!(r#"{{"jsonrpc":"2.0","method":"say_hello","id":{}}}"#, i);
-        let response = request(req.into(), uri.clone()).await.unwrap();
+        let response = http_request(req.into(), uri.clone()).await.unwrap();
         assert_eq!(response.status, StatusCode::OK);
         assert_eq!(
             response.body,
@@ -151,7 +77,7 @@ async fn single_method_call_with_params() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-    let response = request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
     assert_eq!(response.status, StatusCode::OK);
     assert_eq!(
         response.body,
@@ -166,7 +92,7 @@ async fn should_return_method_not_found() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"bar","id":"foo"}"#;
-    let response = request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
     assert_eq!(response.status, StatusCode::OK);
     assert_eq!(response.body, method_not_found(Id::Str("foo".into())));
 }
@@ -178,7 +104,7 @@ async fn invalid_json_id_missing_value() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
-    let response = request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
     // If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
     assert_eq!(response.body, parse_error(Id::Null));
 }
@@ -190,7 +116,7 @@ async fn invalid_request_object() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
-    let response = request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
     assert_eq!(response.status, StatusCode::OK);
     assert_eq!(response.body, invalid_request(Id::Num(1)));
 }

--- a/src/ws/raw/tests.rs
+++ b/src/ws/raw/tests.rs
@@ -29,12 +29,9 @@
 use crate::client::WsTransportClient;
 use crate::common::{self, Call, MethodCall, Notification, Params, Request, Version};
 use crate::ws::{RawWsServer, RawWsServerEvent, WsTransportServer};
+use jsonrpsee_test_utils::helpers::*;
 use serde_json::Value;
 use std::net::SocketAddr;
-
-fn to_uri(sockaddr: SocketAddr) -> String {
-    format!("ws://{}", sockaddr)
-}
 
 async fn raw_server() -> (RawWsServer, SocketAddr) {
     let server = WsTransportServer::builder("127.0.0.1:0".parse().unwrap())
@@ -50,7 +47,7 @@ async fn request_work() {
     let (mut server, server_addr) = raw_server().await;
 
     tokio::spawn(async move {
-        let mut client = WsTransportClient::new(&to_uri(server_addr)).await.unwrap();
+        let mut client = WsTransportClient::new(&to_ws_uri_string(server_addr)).await.unwrap();
         let call = Call::MethodCall(MethodCall {
             jsonrpc: Version::V2,
             method: "hello_world".to_owned(),
@@ -78,7 +75,7 @@ async fn notification_work() {
     let (mut server, server_addr) = raw_server().await;
 
     tokio::spawn(async move {
-        let mut client = WsTransportClient::new(&to_uri(server_addr)).await.unwrap();
+        let mut client = WsTransportClient::new(&to_ws_uri_string(server_addr)).await.unwrap();
         let n = Notification {
             jsonrpc: Version::V2,
             method: "hello_world".to_owned(),

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -1,11 +1,85 @@
 #![cfg(test)]
 
 use crate::client::{WsClient, WsSubscription};
-use crate::common::{Id, JsonValue, Params};
+use crate::common::Params;
 use crate::ws::WsServer;
-use futures::channel::oneshot;
-use helpers::*;
+use futures::channel::oneshot::{self, Sender};
+use futures::future::FutureExt;
+use futures::{pin_mut, select};
+use jsonrpsee_test_utils::helpers::*;
+use jsonrpsee_test_utils::types::{Id, WebSocketTestClient};
+use serde_json::Value as JsonValue;
 use std::net::SocketAddr;
+
+/// Spawns a dummy `JSONRPC v2 WebSocket` that just send subscriptions to `subscribe_hello` and
+/// `subscribe_foo`.
+//
+// TODO: not sure why `tokio::spawn` doesn't works for this.
+pub fn server_subscribe_only(server_started: Sender<SocketAddr>) {
+    std::thread::spawn(move || {
+        use async_std::task::block_on;
+        let server = block_on(WsServer::new("127.0.0.1:0")).unwrap();
+        let mut hello = server
+            .register_subscription("subscribe_hello".to_owned(), "unsubscribe_hello".to_owned())
+            .unwrap();
+        let mut foo = server
+            .register_subscription("subscribe_foo".to_owned(), "unsubscribe_foo".to_owned())
+            .unwrap();
+        server_started.send(*server.local_addr()).unwrap();
+
+        loop {
+            block_on(hello.send(JsonValue::String("hello from subscription".to_owned())));
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            block_on(foo.send(JsonValue::Number(1337_u64.into())));
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    });
+}
+
+/// Spawns a dummy `JSONRPC v2 WebSocket`
+/// It has two hardcoded methods "say_hello" and "add", one hardcoded notification "notif"
+pub async fn server(server_started: Sender<SocketAddr>) {
+    let server = WsServer::new("127.0.0.1:0").await.unwrap();
+    let mut hello = server.register_method("say_hello".to_owned()).unwrap();
+    let mut add = server.register_method("add".to_owned()).unwrap();
+    let mut notif = server
+        .register_notification("notif".to_owned(), false)
+        .unwrap();
+    server_started.send(*server.local_addr()).unwrap();
+
+    loop {
+        let hello_fut = async {
+            let handle = hello.next().await;
+            log::debug!("server respond to hello");
+            handle
+                .respond(Ok(JsonValue::String("hello".to_owned())))
+                .await;
+        }
+        .fuse();
+
+        let add_fut = async {
+            let handle = add.next().await;
+            let params: Vec<u64> = handle.params().clone().parse().unwrap();
+            let sum: u64 = params.iter().sum();
+            handle.respond(Ok(JsonValue::Number(sum.into()))).await;
+        }
+        .fuse();
+
+        let notif_fut = async {
+            let params = notif.next().await;
+            println!("received notification: say_hello params[{:?}]", params);
+        }
+        .fuse();
+
+        pin_mut!(hello_fut, add_fut, notif_fut);
+        select! {
+            say_hello = hello_fut => (),
+            add = add_fut => (),
+            notif = notif_fut => (),
+            complete => (),
+        };
+    }
+}
 
 #[tokio::test]
 async fn single_method_call_works() {
@@ -196,168 +270,4 @@ async fn register_methods_works() {
             .is_ok(),
         "Failed register_subscription should not have side-effects"
     );
-}
-
-mod helpers {
-    use crate::common::{Id, JsonValue};
-    use crate::ws::WsServer;
-    use futures::channel::oneshot::Sender;
-    use futures::future::FutureExt;
-    use futures::io::{BufReader, BufWriter};
-    use futures::{pin_mut, select};
-    use soketto::handshake;
-    use std::net::SocketAddr;
-    use tokio::net::TcpStream;
-    use tokio_util::compat::{Compat, Tokio02AsyncReadCompatExt};
-
-    type Error = Box<dyn std::error::Error>;
-
-    pub struct WebSocketTestClient {
-        tx: soketto::Sender<BufReader<BufWriter<Compat<TcpStream>>>>,
-        rx: soketto::Receiver<BufReader<BufWriter<Compat<TcpStream>>>>,
-    }
-
-    impl WebSocketTestClient {
-        pub async fn new(url: SocketAddr) -> Result<Self, Error> {
-            let socket = TcpStream::connect(url).await?;
-            let mut client = handshake::Client::new(
-                BufReader::new(BufWriter::new(socket.compat())),
-                "test-client",
-                "/",
-            );
-            match client.handshake().await {
-                Ok(handshake::ServerResponse::Accepted { .. }) => {
-                    let (tx, rx) = client.into_builder().finish();
-                    Ok(Self { tx, rx })
-                }
-                r @ _ => Err(format!("WebSocketHandshake failed: {:?}", r).into()),
-            }
-        }
-
-        pub async fn send_request_text(&mut self, msg: impl AsRef<str>) -> Result<String, Error> {
-            self.tx.send_text(msg).await?;
-            self.tx.flush().await?;
-            let mut data = Vec::new();
-            self.rx.receive_data(&mut data).await?;
-            String::from_utf8(data).map_err(Into::into)
-        }
-
-        pub async fn send_request_binary(&mut self, msg: &[u8]) -> Result<String, Error> {
-            self.tx.send_binary(msg).await?;
-            self.tx.flush().await?;
-            let mut data = Vec::new();
-            self.rx.receive_data(&mut data).await?;
-            String::from_utf8(data).map_err(Into::into)
-        }
-
-        pub async fn close(&mut self) -> Result<(), Error> {
-            self.tx.close().await.map_err(Into::into)
-        }
-    }
-
-    /// Spawns a dummy `JSONRPC v2 WebSocket` that just send subscriptions to `subscribe_hello` and
-    /// `subscribe_foo`.
-    //
-    // TODO: not sure why `tokio::spawn` doesn't works for this.
-    pub fn server_subscribe_only(server_started: Sender<SocketAddr>) {
-        std::thread::spawn(move || {
-            use async_std::task::block_on;
-            let server = block_on(WsServer::new("127.0.0.1:0")).unwrap();
-            let mut hello = server
-                .register_subscription("subscribe_hello".to_owned(), "unsubscribe_hello".to_owned())
-                .unwrap();
-            let mut foo = server
-                .register_subscription("subscribe_foo".to_owned(), "unsubscribe_foo".to_owned())
-                .unwrap();
-            server_started.send(*server.local_addr()).unwrap();
-
-            loop {
-                block_on(hello.send(JsonValue::String("hello from subscription".to_owned())));
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                block_on(foo.send(JsonValue::Number(1337_u64.into())));
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-        });
-    }
-
-    /// Spawns a dummy `JSONRPC v2 WebSocket`
-    /// It has two hardcoded methods "say_hello" and "add", one hardcoded notification "notif"
-    pub async fn server(server_started: Sender<SocketAddr>) {
-        let server = WsServer::new("127.0.0.1:0").await.unwrap();
-        let mut hello = server.register_method("say_hello".to_owned()).unwrap();
-        let mut add = server.register_method("add".to_owned()).unwrap();
-        let mut notif = server
-            .register_notification("notif".to_owned(), false)
-            .unwrap();
-        server_started.send(*server.local_addr()).unwrap();
-
-        loop {
-            let hello_fut = async {
-                let handle = hello.next().await;
-                log::debug!("server respond to hello");
-                handle
-                    .respond(Ok(JsonValue::String("hello".to_owned())))
-                    .await;
-            }
-            .fuse();
-
-            let add_fut = async {
-                let handle = add.next().await;
-                let params: Vec<u64> = handle.params().clone().parse().unwrap();
-                let sum: u64 = params.iter().sum();
-                handle.respond(Ok(JsonValue::Number(sum.into()))).await;
-            }
-            .fuse();
-
-            let notif_fut = async {
-                let params = notif.next().await;
-                println!("received notification: say_hello params[{:?}]", params);
-            }
-            .fuse();
-
-            pin_mut!(hello_fut, add_fut, notif_fut);
-            select! {
-                say_hello = hello_fut => (),
-                add = add_fut => (),
-                notif = notif_fut => (),
-                complete => (),
-            };
-        }
-    }
-
-    pub fn ok_response(result: JsonValue, id: Id) -> String {
-        format!(
-            r#"{{"jsonrpc":"2.0","result":{},"id":{}}}"#,
-            result,
-            serde_json::to_string(&id).unwrap()
-        )
-    }
-
-    pub fn method_not_found(id: Id) -> String {
-        format!(
-            r#"{{"jsonrpc":"2.0","error":{{"code":-32601,"message":"Method not found"}},"id":{}}}"#,
-            serde_json::to_string(&id).unwrap()
-        )
-    }
-
-    pub fn parse_error(id: Id) -> String {
-        format!(
-            r#"{{"jsonrpc":"2.0","error":{{"code":-32700,"message":"Parse error"}},"id":{}}}"#,
-            serde_json::to_string(&id).unwrap()
-        )
-    }
-
-    pub fn invalid_request(id: Id) -> String {
-        format!(
-            r#"{{"jsonrpc":"2.0","error":{{"code":-32600,"message":"Invalid request"}},"id":{}}}"#,
-            serde_json::to_string(&id).unwrap()
-        )
-    }
-
-    pub fn invalid_params(id: Id) -> String {
-        format!(
-            r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid params"}},"id":{}}}"#,
-            serde_json::to_string(&id).unwrap()
-        )
-    }
 }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "jsonrpsee-test-utils"
+version = "0.1.0"
+authors = ["Niklas <niklasadolfsson1@gmail.com>"]
+license = "MIT"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futures = "0.3.6"
+hyper = "0.13.8"
+serde = { version = "1.0.116", default-features = false, features = ["derive"] }
+serde_json = "1.0.58"
+soketto = "0.4.2"
+tokio = { version = "0.2.22", features = ["dns", "stream", "tcp", "rt-threaded", "macros"] }
+tokio-util = { version = "0.3", features = ["compat"] }

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -1,0 +1,79 @@
+use crate::types::{Body, HttpResponse, Id, Uri};
+use serde_json::Value;
+use std::net::SocketAddr;
+
+/// Converts a sockaddress to a WebSocket URI.
+pub fn to_ws_uri_string(addr: SocketAddr) -> String {
+    let mut s = String::new();
+    s.push_str("ws://");
+    s.push_str(&addr.to_string());
+    s
+}
+
+/// Converts a sockaddress to a HTTP URI.
+pub fn to_http_uri(sockaddr: SocketAddr) -> Uri {
+    let s = sockaddr.to_string();
+    Uri::builder()
+        .scheme("http")
+        .authority(s.as_str())
+        .path_and_query("/")
+        .build()
+        .unwrap()
+}
+
+pub fn ok_response(result: Value, id: Id) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","result":{},"id":{}}}"#,
+        result,
+        serde_json::to_string(&id).unwrap()
+    )
+}
+
+pub fn method_not_found(id: Id) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","error":{{"code":-32601,"message":"Method not found"}},"id":{}}}"#,
+        serde_json::to_string(&id).unwrap()
+    )
+}
+
+pub fn parse_error(id: Id) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","error":{{"code":-32700,"message":"Parse error"}},"id":{}}}"#,
+        serde_json::to_string(&id).unwrap()
+    )
+}
+
+pub fn invalid_request(id: Id) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","error":{{"code":-32600,"message":"Invalid request"}},"id":{}}}"#,
+        serde_json::to_string(&id).unwrap()
+    )
+}
+
+pub fn invalid_params(id: Id) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid params"}},"id":{}}}"#,
+        serde_json::to_string(&id).unwrap()
+    )
+}
+
+pub async fn http_request(body: Body, uri: Uri) -> Result<HttpResponse, String> {
+    let client = hyper::Client::new();
+    let r = hyper::Request::post(uri)
+        .header(
+            hyper::header::CONTENT_TYPE,
+            hyper::header::HeaderValue::from_static("application/json"),
+        )
+        .body(body)
+        .expect("uri and request headers are valid; qed");
+    let res = client.request(r).await.map_err(|e| format!("{:?}", e))?;
+
+    let (parts, body) = res.into_parts();
+    let bytes = hyper::body::to_bytes(body).await.unwrap();
+
+    Ok(HttpResponse {
+        status: parts.status,
+        header: parts.headers,
+        body: String::from_utf8(bytes.to_vec()).unwrap(),
+    })
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,4 @@
+//! Shared test helpers for JSONRPC v2.
+
+pub mod helpers;
+pub mod types;

--- a/test-utils/src/types.rs
+++ b/test-utils/src/types.rs
@@ -1,0 +1,74 @@
+use futures::io::{BufReader, BufWriter};
+use serde::{Deserialize, Serialize};
+use soketto::handshake;
+use std::net::SocketAddr;
+use tokio::net::TcpStream;
+use tokio_util::compat::{Compat, Tokio02AsyncReadCompatExt};
+
+pub use hyper::{Body, HeaderMap, StatusCode, Uri};
+
+type Error = Box<dyn std::error::Error>;
+
+/// Request Id
+#[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum Id {
+    /// No id (notification)
+    Null,
+    /// Numeric id
+    Num(u64),
+    /// String id
+    Str(String),
+}
+
+#[derive(Debug)]
+pub struct HttpResponse {
+    pub status: StatusCode,
+    pub header: HeaderMap,
+    pub body: String,
+}
+
+/// WebSocket client to construct with arbitrary payload to construct bad payloads.
+pub struct WebSocketTestClient {
+    tx: soketto::Sender<BufReader<BufWriter<Compat<TcpStream>>>>,
+    rx: soketto::Receiver<BufReader<BufWriter<Compat<TcpStream>>>>,
+}
+
+impl WebSocketTestClient {
+    pub async fn new(url: SocketAddr) -> Result<Self, Error> {
+        let socket = TcpStream::connect(url).await?;
+        let mut client = handshake::Client::new(
+            BufReader::new(BufWriter::new(socket.compat())),
+            "test-client",
+            "/",
+        );
+        match client.handshake().await {
+            Ok(handshake::ServerResponse::Accepted { .. }) => {
+                let (tx, rx) = client.into_builder().finish();
+                Ok(Self { tx, rx })
+            }
+            r @ _ => Err(format!("WebSocketHandshake failed: {:?}", r).into()),
+        }
+    }
+
+    pub async fn send_request_text(&mut self, msg: impl AsRef<str>) -> Result<String, Error> {
+        self.tx.send_text(msg).await?;
+        self.tx.flush().await?;
+        let mut data = Vec::new();
+        self.rx.receive_data(&mut data).await?;
+        String::from_utf8(data).map_err(Into::into)
+    }
+
+    pub async fn send_request_binary(&mut self, msg: &[u8]) -> Result<String, Error> {
+        self.tx.send_binary(msg).await?;
+        self.tx.flush().await?;
+        let mut data = Vec::new();
+        self.rx.receive_data(&mut data).await?;
+        String::from_utf8(data).map_err(Into::into)
+    }
+
+    pub async fn close(&mut self) -> Result<(), Error> {
+        self.tx.close().await.map_err(Into::into)
+    }
+}


### PR DESCRIPTION
Get rid of all code duplication within testing.

This PR introduces a separate helper crate just for testing and not to leak features from `dev-dependencies` into `dependencies`.