### PR TITLE
feat(http client): support tokio02 via hyper 0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,17 +64,17 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Cargo check no-default-features
+      - name: Cargo check all targets
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --benches --tests
+          args: --all-targets
 
-      - name: Cargo check all-features
+      - name: Cargo check HTTP client with tokio02
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --benches --tests --all-features
+          args: --manifest-path http-client/Cargo.toml --no-default-features --features tokio02
 
   tests:
     name: Run tests

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -21,8 +21,8 @@ url = "2.2"
 
 [features]
 default = ["tokio1"]
-tokio1 = ["hyper14", "jsonrpsee-utils/tokio1"]
-tokio02 = ["hyper13", "jsonrpsee-utils/tokio02"]
+tokio1 = ["hyper14", "jsonrpsee-utils/hyper14"]
+tokio02 = ["hyper13", "jsonrpsee-utils/hyper13"]
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 futures = "0.3"
-hyper14 = { package = "hyper", version = "0.14", features = ["stream", "client", "server", "http1", "http2", "tcp"], optional = true }
+hyper14 = { package = "hyper", version = "0.14", features = ["client", "http1", "http2", "tcp"], optional = true }
 hyper13 = { package = "hyper", version = "0.13", optional = true }
 jsonrpsee-types = { path = "../types", version = "0.1" }
 jsonrpsee-utils = { path = "../utils", version = "0.1", default-features = false, optional = true }

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -8,15 +8,21 @@ license = "MIT"
 
 [dependencies]
 futures = "0.3"
-hyper = { version = "0.14", features = ["stream", "client", "server", "http1", "http2", "tcp"] }
+hyper14 = { package = "hyper", version = "0.14", features = ["stream", "client", "server", "http1", "http2", "tcp"], optional = true }
+hyper13 = { package = "hyper", version = "0.13", optional = true }
 jsonrpsee-types = { path = "../types", version = "0.1" }
-jsonrpsee-utils = { path = "../utils", version = "0.1" }
+jsonrpsee-utils = { path = "../utils", version = "0.1", default-features = false, optional = true }
 log = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 unicase = "2.6"
 url = "2.2"
+
+[features]
+default = ["tokio1"]
+tokio1 = ["hyper14", "jsonrpsee-utils/tokio1"]
+tokio02 = ["hyper13", "jsonrpsee-utils/tokio02"]
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }

--- a/http-client/src/lib.rs
+++ b/http-client/src/lib.rs
@@ -1,3 +1,12 @@
+#[cfg(not(any(feature = "tokio1", feature = "tokio02")))]
+compile_error!("Either feature \"tokio1\" or \"tokio02\" must be enabled for this crate.");
+
+#[cfg(feature = "tokio1")]
+extern crate hyper14 as hyper;
+
+#[cfg(feature = "tokio02")]
+extern crate hyper13 as hyper;
+
 mod client;
 mod transport;
 

--- a/http-client/src/lib.rs
+++ b/http-client/src/lib.rs
@@ -1,8 +1,8 @@
 #[cfg(all(feature = "tokio1", feature = "tokio02"))]
-compile_error!("feature \"tokio1\" and \"tokio02\" are mutably exclusive");
+compile_error!("feature `tokio1` and `tokio02` are mutably exclusive");
 
 #[cfg(not(any(feature = "tokio1", feature = "tokio02")))]
-compile_error!("feature \"tokio1\" or \"tokio02\" must be enabled for this crate");
+compile_error!("feature `tokio1` or `tokio02` must be enabled for this crate");
 
 #[cfg(all(feature = "tokio1", not(feature = "tokio02")))]
 extern crate hyper14 as hyper;

--- a/http-client/src/lib.rs
+++ b/http-client/src/lib.rs
@@ -1,10 +1,13 @@
-#[cfg(not(any(feature = "tokio1", feature = "tokio02")))]
-compile_error!("Either feature \"tokio1\" or \"tokio02\" must be enabled for this crate.");
+#[cfg(all(feature = "tokio1", feature = "tokio02"))]
+compile_error!("feature \"tokio1\" and \"tokio02\" are mutably exclusive");
 
-#[cfg(feature = "tokio1")]
+#[cfg(not(any(feature = "tokio1", feature = "tokio02")))]
+compile_error!("feature \"tokio1\" or \"tokio02\" must be enabled for this crate");
+
+#[cfg(all(feature = "tokio1", not(feature = "tokio02")))]
 extern crate hyper14 as hyper;
 
-#[cfg(feature = "tokio02")]
+#[cfg(all(feature = "tokio02", not(feature = "tokio1")))]
 extern crate hyper13 as hyper;
 
 mod client;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,11 +9,17 @@ license = "MIT"
 [dependencies]
 futures = "0.3"
 globset = "0.4"
