### PR TITLE
[jsonrpc types]: implement Display for Request/Response

### DIFF
--- a/src/client/http/transport.rs
+++ b/src/client/http/transport.rs
@@ -73,7 +73,7 @@ impl HttpTransportClient {
 		&'s mut self,
 		request: jsonrpc::Request,
 	) -> Pin<Box<dyn Future<Output = Result<(), RequestError>> + Send + 's>> {
-		log::debug!("send: {}", jsonrpc::to_string(&request).expect("request valid JSON; qed"));
+		log::debug!("send: {}", request);
 		let mut requests_tx = self.requests_tx.clone();
 
 		let request = jsonrpc::to_vec(&request).map(|body| {
@@ -130,10 +130,9 @@ impl HttpTransportClient {
 				.await
 				.map_err(|err| RequestError::Http(Box::new(err)))?;
 
-			// TODO: use Response::from_json
-			let as_json: jsonrpc::Response = jsonrpc::from_slice(&body).map_err(RequestError::ParseError)?;
-			log::debug!("recv: {}", jsonrpc::to_string(&as_json).expect("request valid JSON; qed"));
-			Ok(as_json)
+			let response: jsonrpc::Response = jsonrpc::from_slice(&body).map_err(RequestError::ParseError)?;
+			log::debug!("recv: {}", response);
+			Ok(response)
 		})
 	}
 }

--- a/src/client/ws/transport.rs
+++ b/src/client/ws/transport.rs
@@ -198,7 +198,7 @@ impl WsTransportClient {
 		request: jsonrpc::Request,
 	) -> Pin<Box<dyn Future<Output = Result<(), WsConnectError>> + Send + 'a>> {
 		Box::pin(async move {
-			log::debug!("send: {}", jsonrpc::to_string(&request).expect("valid Request; qed"));
+			log::debug!("send: {}", request);
 			let request = jsonrpc::to_vec(&request).map_err(WsConnectError::Serialization)?;
 			self.sender.send_binary(request).await?;
 			self.sender.flush().await?;
@@ -214,7 +214,7 @@ impl WsTransportClient {
 			let mut message = Vec::new();
 			self.receiver.receive_data(&mut message).await?;
 			let response = jsonrpc::from_slice(&message).map_err(WsConnectError::ParseError)?;
-			log::debug!("recv: {}", jsonrpc::to_string(&response).expect("valid Request; qed"));
+			log::debug!("recv: {}", response);
 			Ok(response)
 		})
 	}

--- a/src/http/tests.rs
+++ b/src/http/tests.rs
@@ -19,7 +19,6 @@ async fn server(server_started_tx: Sender<SocketAddr>) {
 	loop {
 		let hello_fut = async {
 			let handle = hello.next().await;
-			log::debug!("server respond to hello");
 			handle.respond(Ok(JsonValue::String("hello".to_owned()))).await.unwrap();
 		}
 		.fuse();

--- a/src/types/jsonrpc/request.rs
+++ b/src/types/jsonrpc/request.rs
@@ -26,7 +26,7 @@
 
 use super::{Id, Params, Version};
 
-use alloc::{string::String, vec::Vec};
+use alloc::{fmt, string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
 
 /// Represents jsonrpc request which is a method call.
@@ -108,6 +108,12 @@ pub enum Request {
 	Batch(Vec<Call>),
 }
 
+impl fmt::Display for Request {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", super::to_string(self).expect("Request valid JSON; qed"))
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -115,9 +121,6 @@ mod tests {
 
 	#[test]
 	fn method_call_serialize() {
-		use serde_json;
-		use serde_json::Value;
-
 		let m = MethodCall {
 			jsonrpc: Version::V2,
 			method: "update".to_owned(),
@@ -131,9 +134,6 @@ mod tests {
 
 	#[test]
 	fn notification_serialize() {
-		use serde_json;
-		use serde_json::Value;
-
 		let n = Notification {
 			jsonrpc: Version::V2,
 			method: "update".to_owned(),
@@ -146,9 +146,6 @@ mod tests {
 
 	#[test]
 	fn call_serialize() {
-		use serde_json;
-		use serde_json::Value;
-
 		let n = Call::Notification(Notification {
 			jsonrpc: Version::V2,
 			method: "update".to_owned(),
@@ -161,8 +158,6 @@ mod tests {
 
 	#[test]
 	fn request_serialize_batch() {
-		use serde_json;
-
 		let batch = Request::Batch(vec![
 			Call::MethodCall(MethodCall {
 				jsonrpc: Version::V2,
@@ -216,8 +211,6 @@ mod tests {
 
 	#[test]
 	fn call_deserialize() {
-		use serde_json;
-
 		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1]}"#;
 		let deserialized: Call = serde_json::from_str(s).unwrap();
 		assert_eq!(
@@ -280,8 +273,6 @@ mod tests {
 
 	#[test]
 	fn request_deserialize_batch() {
-		use serde_json;
-
 		let s = r#"[{}, {"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1},{"jsonrpc": "2.0", "method": "update", "params": [1]}]"#;
 		let deserialized: Request = serde_json::from_str(s).unwrap();
 		assert_eq!(
@@ -305,8 +296,6 @@ mod tests {
 
 	#[test]
 	fn request_invalid_returns_id() {
-		use serde_json;
-
 		let s = r#"{"id":120,"method":"my_method","params":["foo", "bar"],"extra_field":[]}"#;
 		let deserialized: Request = serde_json::from_str(s).unwrap();
 

--- a/src/types/jsonrpc/request.rs
+++ b/src/types/jsonrpc/request.rs
@@ -110,7 +110,7 @@ pub enum Request {
 
 impl fmt::Display for Request {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}", super::to_string(self).expect("Request valid JSON; qed"))
+		write!(f, "{}", serde_json::to_string(self).expect("Request valid JSON; qed"))
 	}
 }
 

--- a/src/types/jsonrpc/response.rs
+++ b/src/types/jsonrpc/response.rs
@@ -49,7 +49,7 @@ pub enum Response {
 
 impl fmt::Display for Response {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}", super::to_string(self).expect("Response valid JSON; qed"))
+		write!(f, "{}", serde_json::to_string(self).expect("Response valid JSON; qed"))
 	}
 }
 

--- a/src/types/jsonrpc/response.rs
+++ b/src/types/jsonrpc/response.rs
@@ -199,8 +199,8 @@ impl SubscriptionId {
 
 #[cfg(test)]
 mod tests {
+	use super::{Error, Failure, Id, Output, Response, Success, Version};
 	use serde_json::Value;
-	use super::{Version, Id, Response, Error, Failure, Output, Success};
 
 	#[test]
 	fn success_output_serialize() {

--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -414,7 +414,7 @@ async fn background_task(mut server: RawServer, mut from_front: mpsc::UnboundedR
 				}
 			}
 			Either::Right(RawServerEvent::Notification(notification)) => {
-				log::debug!("[backend]: received notification: {:?}", notification);
+				log::trace!("[backend]: received notification: {:?}", notification);
 				if let Some((handler, allow_losses)) = registered_notifications.get_mut(notification.method()) {
 					let params: &jsonrpc::Params = notification.params().into();
 					// Note: we just ignore errors. It doesn't make sense logically speaking to


### PR DESCRIPTION
The reasoning why to implement `Display` for Request and Response is to avoid repeating evertime we want to log something in human-readable format.

Instead of doing `log::debug!("recv: {}", jsonrpc::to_string(&req).expect("request valid JSON; qed"));` as it was done perfomed this PR.

Unrelated, I removed some unused code