### PR TITLE
RpcModule and RpcContextModule

### DIFF
--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -45,6 +45,9 @@ pub enum Error {
 	/// Method was already registered.
 	#[error("Method: {0} was already registered")]
 	MethodAlreadyRegistered(String),
+	/// Subscribe and unsubscribe method names are the same.
+	#[error("Cannot use the same method name for subcribe and unsubscribe, used: {0}")]
+	SubscriptionNameConflict(String),
 	/// Websocket request timeout
 	#[error("Websocket request timeout")]
 	WsRequestTimeout,

--- a/ws-server/src/lib.rs
+++ b/ws-server/src/lib.rs
@@ -32,4 +32,4 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-pub use server::{Server as WsServer, SubscriptionSink};
+pub use server::{RpcContextModule, RpcModule, Server as WsServer, SubscriptionSink};

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -41,7 +41,7 @@ use tokio::{
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
-use crate::types::{ConnectionId, RpcSender, RpcId, RpcMethod, Methods};
+use crate::types::{ConnectionId, Methods, RpcId, RpcMethod, RpcSender};
 use crate::types::{JsonRpcError, JsonRpcErrorParams};
 use crate::types::{JsonRpcInvalidRequest, JsonRpcRequest, JsonRpcResponse, TwoPointZero};
 use crate::types::{JsonRpcNotification, JsonRpcNotificationParams};

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -48,7 +48,7 @@ use crate::types::{JsonRpcNotification, JsonRpcNotificationParams};
 
 mod module;
 
-pub use module::Module;
+pub use module::RpcModule;
 
 type SubscriptionId = u64;
 
@@ -164,7 +164,7 @@ fn send_error(id: RpcId, tx: RpcSender, code: i32, message: &str) {
 }
 
 pub struct Server {
-	root: Module,
+	root: RpcModule,
 	listener: TcpListener,
 }
 
@@ -173,7 +173,7 @@ impl Server {
 	pub async fn new(addr: impl ToSocketAddrs) -> anyhow::Result<Self> {
 		let listener = TcpListener::bind(addr).await?;
 
-		Ok(Server { listener, root: Module::new() })
+		Ok(Server { listener, root: RpcModule::new() })
 	}
 
 	/// Register a new RPC method, which responds with a given callback.
@@ -195,7 +195,7 @@ impl Server {
 	}
 
 	/// Register all methods from a module on this server.
-	pub fn register_module(&mut self, module: Module) -> Result<(), Error> {
+	pub fn register_module(&mut self, module: RpcModule) -> Result<(), Error> {
 		self.root.merge(module)
 	}
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -41,7 +41,7 @@ use tokio::{
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
-use crate::types::{ConnectionId, Methods, RpcId, RpcMethod, RpcSender};
+use crate::types::{ConnectionId, Methods, RpcId, RpcSender};
 use crate::types::{JsonRpcError, JsonRpcErrorParams};
 use crate::types::{JsonRpcInvalidRequest, JsonRpcRequest, JsonRpcResponse, TwoPointZero};
 use crate::types::{JsonRpcNotification, JsonRpcNotificationParams};
@@ -207,7 +207,7 @@ impl Server {
 	/// Start responding to connections requests. This will block current thread until the server is stopped.
 	pub async fn start(self) {
 		let mut incoming = TcpListenerStream::new(self.listener);
-		let methods = Arc::new(self.root.into_map());
+		let methods = Arc::new(self.root.into_methods());
 		let mut id = 0;
 
 		while let Some(socket) = incoming.next().await {

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -48,7 +48,7 @@ use crate::types::{JsonRpcNotification, JsonRpcNotificationParams};
 
 mod module;
 
-pub use module::RpcModule;
+pub use module::{RpcContextModule, RpcModule};
 
 type SubscriptionId = u64;
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -41,22 +41,16 @@ use tokio::{
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
+use crate::types::{ConnectionId, RpcSender, RpcId, RpcMethod, Methods};
 use crate::types::{JsonRpcError, JsonRpcErrorParams};
 use crate::types::{JsonRpcInvalidRequest, JsonRpcRequest, JsonRpcResponse, TwoPointZero};
 use crate::types::{JsonRpcNotification, JsonRpcNotificationParams};
 
-type ConnectionId = usize;
+mod module;
+
+pub use module::Module;
+
 type SubscriptionId = u64;
-
-type RpcSender<'a> = &'a mpsc::UnboundedSender<String>;
-type RpcId<'a> = Option<&'a RawValue>;
-type Method = Box<dyn Send + Sync + Fn(RpcId, RpcParams, RpcSender, ConnectionId) -> anyhow::Result<()>>;
-type Methods = FxHashMap<&'static str, Method>;
-
-pub struct Server {
-	methods: Methods,
-	listener: TcpListener,
-}
 
 trait RpcResult {
 	fn to_json(self, id: Option<&RawValue>) -> anyhow::Result<String>;
@@ -68,6 +62,31 @@ pub enum RpcError {
 	Unknown,
 	#[error("invalid params")]
 	InvalidParams,
+}
+
+/// Parameters sent with the RPC request
+#[derive(Clone, Copy)]
+pub struct RpcParams<'a>(Option<&'a str>);
+
+impl<'a> RpcParams<'a> {
+	/// Attempt to parse all parameters as array or map into type T
+	pub fn parse<T>(self) -> Result<T, RpcError>
+	where
+		T: Deserialize<'a>,
+	{
+		match self.0 {
+			None => Err(RpcError::InvalidParams),
+			Some(params) => serde_json::from_str(params).map_err(|_| RpcError::InvalidParams),
+		}
+	}
+
+	/// Attempt to parse only the first parameter from an array into type T
+	pub fn one<T>(self) -> Result<T, RpcError>
+	where
+		T: Deserialize<'a>,
+	{
+		self.parse::<[T; 1]>().map(|[res]| res)
+	}
 }
 
 #[derive(Clone)]
@@ -108,31 +127,6 @@ impl SubscriptionSink {
 	}
 }
 
-/// Parameters sent with the RPC request
-#[derive(Clone, Copy)]
-pub struct RpcParams<'a>(Option<&'a str>);
-
-impl<'a> RpcParams<'a> {
-	/// Attempt to parse all parameters as array or map into type T
-	pub fn parse<T>(self) -> Result<T, RpcError>
-	where
-		T: Deserialize<'a>,
-	{
-		match self.0 {
-			None => Err(RpcError::InvalidParams),
-			Some(params) => serde_json::from_str(params).map_err(|_| RpcError::InvalidParams),
-		}
-	}
-
-	/// Attempt to parse only the first parameter from an array into type T
-	pub fn one<T>(self) -> Result<T, RpcError>
-	where
-		T: Deserialize<'a>,
-	{
-		self.parse::<[T; 1]>().map(|[res]| res)
-	}
-}
-
 // Private helper for sending JSON-RPC responses to the client
 fn send_response(id: RpcId, tx: RpcSender, result: impl Serialize) {
 	let json = match serde_json::to_string(&JsonRpcResponse { jsonrpc: TwoPointZero, id, result }) {
@@ -169,22 +163,17 @@ fn send_error(id: RpcId, tx: RpcSender, code: i32, message: &str) {
 	}
 }
 
+pub struct Server {
+	root: Module,
+	listener: TcpListener,
+}
+
 impl Server {
-	/// Create a new WebSocket RPC server, bound to the `addr`
+	/// Create a new WebSocket RPC server, bound to the `addr`.
 	pub async fn new(addr: impl ToSocketAddrs) -> anyhow::Result<Self> {
 		let listener = TcpListener::bind(addr).await?;
 
-		Ok(Server { listener, methods: Default::default() })
-	}
-
-	fn insert_method(&mut self, name: &'static str, method: Method) -> Result<(), Error> {
-		if self.methods.get(name).is_some() {
-			return Err(Error::MethodAlreadyRegistered(name.into()));
-		}
-
-		self.methods.insert(name, method);
-
-		Ok(())
+		Ok(Server { listener, root: Module::new() })
 	}
 
 	/// Register a new RPC method, which responds with a given callback.
@@ -193,16 +182,7 @@ impl Server {
 		R: Serialize,
 		F: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static,
 	{
-		self.insert_method(
-			method_name,
-			Box::new(move |id, params, tx, _| {
-				let result = callback(params)?;
-
-				send_response(id, tx, result);
-
-				Ok(())
-			}),
-		)
+		self.root.register_method(method_name, callback)
 	}
 
 	/// Register a new RPC subscription, with subscribe and unsubscribe methods.
@@ -211,59 +191,15 @@ impl Server {
 		subscribe_method_name: &'static str,
 		unsubscribe_method_name: &'static str,
 	) -> Result<SubscriptionSink, Error> {
-		let subscribers = Arc::new(Mutex::new(FxHashMap::default()));
-
-		{
-			let subscribers = subscribers.clone();
-			self.insert_method(
-				subscribe_method_name,
-				Box::new(move |id, _, tx, conn| {
-					let sub_id = {
-						const JS_NUM_MASK: SubscriptionId = !0 >> 11;
-
-						let sub_id = rand::random::<SubscriptionId>() & JS_NUM_MASK;
-
-						subscribers.lock().insert((conn, sub_id), tx.clone());
-
-						sub_id
-					};
-
-					send_response(id, tx, sub_id);
-
-					Ok(())
-				}),
-			)?;
-		}
-
-		{
-			let subscribers = subscribers.clone();
-			let result = self.insert_method(
-				unsubscribe_method_name,
-				Box::new(move |id, params, tx, conn| {
-					let sub_id = params.one()?;
-
-					subscribers.lock().remove(&(conn, sub_id));
-
-					send_response(id, tx, "Unsubscribed");
-
-					Ok(())
-				}),
-			);
-
-			match result {
-				Ok(()) => (),
-				Err(err) => {
-					// Remove subscribe method if unsubscribe has failed
-					self.methods.remove(subscribe_method_name);
-					return Err(err);
-				}
-			}
-		}
-
-		Ok(SubscriptionSink { method: subscribe_method_name, subscribers })
+		self.root.register_subscription(subscribe_method_name, unsubscribe_method_name)
 	}
 
-	/// Returns socket address to which the server is bound
+	/// Register all methods from a module on this server.
+	pub fn register_module(&mut self, module: Module) -> Result<(), Error> {
+		self.root.merge(module)
+	}
+
+	/// Returns socket address to which the server is bound.
 	pub fn local_addr(&self) -> anyhow::Result<SocketAddr> {
 		self.listener.local_addr().map_err(Into::into)
 	}
@@ -271,7 +207,7 @@ impl Server {
 	/// Start responding to connections requests. This will block current thread until the server is stopped.
 	pub async fn start(self) {
 		let mut incoming = TcpListenerStream::new(self.listener);
-		let methods = Arc::new(self.methods);
+		let methods = Arc::new(self.root.into_map());
 		let mut id = 0;
 
 		while let Some(socket) = incoming.next().await {

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -7,17 +7,12 @@ pub struct RpcModule {
 impl RpcModule {
 	/// Instantiate a new `RpcModule`.
 	pub fn new() -> Self {
-		RpcModule {
-			methods: Methods::default()
-		}
+		RpcModule { methods: Methods::default() }
 	}
 
 	/// Add context for this module, turning it into an `RpcContextModule`.
 	pub fn with_context<Context>(self, ctx: Context) -> RpcContextModule<Context> {
-		RpcContextModule {
-			ctx: Arc::new(ctx),
-			module: self,
-		}
+		RpcContextModule { ctx: Arc::new(ctx), module: self }
 	}
 
 	fn verify_method_name(&mut self, name: &str) -> Result<(), Error> {
@@ -131,10 +126,7 @@ pub struct RpcContextModule<Context> {
 impl<Context> RpcContextModule<Context> {
 	/// Create a new module with a given shared `Context`.
 	pub fn new(ctx: Context) -> Self {
-		RpcContextModule {
-			ctx: Arc::new(ctx),
-			module: RpcModule::new(),
-		}
+		RpcContextModule { ctx: Arc::new(ctx), module: RpcModule::new() }
 	}
 
 	/// Register a new RPC method, which responds with a given callback.

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+pub struct Module {
+	methods: Methods,
+}
+
+impl Module {
+	pub fn new() -> Self {
+		Module {
+			methods: Methods::default()
+		}
+	}
+
+	fn verify_method_name(&mut self, name: &'static str) -> Result<(), Error> {
+		if self.methods.get(name).is_some() {
+			return Err(Error::MethodAlreadyRegistered(name.into()));
+		}
+
+		Ok(())
+	}
+
+	/// Register a new RPC method, which responds with a given callback.
+	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
+	where
+		R: Serialize,
+		F: RpcMethod<R>,
+	{
+		self.verify_method_name(method_name)?;
+
+		self.methods.insert(
+			method_name,
+			Box::new(move |id, params, tx, _| {
+				let result = callback(params)?;
+
+				send_response(id, tx, result);
+
+				Ok(())
+			}),
+		);
+
+		Ok(())
+	}
+
+	/// Register a new RPC subscription, with subscribe and unsubscribe methods.
+	pub fn register_subscription(
+		&mut self,
+		subscribe_method_name: &'static str,
+		unsubscribe_method_name: &'static str,
+	) -> Result<SubscriptionSink, Error> {
+		if subscribe_method_name == unsubscribe_method_name {
+			return Err(Error::MethodAlreadyRegistered(subscribe_method_name.into()));
+		}
+
+		self.verify_method_name(subscribe_method_name)?;
+		self.verify_method_name(unsubscribe_method_name)?;
+
+		let subscribers = Arc::new(Mutex::new(FxHashMap::default()));
+
+		{
+			let subscribers = subscribers.clone();
+			self.methods.insert(
+				subscribe_method_name,
+				Box::new(move |id, _, tx, conn| {
+					let sub_id = {
+						const JS_NUM_MASK: SubscriptionId = !0 >> 11;
+
+						let sub_id = rand::random::<SubscriptionId>() & JS_NUM_MASK;
+
+						subscribers.lock().insert((conn, sub_id), tx.clone());
+
+						sub_id
+					};
+
+					send_response(id, tx, sub_id);
+
+					Ok(())
+				}),
+			);
+		}
+
+		{
+			let subscribers = subscribers.clone();
+			self.methods.insert(
+				unsubscribe_method_name,
+				Box::new(move |id, params, tx, conn| {
+					let sub_id = params.one()?;
+
+					subscribers.lock().remove(&(conn, sub_id));
+
+					send_response(id, tx, "Unsubscribed");
+
+					Ok(())
+				}),
+			);
+		}
+
+		Ok(SubscriptionSink { method: subscribe_method_name, subscribers })
+	}
+
+	pub(crate) fn into_map(self) -> Methods {
+		self.methods
+	}
+
+	pub(crate) fn merge(&mut self, other: Module) -> Result<(), Error> {
+		for name in other.methods.keys() {
+			self.verify_method_name(name)?;
+		}
+
+		for (name, callback) in other.methods {
+			self.methods.insert(name, callback);
+		}
+
+		Ok(())
+	}
+}

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -1,4 +1,10 @@
-use super::*;
+use crate::server::{send_response, Methods, RpcError, RpcParams, SubscriptionId, SubscriptionSink};
+use crate::types::RpcMethod;
+use jsonrpsee_types::error::Error;
+use parking_lot::Mutex;
+use rustc_hash::FxHashMap;
+use serde::Serialize;
+use std::sync::Arc;
 
 #[derive(Default)]
 pub struct RpcModule {
@@ -53,7 +59,7 @@ impl RpcModule {
 		unsubscribe_method_name: &'static str,
 	) -> Result<SubscriptionSink, Error> {
 		if subscribe_method_name == unsubscribe_method_name {
-			return Err(Error::MethodAlreadyRegistered(subscribe_method_name.into()));
+			return Err(Error::SubscriptionNameConflict(subscribe_method_name.into()));
 		}
 
 		self.verify_method_name(subscribe_method_name)?;
@@ -102,7 +108,7 @@ impl RpcModule {
 		Ok(SubscriptionSink { method: subscribe_method_name, subscribers })
 	}
 
-	pub(crate) fn into_map(self) -> Methods {
+	pub(crate) fn into_methods(self) -> Methods {
 		self.methods
 	}
 

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Default)]
 pub struct RpcModule {
 	methods: Methods,
 }

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -125,7 +125,7 @@ async fn register_same_subscribe_unsubscribe_is_err() {
 	let mut server = WsServer::new("127.0.0.1:0").await.unwrap();
 	assert!(matches!(
 		server.register_subscription("subscribe_hello", "subscribe_hello"),
-		Err(Error::MethodAlreadyRegistered(_))
+		Err(Error::SubscriptionNameConflict(_))
 	));
 }
 

--- a/ws-server/src/types.rs
+++ b/ws-server/src/types.rs
@@ -4,6 +4,19 @@ use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use std::fmt;
+use tokio::sync::mpsc;
+use rustc_hash::FxHashMap;
+use crate::server::{RpcParams, RpcError};
+
+pub type ConnectionId = usize;
+pub type RpcSender<'a> = &'a mpsc::UnboundedSender<String>;
+pub type RpcId<'a> = Option<&'a RawValue>;
+pub type Method = Box<dyn Send + Sync + Fn(RpcId, RpcParams, RpcSender, ConnectionId) -> anyhow::Result<()>>;
+pub type Methods = FxHashMap<&'static str, Method>;
+
+pub trait RpcMethod<R>: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static {}
+
+impl<R, T> RpcMethod<R> for T where T: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static {}
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]

--- a/ws-server/src/types.rs
+++ b/ws-server/src/types.rs
@@ -1,12 +1,12 @@
+use crate::server::{RpcError, RpcParams};
 use beef::lean::Cow;
+use rustc_hash::FxHashMap;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use std::fmt;
 use tokio::sync::mpsc;
-use rustc_hash::FxHashMap;
-use crate::server::{RpcParams, RpcError};
 
 pub type ConnectionId = usize;
 pub type RpcSender<'a> = &'a mpsc::UnboundedSender<String>;


### PR DESCRIPTION
This PR adds module functionality to the ws-server (although it should be fairly easy to make it general use for either ws and http).

Modules are equivalent to `IoHandler` while `Context` in `RpcContextModule` is equivalent to `Metadata` in `jsonrpc-core`, with the major difference here is that `RpcModule` is a concrete type without any generics, and `RpcContextModule` can be converted to `RpcModule` once all methods that need the extra context are defined.

I expect to do changes as I run into unexpected issues when migrating RPC layer in Substrate, so I would consider the API to be wildly unstable at this point.