### PR TITLE
chore: make `debug log` less verbose.

### DIFF
--- a/src/client/http/raw.rs
+++ b/src/client/http/raw.rs
@@ -189,7 +189,6 @@ impl RawClient {
 				id: jsonrpc::Id::Num(id.0),
 			}));
 
-			log::debug!(target: "jsonrpsee-http-raw-client", "request={:?}", request);
 			// Note that in case of an error, we "lose" the request id (as in, it will never be
 			// used). This isn't a problem, however.
 			self.inner.send_request(request).await?;

--- a/src/client/http/transport.rs
+++ b/src/client/http/transport.rs
@@ -73,6 +73,7 @@ impl HttpTransportClient {
 		&'s mut self,
 		request: jsonrpc::Request,
 	) -> Pin<Box<dyn Future<Output = Result<(), RequestError>> + Send + 's>> {
+		log::debug!("send: {}", jsonrpc::to_string(&request).expect("request valid JSON; qed"));
 		let mut requests_tx = self.requests_tx.clone();
 
 		let request = jsonrpc::to_vec(&request).map(|body| {
@@ -131,6 +132,7 @@ impl HttpTransportClient {
 
 			// TODO: use Response::from_json
 			let as_json: jsonrpc::Response = jsonrpc::from_slice(&body).map_err(RequestError::ParseError)?;
+			log::debug!("recv: {}", jsonrpc::to_string(&as_json).expect("request valid JSON; qed"));
 			Ok(as_json)
 		})
 	}

--- a/src/client/ws/client.rs
+++ b/src/client/ws/client.rs
@@ -122,7 +122,7 @@ impl Client {
 	) -> Result<(), Error> {
 		let method = method.into();
 		let params = params.into();
-		log::debug!("[frontend]: client send notification: method={:?}, params={:?}", method, params);
+		log::trace!("[frontend]: send notification: method={:?}, params={:?}", method, params);
 		self.to_back.clone().send(FrontToBack::Notification { method, params }).await.map_err(Error::InternalChannel)
 	}
 
