### PR TITLE
fix(ws server): sub/unsubscribe to same method should generate an error

### DIFF
--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -237,8 +237,8 @@ impl Server {
 		{
 			let mut registered_methods = self.registered_methods.lock();
 
-			// NOTE: optimized for that both methods are not registered
-			// For example if the strings are equal this will be slower than just comparing the
+			// NOTE: We optimise for the case where neither method is registered.
+			// This means that if the strings are equal this will be slower than just comparing the
 			// strings.
 			if !registered_methods.insert(subscribe_method_name.clone()) {
 				return Err(());

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -230,6 +230,12 @@ async fn register_methods_works() {
 }
 
 #[tokio::test]
+async fn register_same_subscribe_unsubscribe_is_err() {
+	let server = WsServer::new("127.0.0.1:0").await.unwrap();
+	matches!(server.register_subscription("subscribe_hello".to_owned(), "subscribe_hello".to_owned()), Err(()));
+}
+
+#[tokio::test]
 async fn parse_error_request_should_not_close_connection() {
 	let (server_started_tx, server_started_rx) = oneshot::channel::<SocketAddr>();
 	tokio::spawn(server(server_started_tx));


### PR DESCRIPTION
Subscribe and unsubscribe to the same method should generate an error, which this commit fixes.

This bug was introduced by myself in https://github.com/paritytech/jsonrpsee/commit/fc87889de2615dbb3d0cf2d91a306f016d48df2d