### PR TITLE
Use a constant to express max request body size and consistently use u32 in all crates

### DIFF
--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -6,7 +6,7 @@ use crate::v2::{
 	params::{Id, JsonRpcParams},
 	response::JsonRpcResponse,
 };
-use crate::{Error, JsonRawValue};
+use crate::{Error, JsonRawValue, TEN_MB};
 use async_trait::async_trait;
 use fnv::FnvHashMap;
 use serde::de::DeserializeOwned;
@@ -35,7 +35,7 @@ impl HttpClientBuilder {
 
 impl Default for HttpClientBuilder {
 	fn default() -> Self {
-		Self { max_request_body_size: 10 * 1024 * 1024 }
+		Self { max_request_body_size: TEN_MB }
 	}
 }
 

--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -6,7 +6,7 @@ use crate::v2::{
 	params::{Id, JsonRpcParams},
 	response::JsonRpcResponse,
 };
-use crate::{Error, JsonRawValue, TEN_MB};
+use crate::{Error, JsonRawValue, TEN_MB_SIZE_BYTES};
 use async_trait::async_trait;
 use fnv::FnvHashMap;
 use serde::de::DeserializeOwned;
@@ -35,7 +35,7 @@ impl HttpClientBuilder {
 
 impl Default for HttpClientBuilder {
 	fn default() -> Self {
-		Self { max_request_body_size: TEN_MB }
+		Self { max_request_body_size: TEN_MB_SIZE_BYTES }
 	}
 }
 

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -30,7 +30,7 @@ mod response;
 mod server;
 
 pub use access_control::{AccessControl, AccessControlBuilder, AllowHosts, Host};
-pub use jsonrpsee_types::{Error, TEN_MB};
+pub use jsonrpsee_types::{Error, TEN_MB_SIZE_BYTES};
 pub use module::{RpcContextModule, RpcModule};
 pub use server::{Builder as HttpServerBuilder, Server as HttpServer};
 

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -30,7 +30,7 @@ mod response;
 mod server;
 
 pub use access_control::{AccessControl, AccessControlBuilder, AllowHosts, Host};
-pub use jsonrpsee_types::Error;
+pub use jsonrpsee_types::{Error, TEN_MB};
 pub use module::{RpcContextModule, RpcModule};
 pub use server::{Builder as HttpServerBuilder, Server as HttpServer};
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -27,6 +27,7 @@
 use crate::module::RpcModule;
 use crate::response;
 use crate::AccessControl;
+use crate::TEN_MB;
 use anyhow::anyhow;
 use futures::{channel::mpsc, StreamExt};
 use hyper::{
@@ -100,7 +101,7 @@ impl Builder {
 
 impl Default for Builder {
 	fn default() -> Self {
-		Self { max_request_body_size: 10 * 1024 * 1024, access_control: AccessControl::default(), keep_alive: true }
+		Self { max_request_body_size: TEN_MB, access_control: AccessControl::default(), keep_alive: true }
 	}
 }
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -27,7 +27,7 @@
 use crate::module::RpcModule;
 use crate::response;
 use crate::AccessControl;
-use crate::TEN_MB;
+use crate::TEN_MB_SIZE_BYTES;
 use anyhow::anyhow;
 use futures::{channel::mpsc, StreamExt};
 use hyper::{
@@ -101,7 +101,7 @@ impl Builder {
 
 impl Default for Builder {
 	fn default() -> Self {
-		Self { max_request_body_size: TEN_MB, access_control: AccessControl::default(), keep_alive: true }
+		Self { max_request_body_size: TEN_MB_SIZE_BYTES, access_control: AccessControl::default(), keep_alive: true }
 	}
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate alloc;
 
 /// Ten megabytes.
-pub const TEN_MB: u32 = 10 * 1024 * 1024;
+pub const TEN_MB_SIZE_BYTES: u32 = 10 * 1024 * 1024;
 
 /// JSON-RPC 2.0 specification related types v2.
 pub mod v2;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -5,6 +5,9 @@
 
 extern crate alloc;
 
+/// Ten megabytes.
+pub const TEN_MB: u32 = 10 * 1024 * 1024;
+
 /// JSON-RPC 2.0 specification related types v2.
 pub mod v2;
 

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -37,7 +37,7 @@ use crate::v2::response::{JsonRpcNotifResponse, JsonRpcResponse};
 use crate::{
 	manager::RequestManager, BatchMessage, Error, FrontToBack, RequestMessage, Subscription, SubscriptionMessage,
 };
-use crate::TEN_MB;
+use crate::TEN_MB_SIZE_BYTES;
 use async_std::sync::Mutex;
 use async_trait::async_trait;
 use futures::{
@@ -171,7 +171,7 @@ pub struct WsClientBuilder<'a> {
 impl<'a> Default for WsClientBuilder<'a> {
 	fn default() -> Self {
 		Self {
-			max_request_body_size: TEN_MB,
+			max_request_body_size: TEN_MB_SIZE_BYTES,
 			request_timeout: None,
 			connection_timeout: Duration::from_secs(10),
 			origin: None,

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -37,6 +37,7 @@ use crate::v2::response::{JsonRpcNotifResponse, JsonRpcResponse};
 use crate::{
 	manager::RequestManager, BatchMessage, Error, FrontToBack, RequestMessage, Subscription, SubscriptionMessage,
 };
+use crate::TEN_MB;
 use async_std::sync::Mutex;
 use async_trait::async_trait;
 use futures::{
@@ -158,7 +159,7 @@ impl RequestIdGuard {
 /// Configuration.
 #[derive(Clone, Debug)]
 pub struct WsClientBuilder<'a> {
-	max_request_body_size: usize,
+	max_request_body_size: u32,
 	request_timeout: Option<Duration>,
 	connection_timeout: Duration,
 	origin: Option<Cow<'a, str>>,
@@ -170,7 +171,7 @@ pub struct WsClientBuilder<'a> {
 impl<'a> Default for WsClientBuilder<'a> {
 	fn default() -> Self {
 		Self {
-			max_request_body_size: 10 * 1024 * 1024,
+			max_request_body_size: TEN_MB,
 			request_timeout: None,
 			connection_timeout: Duration::from_secs(10),
 			origin: None,
@@ -183,7 +184,7 @@ impl<'a> Default for WsClientBuilder<'a> {
 
 impl<'a> WsClientBuilder<'a> {
 	/// Set max request body size.
-	pub fn max_request_body_size(mut self, size: usize) -> Self {
+	pub fn max_request_body_size(mut self, size: u32) -> Self {
 		self.max_request_body_size = size;
 		self
 	}

--- a/ws-client/src/transport.rs
+++ b/ws-client/src/transport.rs
@@ -75,7 +75,7 @@ pub struct WsTransportClientBuilder<'a> {
 	/// `Origin` header is passed.
 	pub origin: Option<Cow<'a, str>>,
 	/// Max payload size
-	pub max_request_body_size: usize,
+	pub max_request_body_size: u32,
 }
 
 /// Stream mode, either plain TCP or TLS.
@@ -255,7 +255,7 @@ impl<'a> WsTransportClientBuilder<'a> {
 
 		// If the handshake succeeded, return.
 		let mut builder = client.into_builder();
-		builder.set_max_message_size(self.max_request_body_size);
+		builder.set_max_message_size(self.max_request_body_size as usize);
 		let (sender, receiver) = builder.finish();
 		Ok((Sender { inner: sender }, Receiver { inner: receiver }))
 	}


### PR DESCRIPTION
Closes #257 

`soketto` uses `usize` for the `max_message_size` so if we want to remain consistent we should do the same. I think a `u32` is ok though?