### PR TITLE
[http client]: request ID `Ordering::Relaxed`

### DIFF
--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -49,7 +49,7 @@ impl Client for HttpClient {
 		P: Into<jsonrpc::Params> + Send,
 	{
 		// NOTE: `fetch_add` wraps on overflow which is intended.
-		let id = self.request_id.fetch_add(1, Ordering::SeqCst);
+		let id = self.request_id.fetch_add(1, Ordering::Relaxed);
 		let request = jsonrpc::Request::Single(jsonrpc::Call::MethodCall(jsonrpc::MethodCall {
 			jsonrpc: jsonrpc::Version::V2,
 			method: method.into(),


### PR DESCRIPTION
Request ID is just a counter and doesn't require any synchronization besides an atomic value.

Fixes https://github.com/paritytech/jsonrpsee/pull/199#discussion_r575219903
