### PR TITLE
[proc macros]: fix wrong compile warnings.

### DIFF
--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -160,7 +160,7 @@ fn build_client_api(api: api_def::ApiDefinition) -> Result<proc_macro2::TokenStr
 
 	Ok(quote_spanned!(api.name.span()=>
 		#visibility enum #enum_name #generics {
-			 #(#variants,)* #(#[allow(unused)] #ret_variants,)*
+			 #(#[allow(unused)] #variants,)* #(#[allow(unused)] #ret_variants,)*
 		}
 
 		#client_impl_block


### PR DESCRIPTION
The generated enum variants is hack to bound the type params to the enum itself.
Thus, the enum patterns are never used and will always generated warnings so
this commit adds `unused` on all the variants.

Closing #106 

Example:

```rust
jsonrpsee_proc_macros::rpc_client_api! {
	RpcApi {
		#[rpc(method = "state_getPairs")]
		fn storage_pairs(prefix: StorageKey, hash: Option<Hash>) -> Vec<(StorageKey, StorageData)>;
		#[rpc(method = "chain_getFinalizedHead")]
		fn finalized_head() -> Hash;
	}
}
```

Expands to:

```rust
enum RpcApi {
    StoragePairs {
        prefix: StorageKey,
        hash: Option<Hash>,
    },
    FinalizedHead {},
    #[allow(unused)]
    _0(Vec<(StorageKey, StorageData)>),
    #[allow(unused)]
    _1(Hash),
}
impl RpcApi {
    async fn storage_pairs(
        client: &impl jsonrpsee_types::traits::Client,
        param0: impl Into<StorageKey>,
        param1: impl Into<Option<Hash>>,
    ) -> core::result::Result<Vec<(StorageKey, StorageData)>, jsonrpsee_types::error::Error>
    where
        Vec<(StorageKey, StorageData)>: jsonrpsee_types::jsonrpc::DeserializeOwned,
        StorageKey: jsonrpsee_types::jsonrpc::Serialize,
        Option<Hash>: jsonrpsee_types::jsonrpc::Serialize,
    {
        client
            .request(
                "state_getPairs",
                jsonrpsee_types::jsonrpc::Params::Map({
                    let mut map = jsonrpsee_types::jsonrpc::JsonMap::with_capacity(2usize);
                    map.insert(
                        "prefix".to_string(),
                        jsonrpsee_types::jsonrpc::to_value(param0.into()).map_err(|e| {
                            jsonrpsee_types::error::Error::Custom({
                                let res = ::alloc::fmt::format(::core::fmt::Arguments::new_v1(
                                    &[""],
                                    &match (&e,) {
                                        (arg0,) => [::core::fmt::ArgumentV1::new(
                                            arg0,
                                            ::core::fmt::Debug::fmt,
                                        )],
                                    },
                                ));
                                res
                            })
                        })?,
                    );
                    map.insert(
                        "hash".to_string(),
                        jsonrpsee_types::jsonrpc::to_value(param1.into()).map_err(|e| {
                            jsonrpsee_types::error::Error::Custom({
                                let res = ::alloc::fmt::format(::core::fmt::Arguments::new_v1(
                                    &[""],
                                    &match (&e,) {
                                        (arg0,) => [::core::fmt::ArgumentV1::new(
                                            arg0,
                                            ::core::fmt::Debug::fmt,
                                        )],
                                    },
                                ));
                                res
                            })
                        })?,
                    );
                    map
                }),
            )
            .await
    }
    async fn finalized_head(
        client: &impl jsonrpsee_types::traits::Client,
    ) -> core::result::Result<Hash, jsonrpsee_types::error::Error>
    where
        Hash: jsonrpsee_types::jsonrpc::DeserializeOwned,
    {
        client
            .request(
                "chain_getFinalizedHead",
                jsonrpsee_types::jsonrpc::Params::None,
            )
            .await
    }
}
```


