### PR TITLE
Fix race conditions.

### DIFF
--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -119,7 +119,7 @@ impl RequestIdGuard {
 
 	fn get_slot(&self) -> Result<(), Error> {
 		self.current_pending
-			.fetch_updated(Ordering::Relaxed, Ordering::Relaxed, |val| {
+			.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
 				if val >= self.max_concurrent_requests {
 					None
 				} else {

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -119,7 +119,7 @@ impl RequestIdGuard {
 
 	fn get_slot(&self) -> Result<(), Error> {
 		self.current_pending
-			.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+			.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
 				if val >= self.max_concurrent_requests {
 					None
 				} else {
@@ -153,7 +153,7 @@ impl RequestIdGuard {
 
 	fn reclaim_request_id(&self) {
 		// NOTE we ignore the error here, since we are simply saturating at 0
-		let _ = self.current_pending.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+		let _ = self.current_pending.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
 			if val > 0 {
 				Some(val - 1)
 			} else {


### PR DESCRIPTION
We see a lot of "Invalid request ID" errors after updating to `alpha.5`. I believe this might because of possible race condition in `reclaim_request_id`, although haven't tested this yet.

Also I'm not entirely sure if `Ordering::Relaxed` is the right choice in the entire `RequestIdGuard`, but I'm really not an expert in this. Honestly would rather be on the safe side and use `SeqCst` unless you are sure it's correct. :)

