### PR TITLE
refactor: move `new jsonrpc types` to shared types

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -8,6 +8,11 @@ license = "MIT"
 
 [dependencies]
 async-trait = "0.1"
+anyhow = "1"
+# TODO: revisit whether to use `futures::channel` or `tokio::channel` here.
+tokio = { version = "1", features = ["sync"] }
+beef = "0.5"
+rustc-hash = "1"
 futures = "0.3"
 log = "0.4"
 thiserror = "1.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,5 +17,5 @@ futures = "0.3"
 log = "0.4"
 thiserror = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1", features = ["raw_value"] }
 smallvec = "1.0"

--- a/types/src/jsonrpc_v2/error.rs
+++ b/types/src/jsonrpc_v2/error.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+/// Error.
+#[derive(Error, Debug)]
+pub enum RpcError {
+	#[error("unknown rpc error")]
+	Unknown,
+	#[error("invalid params")]
+	InvalidParams,
+}

--- a/types/src/jsonrpc_v2/traits.rs
+++ b/types/src/jsonrpc_v2/traits.rs
@@ -1,0 +1,15 @@
+//! Module for shared traits in JSON-RPC related types.
+
+use super::error::RpcError;
+use super::RpcParams;
+use serde_json::value::RawValue;
+
+/// RPC Call.
+pub trait RpcMethod<R>: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static {}
+
+impl<R, T> RpcMethod<R> for T where T: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static {}
+
+/// RPC Call Result.
+trait RpcResult {
+	fn to_json(self, id: Option<&RawValue>) -> anyhow::Result<String>;
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -8,6 +8,9 @@ extern crate alloc;
 /// JSON-RPC 2.0 specification related types.
 pub mod jsonrpc;
 
+/// JSON-RPC 2.0 specification related types v2.
+pub mod jsonrpc_v2;
+
 /// Shared error type.
 pub mod error;
 

--- a/ws-server/src/lib.rs
+++ b/ws-server/src/lib.rs
@@ -27,7 +27,6 @@
 extern crate alloc;
 
 mod server;
-mod types;
 
 #[cfg(test)]
 mod tests;

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -28,12 +28,11 @@ use futures::io::{BufReader, BufWriter};
 use jsonrpsee_types::error::Error;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
-use serde_json::value::{to_raw_value, RawValue};
+use serde::Serialize;
+use serde_json::value::to_raw_value;
 use soketto::handshake::{server::Response, Server as SokettoServer};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use thiserror::Error;
 use tokio::{
 	net::{TcpListener, ToSocketAddrs},
 	sync::mpsc,
@@ -41,53 +40,16 @@ use tokio::{
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
-use crate::types::{ConnectionId, Methods, RpcId, RpcSender};
-use crate::types::{JsonRpcError, JsonRpcErrorParams};
-use crate::types::{JsonRpcInvalidRequest, JsonRpcRequest, JsonRpcResponse, TwoPointZero};
-use crate::types::{JsonRpcNotification, JsonRpcNotificationParams};
+use jsonrpsee_types::jsonrpc_v2::{ConnectionId, Methods, RpcError, RpcId, RpcParams, RpcSender};
+use jsonrpsee_types::jsonrpc_v2::{JsonRpcError, JsonRpcErrorParams};
+use jsonrpsee_types::jsonrpc_v2::{JsonRpcInvalidRequest, JsonRpcRequest, JsonRpcResponse, TwoPointZero};
+use jsonrpsee_types::jsonrpc_v2::{JsonRpcNotification, JsonRpcNotificationParams};
 
 mod module;
 
 pub use module::{RpcContextModule, RpcModule};
 
 type SubscriptionId = u64;
-
-trait RpcResult {
-	fn to_json(self, id: Option<&RawValue>) -> anyhow::Result<String>;
-}
-
-#[derive(Error, Debug)]
-pub enum RpcError {
-	#[error("unknown rpc error")]
-	Unknown,
-	#[error("invalid params")]
-	InvalidParams,
-}
-
-/// Parameters sent with the RPC request
-#[derive(Clone, Copy)]
-pub struct RpcParams<'a>(Option<&'a str>);
-
-impl<'a> RpcParams<'a> {
-	/// Attempt to parse all parameters as array or map into type T
-	pub fn parse<T>(self) -> Result<T, RpcError>
-	where
-		T: Deserialize<'a>,
-	{
-		match self.0 {
-			None => Err(RpcError::InvalidParams),
-			Some(params) => serde_json::from_str(params).map_err(|_| RpcError::InvalidParams),
-		}
-	}
-
-	/// Attempt to parse only the first parameter from an array into type T
-	pub fn one<T>(self) -> Result<T, RpcError>
-	where
-		T: Deserialize<'a>,
-	{
-		self.parse::<[T; 1]>().map(|[res]| res)
-	}
-}
 
 #[derive(Clone)]
 pub struct SubscriptionSink {
@@ -257,7 +219,7 @@ async fn background_task(socket: tokio::net::TcpStream, methods: Arc<Methods>, i
 
 		match serde_json::from_slice::<JsonRpcRequest>(&data) {
 			Ok(req) => {
-				let params = RpcParams(req.params.map(|params| params.get()));
+				let params = RpcParams::new(req.params.map(|params| params.get()));
 
 				if let Some(method) = methods.get(&*req.method) {
 					(method)(req.id, params, &tx, id)?;

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -1,6 +1,6 @@
 use crate::server::{send_response, Methods, RpcError, RpcParams, SubscriptionId, SubscriptionSink};
-use crate::types::RpcMethod;
 use jsonrpsee_types::error::Error;
+use jsonrpsee_types::jsonrpc_v2::traits::RpcMethod;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use serde::Serialize;


### PR DESCRIPTION
Brute-force but I will build on this in later PRs, as I need to migrate crate by crate to this.

I wasn't in the mood on writing docs for the moved code :)