### PR TITLE
fuse all streams to prevent panics on next_message, allow consumer to…

### DIFF
--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -3,13 +3,14 @@ use crate::jsonrpc::{self, DeserializeOwned, JsonValue, Params, SubscriptionId};
 use core::marker::PhantomData;
 use futures::channel::{mpsc, oneshot};
 use futures::prelude::*;
+use futures::stream::Fuse;
 
 /// Active subscription on a Client.
 pub struct Subscription<Notif> {
 	/// Channel to send requests to the background task.
 	pub to_back: mpsc::Sender<FrontToBack>,
 	/// Channel from which we receive notifications from the server, as encoded `JsonValue`s.
-	pub notifs_rx: mpsc::Receiver<JsonValue>,
+	pub notifs_rx: Fuse<mpsc::Receiver<JsonValue>>,
 	/// Subscription ID,
 	pub id: SubscriptionId,
 	/// Marker in order to pin the `Notif` parameter.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -51,6 +51,12 @@ pub enum Error {
 	/// Configured max number of request slots exceeded.
 	#[error("Configured max number of request slots exceeded")]
 	MaxSlotsExceeded,
+	/// Frontend dropped, terminate.
+	#[error("Frontend dropped, terminate")]
+	FrontendDropped,
+	/// Backend dropped, terminate.
+	#[error("Backend dropped, terminate")]
+	BackendDropped,
 	/// Custom error.
 	#[error("Custom error: {0}")]
 	Custom(String),


### PR DESCRIPTION
… run background as future

Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Further to the discussion in #236, this PR allows for the library consumer to reconnect by directly controlling the execution of the background thread. Furthermore, most streams are now fused to prevent panics.