-hyper = { version = "0.14", features = ["stream"] }
+hyper13 = { package = "hyper", version = "0.13", default-features = false, features = ["stream"], optional = true }
+hyper14 = { package = "hyper", version = "0.14", default-features = false, features = ["stream"], optional = true }
 jsonrpsee-types = { path = "../types", version = "0.1" }
 lazy_static = "1.4"
 log = "0.4"
 unicase = "2.6"
+
+[features]
+default = ["tokio1"]
+tokio1 = ["hyper14"]
+tokio02 = ["hyper13"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,9 +17,7 @@ log = "0.4"
 unicase = "2.6"
 
 [features]
-default = ["tokio1"]
-tokio1 = ["hyper14"]
-tokio02 = ["hyper13"]
+default = ["hyper14"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/utils/src/http/access_control.rs
+++ b/utils/src/http/access_control.rs
@@ -29,7 +29,7 @@
 use crate::http::cors::{AccessControlAllowHeaders, AccessControlAllowOrigin};
 use crate::http::hosts::{AllowHosts, Host};
 use crate::http::{cors, hosts, hyper_helpers};
-use hyper::{self, header};
+use hyper::header;
 
 /// Define access on control on http layer
 #[derive(Clone)]

--- a/utils/src/http/mod.rs
+++ b/utils/src/http/mod.rs
@@ -26,10 +26,13 @@
 
 //! HTTP Server utilities for the `jsonrpsee` library
 
+#[cfg(any(feature = "tokio1", feature = "tokio02"))]
 pub mod access_control;
+#[cfg(any(feature = "tokio1", feature = "tokio02"))]
+pub mod hyper_helpers;
+
 pub mod cors;
 pub mod hosts;
-pub mod hyper_helpers;
 
 mod matcher;
 

--- a/utils/src/http/mod.rs
+++ b/utils/src/http/mod.rs
@@ -26,13 +26,10 @@
 
 //! HTTP Server utilities for the `jsonrpsee` library
 
-#[cfg(any(feature = "tokio1", feature = "tokio02"))]
 pub mod access_control;
-#[cfg(any(feature = "tokio1", feature = "tokio02"))]
-pub mod hyper_helpers;
-
 pub mod cors;
 pub mod hosts;
+pub mod hyper_helpers;
 
 mod matcher;
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,1 +1,10 @@
+#[cfg(all(feature = "tokio1", feature = "tokio02"))]
+compile_error!("feature \"tokio1\" and \"tokio02\" are mutably exclusive");
+
+#[cfg(feature = "hyper13")]
+extern crate hyper13 as hyper;
+
+#[cfg(feature = "hyper14")]
+extern crate hyper14 as hyper;
+
 pub mod http;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,10 +1,13 @@
-#[cfg(all(feature = "tokio1", feature = "tokio02"))]
-compile_error!("feature \"tokio1\" and \"tokio02\" are mutably exclusive");
+#[cfg(all(feature = "hyper13", feature = "hyper14"))]
+compile_error!("feature \"hyper13\" and \"hyper14\" are mutably exclusive");
 
-#[cfg(feature = "hyper13")]
+#[cfg(not(any(feature = "hyper13", feature = "hyper14")))]
+compile_error!("feature \"hyper13\" or \"hyper14\" must be enabled for this crate");
+
+#[cfg(all(feature = "hyper13", not(feature = "hyper14")))]
 extern crate hyper13 as hyper;
 
-#[cfg(feature = "hyper14")]
+#[cfg(all(feature = "hyper14", not(feature = "hyper13")))]
 extern crate hyper14 as hyper;
 
 pub mod http;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,8 +1,8 @@
 #[cfg(all(feature = "hyper13", feature = "hyper14"))]
-compile_error!("feature \"hyper13\" and \"hyper14\" are mutably exclusive");
+compile_error!("feature `hyper13` and `hyper14` are mutably exclusive");
 
 #[cfg(not(any(feature = "hyper13", feature = "hyper14")))]
-compile_error!("feature \"hyper13\" or \"hyper14\" must be enabled for this crate");
+compile_error!("feature `hyper13` or `hyper14` must be enabled for this crate");
 
 #[cfg(all(feature = "hyper13", not(feature = "hyper14")))]
 extern crate hyper13 as hyper;


### PR DESCRIPTION
Conditional compilation mess to support `tokio 0.2` and `tokio 1.0` via feature flags,  closes #200.
Tested successfully locally, but I don't prefer to port all tests for both runtimes.

FYI, `hyper` doesn't support `tokio 0.3` that's why it's not supported and  `tokio 0.1` doesn't support `async await` which doesn't make sense for this library.   