### PR TITLE
[ws client]: unsubscribe direct when subscription is dropped.

### DIFF
--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -352,7 +352,7 @@ async fn background_task(
 				// the channel was full or disconnected.
 				if let Some(unsub_request) = manager
 					.get_request_id_by_subscription_id(&sub_id)
-					.and_then(|req_id| build_unsubscribe_request(&mut manager, req_id, sub_id))
+					.and_then(|req_id| build_unsubscribe_message(&mut manager, req_id, sub_id))
 				{
 					send_unsubscribe_request(&mut sender, &mut manager, unsub_request).await;
 				}
@@ -386,7 +386,7 @@ async fn background_task(
 					Some(send_back_sink) => {
 						if let Err(e) = send_back_sink.try_send(notif.params.result) {
 							log::error!("Dropping subscription {:?} error: {:?}", sub_id, e);
-							let unsub_req = build_unsubscribe_request(&mut manager, request_id, sub_id)
+							let unsub_req = build_unsubscribe_message(&mut manager, request_id, sub_id)
 								.expect("request ID and subscription ID valid checked above; qed");
 							send_unsubscribe_request(&mut sender, &mut manager, unsub_req).await;
 						}
@@ -446,7 +446,7 @@ fn process_response(
 				}
 			};
 
-			let sub_id: SubscriptionId = match jsonrpc::from_value(json_sub_id.clone()) {
+			let sub_id: SubscriptionId = match jsonrpc::from_value(json_sub_id) {
 				Ok(sub_id) => sub_id,
 				Err(_) => {
 					let _ = send_back_oneshot.send(Err(Error::InvalidSubscriptionId));
@@ -459,7 +459,7 @@ fn process_response(
 				match send_back_oneshot.send(Ok((subscribe_rx, sub_id.clone()))) {
 					Ok(_) => Ok(None),
 					Err(_) => {
-						let request = build_unsubscribe_request(manager, response_id, sub_id);
+						let request = build_unsubscribe_message(manager, response_id, sub_id);
 						Ok(request)
 					}
 				}
@@ -482,12 +482,12 @@ async fn send_unsubscribe_request(
 	}
 }
 
-fn build_unsubscribe_request(
+fn build_unsubscribe_message(
 	manager: &mut RequestManager,
 	req_id: u64,
 	sub_id: SubscriptionId,
 ) -> Option<RequestMessage> {
-	let (_, unsub) = manager.remove_subscription(req_id, sub_id.clone())?;
+	let (_, unsub, sub_id) = manager.remove_subscription(req_id, sub_id)?;
 	manager.reclaim_request_id(req_id);
 	let json_sub_id = jsonrpc::to_value(sub_id).expect("SubscriptionId to JSON is infallible; qed");
 	Some(RequestMessage { method: unsub, params: jsonrpc::Params::Array(vec![json_sub_id]), send_back: None })

--- a/ws-client/src/manager.rs
+++ b/ws-client/src/manager.rs
@@ -173,15 +173,15 @@ impl RequestManager {
 		&mut self,
 		request_id: RequestId,
 		subscription_id: SubscriptionId,
-	) -> Option<(SubscriptionSink, UnsubscribeMethod)> {
+	) -> Option<(SubscriptionSink, UnsubscribeMethod, SubscriptionId)> {
 		match (self.requests.entry(request_id), self.subscriptions.entry(subscription_id)) {
 			(Entry::Occupied(request), Entry::Occupied(subscription))
 				if matches!(request.get(), Kind::Subscription(_)) =>
 			{
 				let (_req_id, kind) = request.remove_entry();
-				let _sub_id = subscription.remove_entry();
-				if let Kind::Subscription(send_back) = kind {
-					Some(send_back)
+				let (sub_id, _req_id) = subscription.remove_entry();
+				if let Kind::Subscription((send_back, unsub)) = kind {
+					Some((send_back, unsub, sub_id))
 				} else {
 					unreachable!("Subscription is Subscription checked above; qed");
 				}


### PR DESCRIPTION
When a subscription is dropped because of `max_notifs_per_subscription` is exceeded
the client didn't send an `unsubscribe request` until the subscription was dropped which this commit fixes.

This causes the server to still send messages to the subscription and the client would get lots of
error messages: `InvalidRequestId` because it's not interested in the `subscription` anymore (removed from request manager)

