### PR TITLE
[deps futures]: remove unused features

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dev-dependencies]
 criterion = "0.3"
-futures = "0.3"
+futures-channel = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 num_cpus = "1"
 tokio = { version = "1", features = ["full"] }

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -1,4 +1,4 @@
-use futures::channel::oneshot;
+use futures_channel::oneshot;
 use jsonrpsee::{http_server::HttpServerBuilder, ws_server::WsServer};
 
 /// Run jsonrpsee HTTP server for benchmarks.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dev-dependencies]
 anyhow = "1"
 env_logger = "0.8"
-futures = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 log = "0.4"
 tokio = { version = "1", features = ["full"] }

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
 hyper13-rustls = { package = "hyper-rustls", version = "0.21", optional = true }
 hyper14-rustls = { package = "hyper-rustls", version = "0.22", optional = true }
 hyper14 = { package = "hyper", version = "0.14", features = ["client", "http1", "http2", "tcp"], optional = true }

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -15,7 +15,7 @@ proc-macros = { path = "../proc-macros", version = "0.2.0-alpha.4", package = "j
 
 [dev-dependencies]
 env_logger = "0.8"
-futures = "0.3"
+futures-channel = { version = "0.3", default-features = false }
 log = "0.4"
 test-utils = { path = "../test-utils", version = "0.2.0-alpha.4", package = "jsonrpsee-test-utils" }
 tokio = { version = "1", features = ["full"] }

--- a/jsonrpsee/tests/helpers.rs
+++ b/jsonrpsee/tests/helpers.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::channel::oneshot;
+use futures_channel::oneshot;
 use jsonrpsee::{http_server::HttpServerBuilder, ws_server::WsServer};
 use std::net::SocketAddr;
 use std::time::Duration;

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = "1.8"
-futures = "0.3"
+async-std = "1.9"
+futures-channel = "0.3"
+futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 log = "0.4"
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -114,7 +114,7 @@ pub async fn http_server_with_hardcoded_response(response: String) -> SocketAddr
 		}
 	});
 
-	let (tx, rx) = futures::channel::oneshot::channel::<SocketAddr>();
+	let (tx, rx) = futures_channel::oneshot::channel::<SocketAddr>();
 
 	tokio::spawn(async {
 		let addr = SocketAddr::from(([127, 0, 0, 1], 0));

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -9,9 +9,10 @@ license = "MIT"
 [dependencies]
 async-trait = "0.1"
 beef = "0.5"
-futures = { default-features = false, features = ["std"], version = "0.3" }
-log = { default-features = false, version = "0.4" }
-serde = { default-features = false, features = ["derive"], version = "1.0" }
-serde_json = { default-features = false, features = ["alloc", "raw_value", "std"], version = "1.0" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-util = { version = "0.3", default-features = false, features = ["std", "sink", "channel"] }
+log = { version = "0.4", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive"] }
+serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 smallvec = "1.0"
 thiserror = "1.0"

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -1,8 +1,8 @@
 use crate::error::Error;
 use crate::jsonrpc::{self, DeserializeOwned, JsonValue, Params, SubscriptionId};
 use core::marker::PhantomData;
-use futures::channel::{mpsc, oneshot};
-use futures::prelude::*;
+use futures_channel::{mpsc, oneshot};
+use futures_util::{stream::StreamExt, sink::SinkExt, future::FutureExt};
 
 /// Active subscription on a Client.
 pub struct Subscription<Notif> {

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::jsonrpc::{self, DeserializeOwned, JsonValue, Params, SubscriptionId};
 use core::marker::PhantomData;
 use futures_channel::{mpsc, oneshot};
-use futures_util::{stream::StreamExt, sink::SinkExt, future::FutureExt};
+use futures_util::{future::FutureExt, sink::SinkExt, stream::StreamExt};
 
 /// Active subscription on a Client.
 pub struct Subscription<Notif> {

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
 	Subscription(String, String),
 	/// Frontend/backend channel error.
 	#[error("Frontend/backend channel error: {0}")]
-	Internal(#[source] futures::channel::mpsc::SendError),
+	Internal(#[source] futures_channel::mpsc::SendError),
 	/// Invalid response,
 	#[error("Invalid response: {0}")]
 	InvalidResponse(Mismatch<String>),

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,7 +8,8 @@ license = "MIT"
 
 [dependencies]
 anyhow = { version = "1", optional = true }
-futures = { version = "0.3", default-features = false, optional = true }
+futures-channel = { version = "0.3", default-features = false, optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true }
 hyper13 = { package = "hyper", version = "0.13", default-features = false, features = ["stream"], optional = true }
 hyper14 = { package = "hyper", version = "0.14", default-features = false, features = ["stream"], optional = true }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.4", optional = true }
@@ -19,9 +20,9 @@ serde_json = { version = "1", features = ["raw_value"], optional = true }
 
 [features]
 default = []
-hyper_13 = ["hyper13", "futures", "jsonrpsee-types"]
-hyper_14 = ["hyper14", "futures", "jsonrpsee-types"]
-server = ["anyhow", "futures", "jsonrpsee-types", "rustc-hash", "serde", "serde_json", "log"]
+hyper_13 = ["hyper13", "futures-util", "jsonrpsee-types"]
+hyper_14 = ["hyper14", "futures-util", "jsonrpsee-types"]
+server = ["anyhow", "futures-channel", "jsonrpsee-types", "rustc-hash", "serde", "serde_json", "log"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/utils/src/hyper_helpers.rs
+++ b/utils/src/hyper_helpers.rs
@@ -26,7 +26,7 @@
 
 //! Utility methods relying on hyper
 
-use futures::StreamExt;
+use futures_util::stream::StreamExt;
 use jsonrpsee_types::error::GenericTransportError;
 
 /// Read a hyper response with configured `HTTP` settings.

--- a/utils/src/server.rs
+++ b/utils/src/server.rs
@@ -1,6 +1,6 @@
 //! Shared helpers for JSON-RPC Servers.
 
-use futures::channel::mpsc;
+use futures_channel::mpsc;
 use jsonrpsee_types::v2::error::{INTERNAL_ERROR_CODE, INTERNAL_ERROR_MSG};
 use jsonrpsee_types::v2::{JsonRpcError, JsonRpcErrorParams, JsonRpcResponse, RpcParams, TwoPointZero};
 use rustc_hash::FxHashMap;

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT"
 
 [dependencies]
 async-trait = "0.1"
-async-std = { version = "1.8", features = ["attributes"] }
+async-std = { version = "1.9", default-features = false, features = ["std"] }
 async-tls = "0.11"
 fnv = "1"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std"] }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.4" }
 log = "0.4"
 serde_json = "1"


### PR DESCRIPTION
I got annoyed that we bring in `futures-executor` as a dependency however `soketto` does this too (should be fixed by https://github.com/paritytech/soketto/pull/30 though), so doesn't help
for the `WS` stuff for now