### PR TITLE
[tests]: fix buffer deadlock bug

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -193,7 +193,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 	let server_url = format!("ws://{}", server_addr);
 
 	let mut config = WsConfig::with_url(&server_url);
-	config.max_request_channel_capacity = 2;
+	config.max_concurrent_requests_capacity = 2;
 	let client = WsClient::new(config).await.unwrap();
 
 	let mut requests = Vec::new();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -193,7 +193,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 	let server_url = format!("ws://{}", server_addr);
 
 	let mut config = WsConfig::with_url(&server_url);
-	config.request_channel_capacity = 2;
+	config.max_request_channel_capacity = 2;
 	let client = WsClient::new(config).await.unwrap();
 
 	let mut requests = Vec::new();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -193,7 +193,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 	let server_url = format!("ws://{}", server_addr);
 
 	let mut config = WsConfig::with_url(&server_url);
-	config.max_subscription_capacity = 2;
+	config.request_channel_capacity = 2;
 	let client = WsClient::new(config).await.unwrap();
 
 	let mut requests = Vec::new();


### PR DESCRIPTION
Fix a bad merge that changed to `request_channel_capacity` to `subscription_channel_capacity`

https://github.com/paritytech/jsonrpsee/commit/7dc9435e225bcc1887a2532e830266d7b1ecd0af#diff-aeefe6b3d3f8b1b5248d6bb4c2888cf2d6802dbf82515f7b02b6a89a1400228fL188