### PR TITLE
fix: include `examples` in the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+	"examples",
 	"benches",
 	"http-client",
 	"http-server",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "jsonrpsee-examples"
+version = "0.1.0"
+authors = ["Niklas Adolfsson <niklasadolfsson1@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-std = "1.9"
+env_logger = "0.8"
+futures = "0.3"
+log = "0.4"
+jsonrpsee-types = { path = "../types", version = "0.1" }
+jsonrpsee-http-client = { path = "../http-client", version = "0.1" }
+jsonrpsee-ws-client = { path = "../ws-client", version = "0.1" }
+jsonrpsee-ws-server = { path = "../ws-server", version = "0.1" }
+jsonrpsee-http-server = { path = "../http-server", version = "0.1" }
+tokio = { version = "1", features = ["full"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "jsonrpsee-examples"
 version = "0.1.0"
-authors = ["Niklas Adolfsson <niklasadolfsson1@gmail.com>"]
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Examples for jsonrpsee"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -26,9 +26,9 @@
 
 use async_std::task;
 use futures::channel::oneshot::{self, Sender};
-use jsonrpsee::client::{HttpClient, HttpConfig};
-use jsonrpsee::http::HttpServer;
-use jsonrpsee::types::jsonrpc::{JsonValue, Params};
+use jsonrpsee_http_client::{HttpClient, HttpConfig};
+use jsonrpsee_http_server::HttpServer;
+use jsonrpsee_types::jsonrpc::{JsonValue, Params};
 
 const SOCK_ADDR: &str = "127.0.0.1:9933";
 const SERVER_URI: &str = "http://localhost:9933";

--- a/examples/examples/ws.rs
+++ b/examples/examples/ws.rs
@@ -26,9 +26,9 @@
 
 use async_std::task;
 use futures::channel::oneshot::{self, Sender};
-use jsonrpsee::client::{WsClient, WsConfig};
-use jsonrpsee::types::jsonrpc::{JsonValue, Params};
-use jsonrpsee::ws::WsServer;
+use jsonrpsee_types::jsonrpc::{JsonValue, Params};
+use jsonrpsee_ws_client::{WsClient, WsConfig};
+use jsonrpsee_ws_server::WsServer;
 
 const SOCK_ADDR: &str = "127.0.0.1:9944";
 const SERVER_URI: &str = "ws://localhost:9944";

--- a/examples/examples/ws_subscription.rs
+++ b/examples/examples/ws_subscription.rs
@@ -26,9 +26,9 @@
 
 use async_std::task;
 use futures::channel::oneshot::{self, Sender};
-use jsonrpsee::client::{WsClient, WsConfig, WsSubscription};
-use jsonrpsee::types::jsonrpc::{JsonValue, Params};
-use jsonrpsee::ws::WsServer;
+use jsonrpsee_types::jsonrpc::{JsonValue, Params};
+use jsonrpsee_ws_client::{WsClient, WsConfig, WsSubscription};
+use jsonrpsee_ws_server::WsServer;
 
 const SOCK_ADDR: &str = "127.0.0.1:9966";
 const SERVER_URI: &str = "ws://localhost:9966";


### PR DESCRIPTION
As we merged `v2` to `master` the `examples` were part of any crate and didn't work.

So this fixes that.

Thus, `cargo run --example <example>` will work after this commit.