@@ -137,7 +137,7 @@ impl Client {
 	{
 		let method = method.into();
 		let params = params.into();
-		log::debug!("[frontend]: send request: method={:?}, params={:?}", method, params);
+		log::trace!("[frontend]: send request: method={:?}, params={:?}", method, params);
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		self.to_back.clone().send(FrontToBack::StartRequest { method, params, send_back: send_back_tx }).await?;
 
@@ -171,6 +171,7 @@ impl Client {
 			return Err(Error::Subscription(subscribe_method, unsubscribe_method));
 		}
 
+		log::trace!("[frontend]: subscribe: {:?}, unsubscribe: {:?}", subscribe_method, unsubscribe_method);
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		self.to_back
 			.clone()

--- a/src/client/ws/raw.rs
+++ b/src/client/ws/raw.rs
@@ -444,7 +444,6 @@ impl RawClient {
 	/// Processes the response obtained from the server. Updates the internal state of `self` to
 	/// account for it.
 	fn process_response(&mut self, response: jsonrpc::Output) -> Result<(), RawClientError> {
-		log::debug!(target: "ws-client-raw", "received response: {:?}", response);
 		let request_id = match response.id() {
 			jsonrpc::Id::Num(n) => RawClientRequestId(*n),
 			jsonrpc::Id::Str(s) => {

--- a/src/client/ws/transport.rs
+++ b/src/client/ws/transport.rs
@@ -198,7 +198,7 @@ impl WsTransportClient {
 		request: jsonrpc::Request,
 	) -> Pin<Box<dyn Future<Output = Result<(), WsConnectError>> + Send + 'a>> {
 		Box::pin(async move {
-			log::debug!("send request: {:?}", request);
+			log::debug!("send: {}", jsonrpc::to_string(&request).expect("valid Request; qed"));
 			let request = jsonrpc::to_vec(&request).map_err(WsConnectError::Serialization)?;
 			self.sender.send_binary(request).await?;
 			self.sender.flush().await?;
@@ -214,7 +214,7 @@ impl WsTransportClient {
 			let mut message = Vec::new();
 			self.receiver.receive_data(&mut message).await?;
 			let response = jsonrpc::from_slice(&message).map_err(WsConnectError::ParseError)?;
-			log::debug!("received response: {:?}", response);
+			log::debug!("recv: {}", jsonrpc::to_string(&response).expect("valid Request; qed"));
 			Ok(response)
 		})
 	}

--- a/src/http/transport/mod.rs
+++ b/src/http/transport/mod.rs
@@ -85,9 +85,6 @@ impl HttpTransportServer {
 	// >       might switch out to a different library later without breaking the API.
 	pub async fn new(addr: &SocketAddr) -> Result<HttpTransportServer, Box<dyn error::Error + Send + Sync>> {
 		let (background_thread, local_addr) = background::BackgroundHttp::bind(addr).await?;
-
-		log::debug!(target: "jsonrpc-http-server", "Starting jsonrpc http server at address={:?}, local_addr={:?}", addr, local_addr);
-
 		Ok(HttpTransportServer { background_thread, local_addr, requests: Default::default(), next_request_id: 0 })
 	}
 
@@ -118,7 +115,6 @@ impl HttpTransportServer {
 			let request = match self.background_thread.next().await {
 				Ok(r) => r,
 				Err(_) => loop {
-					log::debug!("http transport server inf loop?!");
 					futures::pending!()
 				},
 			};
@@ -144,10 +140,7 @@ impl HttpTransportServer {
 				self.requests.shrink_to_fit();
 			}
 
-			let request = TransportServerEvent::Request { id: request_id, request: request.request };
-
-			log::debug!(target: "jsonrpc-http-transport-server", "received request: {:?}", request);
-			request
+			TransportServerEvent::Request { id: request_id, request: request.request }
 		})
 	}
 

--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -354,7 +354,7 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 		match outcome {
 			Either::Left(None) => {
 				log::trace!("[backend]: background_task terminated");
-				return
+				return;
 			}
 			Either::Left(Some(FrontToBack::AnswerRequest { request_id, answer })) => {
 				log::trace!("[backend]: answer_request: {:?} id: {:?}", answer, request_id);

--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -184,11 +184,11 @@ impl Server {
 		method_name: String,
 		allow_losses: bool,
 	) -> Result<RegisteredNotification, Error> {
-		log::debug!("[frontend]: register_notification={}", method_name);
 		if !self.registered_methods.lock().insert(method_name.clone()) {
 			return Err(Error::AlreadyRegistered(method_name));
 		}
 
+		log::trace!("[frontend]: register_notification={}", method_name);
 		let (tx, rx) = mpsc::channel(32);
 
 		self.to_back
@@ -209,11 +209,11 @@ impl Server {
 	///
 	/// Returns an error if the method name was already registered.
 	pub fn register_method(&self, method_name: String) -> Result<RegisteredMethod, Error> {
-		log::debug!("[frontend]: register_method={}", method_name);
 		if !self.registered_methods.lock().insert(method_name.clone()) {
 			return Err(Error::AlreadyRegistered(method_name));
 		}
 
+		log::trace!("[frontend]: register_method={}", method_name);
 		let (tx, rx) = mpsc::channel(32);
 
 		self.to_back
@@ -234,11 +234,6 @@ impl Server {
 		subscribe_method_name: String,
 		unsubscribe_method_name: String,
 	) -> Result<RegisteredSubscription, Error> {
-		log::debug!(
-			"[frontend]: server register subscription: subscribe_method={}, unsubscribe_method={}",
-			subscribe_method_name,
-			unsubscribe_method_name
-		);
 		{
 			let mut registered_methods = self.registered_methods.lock();
 
@@ -254,6 +249,11 @@ impl Server {
 			}
 		}
 
+		log::trace!(
+			"[frontend]: server register subscription: subscribe_method={}, unsubscribe_method={}",
+			subscribe_method_name,
+			unsubscribe_method_name
+		);
 		let unique_id = self.next_subscription_unique_id.fetch_add(1, atomic::Ordering::Relaxed);
 
 		self.to_back
@@ -352,14 +352,20 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 		};
 
 		match outcome {
-			Either::Left(None) => return,
+			Either::Left(None) => {
+				log::trace!("[backend]: background_task terminated");
+				return
+			}
 			Either::Left(Some(FrontToBack::AnswerRequest { request_id, answer })) => {
+				log::trace!("[backend]: answer_request: {:?} id: {:?}", answer, request_id);
 				server.request_by_id(&request_id).unwrap().respond(answer);
 			}
 			Either::Left(Some(FrontToBack::RegisterNotifications { name, handler, allow_losses })) => {
+				log::trace!("[backend]: register_notification: {:?}", name);
 				registered_notifications.insert(name, (handler, allow_losses));
 			}
 			Either::Left(Some(FrontToBack::RegisterMethod { name, handler })) => {
+				log::trace!("[backend]: register_method: {:?}", name);
 				registered_methods.insert(name, handler);
 			}
 			Either::Left(Some(FrontToBack::RegisterSubscription {
@@ -367,8 +373,8 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 				subscribe_method,
 				unsubscribe_method,
 			})) => {
-				log::debug!(
-					"[backend]: server register subscription=id={:?}, subscribe_method:{}, unsubscribe_method={}",
+				log::trace!(
+					"[backend]: register subscription=id={:?}, subscribe_method:{}, unsubscribe_method={}",
 					unique_id,
 					subscribe_method,
 					unsubscribe_method
@@ -388,7 +394,7 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 				subscribed_clients.insert(unique_id, Vec::new());
 			}
 			Either::Left(Some(FrontToBack::SendOutNotif { unique_id, notification })) => {
-				log::debug!("[backend]: server preparing response to subscription={:?}", unique_id);
+				log::trace!("[backend]: preparing response to subscription={:?}", unique_id);
 				debug_assert!(subscribed_clients.contains_key(&unique_id));
 				if let Some(clients) = subscribed_clients.get(&unique_id) {
 					log::trace!(
@@ -408,7 +414,7 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 				}
 			}
 			Either::Right(RawServerEvent::Notification(notification)) => {
-				log::debug!("[backend]: server received notification: {:?}", notification);
+				log::debug!("[backend]: received notification: {:?}", notification);
 				if let Some((handler, allow_losses)) = registered_notifications.get_mut(notification.method()) {
 					let params: &jsonrpc::Params = notification.params().into();
 					// Note: we just ignore errors. It doesn't make sense logically speaking to
@@ -422,9 +428,8 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 			}
 			Either::Right(RawServerEvent::Request(request)) => {
 				if let Some(handler) = registered_methods.get_mut(request.method()) {
-					log::debug!("[backend]: server received request: {:?}", request);
+					log::trace!("[backend]: received request: {:?}", request);
 					let params: &jsonrpc::Params = request.params().into();
-					log::debug!("server called handler");
 					match handler.send((request.id(), params.clone())).now_or_never() {
 						Some(Ok(())) => {}
 						Some(Err(_)) | None => {
@@ -432,7 +437,7 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 						}
 					}
 				} else if let Some(sub_unique_id) = subscribe_methods.get(request.method()) {
-					log::debug!("[backend]: server received subscription: {:?}", request);
+					log::trace!("[backend]: received subscription: {:?}", request);
 					if let Ok(sub_id) = request.into_subscription() {
 						debug_assert!(subscribed_clients.contains_key(&sub_unique_id));
 						if let Some(clients) = subscribed_clients.get_mut(&sub_unique_id) {
@@ -444,7 +449,7 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 						active_subscriptions.insert(sub_id, *sub_unique_id);
 					}
 				} else if let Some(sub_unique_id) = unsubscribe_methods.get(request.method()) {
-					log::debug!("[backend]: server received unsubscription: {:?}", request);
+					log::trace!("[backend]: received unsubscription: {:?}", request);
 					match RawServerSubscriptionId::try_from(request.params()) {
 						Ok(sub_id) => {
 							debug_assert!(subscribed_clients.contains_key(&sub_unique_id));
@@ -473,7 +478,7 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 				// We don't really care whether subscriptions are now ready.
 			}
 			Either::Right(RawServerEvent::SubscriptionsClosed(subscriptions)) => {
-				log::debug!("[backend]: server close subscriptions: {:?}", subscriptions);
+				log::trace!("[backend]: close subscriptions: {:?}", subscriptions);
 				// Remove all the subscriptions from `active_subscriptions` and
 				// `subscribed_clients`.
 				for sub_id in subscriptions {


### PR DESCRIPTION
The debug logging was just too verbose and this commit simplies it as follows:

```
DEBUG recv: {"jsonrpc":"2.0","method":"<METHOD>","params":<PARAMS>,"id":<ID>}
DEBUG send: {"jsonrpc":"2.0","result":"<RESULT>","id":<ID>}
```