### PR TITLE
[ws server]: don't close connection when `deserialization` fails

### DIFF
--- a/src/http/tests.rs
+++ b/src/http/tests.rs
@@ -5,8 +5,8 @@ use crate::http::HttpServer;
 use futures::channel::oneshot::{self, Sender};
 use futures::future::FutureExt;
 use futures::{pin_mut, select};
-use jsonrpsee_test_utils::types::{Id, StatusCode};
 use jsonrpsee_test_utils::helpers::*;
+use jsonrpsee_test_utils::types::{Id, StatusCode};
 use std::net::SocketAddr;
 
 async fn server(server_started_tx: Sender<SocketAddr>) {
@@ -77,7 +77,9 @@ async fn single_method_call_with_params() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr))
+        .await
+        .unwrap();
     assert_eq!(response.status, StatusCode::OK);
     assert_eq!(
         response.body,
@@ -92,7 +94,9 @@ async fn should_return_method_not_found() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"bar","id":"foo"}"#;
-    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr))
+        .await
+        .unwrap();
     assert_eq!(response.status, StatusCode::OK);
     assert_eq!(response.body, method_not_found(Id::Str("foo".into())));
 }
@@ -104,7 +108,9 @@ async fn invalid_json_id_missing_value() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
-    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr))
+        .await
+        .unwrap();
     // If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
     assert_eq!(response.body, parse_error(Id::Null));
 }
@@ -116,7 +122,9 @@ async fn invalid_request_object() {
     let server_addr = server_started_rx.await.unwrap();
 
     let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
-    let response = http_request(req.into(), to_http_uri(server_addr)).await.unwrap();
+    let response = http_request(req.into(), to_http_uri(server_addr))
+        .await
+        .unwrap();
     assert_eq!(response.status, StatusCode::OK);
     assert_eq!(response.body, invalid_request(Id::Num(1)));
 }

--- a/src/ws/raw/tests.rs
+++ b/src/ws/raw/tests.rs
@@ -47,7 +47,9 @@ async fn request_work() {
     let (mut server, server_addr) = raw_server().await;
 
     tokio::spawn(async move {
-        let mut client = WsTransportClient::new(&to_ws_uri_string(server_addr)).await.unwrap();
+        let mut client = WsTransportClient::new(&to_ws_uri_string(server_addr))
+            .await
+            .unwrap();
         let call = Call::MethodCall(MethodCall {
             jsonrpc: Version::V2,
             method: "hello_world".to_owned(),
@@ -75,7 +77,9 @@ async fn notification_work() {
     let (mut server, server_addr) = raw_server().await;
 
     tokio::spawn(async move {
-        let mut client = WsTransportClient::new(&to_ws_uri_string(server_addr)).await.unwrap();
+        let mut client = WsTransportClient::new(&to_ws_uri_string(server_addr))
+            .await
+            .unwrap();
         let n = Notification {
             jsonrpc: Version::V2,
             method: "hello_world".to_owned(),

--- a/src/ws/transport.rs
+++ b/src/ws/transport.rs
@@ -425,7 +425,7 @@ async fn per_connection_task(
                         ))
                         .expect("valid JSON; qed");
 
-                        // deserialization failed and then client not alive then close the connection.
+                        // deserialization failed and the client is not alive then close the connection.
                         if let Err(e) = sender.send_text(&response).await {
                             log::warn!(
                                 "Failed to send: {:?} over WebSocket transport with error: {:?}",


### PR DESCRIPTION
The WebSocket server closes the connection when the deserialization of a single request fails, which this PR fixes.

In a follow-up PR, we should try to document the error conditions of `fn per_connection_task` and perhaps differentiate success and error with a `Result<_>` instead of returning just Vec.