### PR TITLE
fix build: downgrade `hashbrown 0.9`

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-hashbrown = "0.10"
+hashbrown = "0.9"
 fnv = "1.0"
 futures = "0.3"
 thiserror = "1.0"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -11,7 +11,7 @@ async-std = { version = "1.8.0", features = ["attributes"] }
 bs58 = "0.4"
 fnv = "1"
 futures = "0.3"
-hashbrown = "0.10"
+hashbrown = "0.9"
 jsonrpsee-types = { path = "../types", version = "0.1" }
 log = "0.4"
 parking_lot = "0.11"


### PR DESCRIPTION
The build failed https://github.com/paritytech/jsonrpsee/actions/runs/501198632 because hashbrown 0.10 has been yanked, https://crates.io/crates/hashbrown/0.10.0.

This PR reverts https://github.com/paritytech/jsonrpsee/pull/185