### PR TITLE
[http client]: support HTTPS

### DIFF
--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
+anyhow = "1.0"
 futures = "0.3"
 surf = { version = "2.1", default-features = false, optional = true }
 jsonrpsee-types = { path = "../types", version = "0.1" }


### PR DESCRIPTION
Closes #189, `HTTPS` is supported by surf which makes this quite simple to implement. The bad thing is that users can't disable it.

I found a faulty unwrap where we should return an error instead, which this PR fixes too but [surf::Error](https://github.com/http-rs/http-types/issues/88) doesn't implement `std::errror::Error`.Thus, I decided to switch to `anyhow` instead `Box<dyn std::error::Error + Send + Sync>`
