### PR TITLE
fix(ws server): remove faulty debug_assert

### DIFF
--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -471,7 +471,6 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 				// Remove all the subscriptions from `active_subscriptions` and
 				// `subscribed_clients`.
 				for sub_id in subscriptions {
-					debug_assert!(active_subscriptions.contains_key(&sub_id));
 					if let Some(unique_id) = active_subscriptions.remove(&sub_id) {
 						debug_assert!(subscribed_clients.contains_key(&unique_id));
 						if let Some(clients) = subscribed_clients.get_mut(&unique_id) {


### PR DESCRIPTION
The code assumed that `subscription id` is still in `active_subscriptions` when the
connection was dropped.

The list of subscriptions (kept in raw server) are not notified when a client dropped its
subscription/unsubscribed thus it's possible that the actual subscriptions are closed before the
entire client was dropped.

This, can be reproduced by:

```rust
	let client = WsClient::new(&uri).await.unwrap();
        {
	        let mut hello_sub: WsSubscription<JsonValue> =
		client.subscribe("subscribe_hello", Params::None, "unsubscribe_hello").await.unwrap();
        }
        drop(client)
        loop {}
```

