### PR TITLE
[types]: allow `data` field in jsonrpc error obj.

### DIFF
--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -1,4 +1,7 @@
-use crate::v2::{error::ErrorCode, params::JsonRpcParams};
+use crate::v2::{
+	error::{JsonRpcErrorCode, JsonRpcErrorObjectAlloc},
+	params::JsonRpcParams,
+};
 use crate::{traits::Client, Error, HttpClientBuilder, JsonValue};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::Id;
@@ -29,31 +32,51 @@ async fn response_with_wrong_id() {
 #[tokio::test]
 async fn response_method_not_found() {
 	let err = run_request_with_response(method_not_found(Id::Num(0))).await.unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::MethodNotFound);
+	let code = JsonRpcErrorCode::MethodNotFound;
+	assert_jsonrpc_error_response(
+		err,
+		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
+	);
 }
 
 #[tokio::test]
 async fn response_parse_error() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).await.unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::ParseError);
+	let code = JsonRpcErrorCode::ParseError;
+	assert_jsonrpc_error_response(
+		err,
+		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
+	);
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err = run_request_with_response(invalid_request(Id::Num(0_u64))).await.unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::InvalidRequest);
+	let code = JsonRpcErrorCode::InvalidRequest;
+	assert_jsonrpc_error_response(
+		err,
+		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
+	);
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err = run_request_with_response(invalid_params(Id::Num(0_u64))).await.unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::InvalidParams);
+	let code = JsonRpcErrorCode::InvalidParams;
+	assert_jsonrpc_error_response(
+		err,
+		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
+	);
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err = run_request_with_response(internal_error(Id::Num(0_u64))).await.unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::InternalError);
+	let code = JsonRpcErrorCode::InternalError;
+	assert_jsonrpc_error_response(
+		err,
+		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
+	);
 }
 
 #[tokio::test]
@@ -104,7 +127,7 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 	client.request("say_hello", JsonRpcParams::NoParams).await
 }
 
-fn assert_jsonrpc_error_response(error: Error, code: ErrorCode) {
+fn assert_jsonrpc_error_response(error: Error, code: JsonRpcErrorObjectAlloc) {
 	match &error {
 		Error::Request(e) => assert_eq!(e.error, code),
 		e => panic!("Expected error: \"{}\", got: {:?}", error, e),

--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -32,51 +32,31 @@ async fn response_with_wrong_id() {
 #[tokio::test]
 async fn response_method_not_found() {
 	let err = run_request_with_response(method_not_found(Id::Num(0))).await.unwrap_err();
-	let code = JsonRpcErrorCode::MethodNotFound;
-	assert_jsonrpc_error_response(
-		err,
-		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
-	);
+	assert_jsonrpc_error_response(err, JsonRpcErrorCode::MethodNotFound.into());
 }
 
 #[tokio::test]
 async fn response_parse_error() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).await.unwrap_err();
-	let code = JsonRpcErrorCode::ParseError;
-	assert_jsonrpc_error_response(
-		err,
-		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
-	);
+	assert_jsonrpc_error_response(err, JsonRpcErrorCode::ParseError.into());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err = run_request_with_response(invalid_request(Id::Num(0_u64))).await.unwrap_err();
-	let code = JsonRpcErrorCode::InvalidRequest;
-	assert_jsonrpc_error_response(
-		err,
-		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
-	);
+	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InvalidRequest.into());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err = run_request_with_response(invalid_params(Id::Num(0_u64))).await.unwrap_err();
-	let code = JsonRpcErrorCode::InvalidParams;
-	assert_jsonrpc_error_response(
-		err,
-		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
-	);
+	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InvalidParams.into());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err = run_request_with_response(internal_error(Id::Num(0_u64))).await.unwrap_err();
-	let code = JsonRpcErrorCode::InternalError;
-	assert_jsonrpc_error_response(
-		err,
-		JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None },
-	);
+	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InternalError.into());
 }
 
 #[tokio::test]

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -38,10 +38,7 @@ use hyper::{
 };
 use jsonrpsee_types::error::{Error, GenericTransportError, RpcError};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest};
-use jsonrpsee_types::v2::{
-	error::{JsonRpcErrorCode, JsonRpcErrorObject},
-	params::RpcParams,
-};
+use jsonrpsee_types::v2::{error::JsonRpcErrorCode, params::RpcParams};
 use jsonrpsee_utils::{hyper_helpers::read_response_to_body, server::send_error};
 use serde::Serialize;
 use socket2::{Domain, Socket, Type};
@@ -189,12 +186,7 @@ impl Server {
 										log::error!("method_call: {} failed: {:?}", req.method, err);
 									}
 								} else {
-									let code = JsonRpcErrorCode::MethodNotFound;
-									send_error(
-										req.id,
-										&tx,
-										JsonRpcErrorObject { code, message: code.message(), data: None },
-									);
+									send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 								}
 							}
 							Err(_e) => {
@@ -202,7 +194,7 @@ impl Server {
 									Ok(req) => (req.id, JsonRpcErrorCode::InvalidRequest),
 									Err(_) => (None, JsonRpcErrorCode::ParseError),
 								};
-								send_error(id, &tx, JsonRpcErrorObject { code, message: code.message(), data: None });
+								send_error(id, &tx, code.into());
 							}
 						};
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -37,7 +37,10 @@ use hyper::{
 };
 use jsonrpsee_types::error::{Error, GenericTransportError, RpcError};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest};
-use jsonrpsee_types::v2::{error::ErrorCode, params::RpcParams};
+use jsonrpsee_types::v2::{
+	error::{JsonRpcErrorCode, JsonRpcErrorObject},
+	params::RpcParams,
+};
 use jsonrpsee_utils::{hyper_helpers::read_response_to_body, server::send_error};
 use serde::Serialize;
 use socket2::{Domain, Socket, Type};
@@ -185,15 +188,20 @@ impl Server {
 										log::error!("method_call: {} failed: {:?}", req.method, err);
 									}
 								} else {
-									send_error(req.id, &tx, ErrorCode::MethodNotFound);
+									let code = JsonRpcErrorCode::MethodNotFound;
+									send_error(
+										req.id,
+										&tx,
+										JsonRpcErrorObject { code, message: code.message(), data: None },
+									);
 								}
 							}
 							Err(_e) => {
-								let (id, err) = match serde_json::from_slice::<JsonRpcInvalidRequest>(&body) {
-									Ok(req) => (req.id, ErrorCode::InvalidRequest),
-									Err(_) => (None, ErrorCode::ParseError),
+								let (id, code) = match serde_json::from_slice::<JsonRpcInvalidRequest>(&body) {
+									Ok(req) => (req.id, JsonRpcErrorCode::InvalidRequest),
+									Err(_) => (None, JsonRpcErrorCode::ParseError),
 								};
-								send_error(id, &tx, err);
+								send_error(id, &tx, JsonRpcErrorObject { code, message: code.message(), data: None });
 							}
 						};
 

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -182,7 +182,7 @@ impl<'de> Visitor<'de> for ErrorCodeVisitor {
 				}
 				Ok(None) => break,
 				// traverse the entire map otherwise it will err,
-				_ => break,
+				_ => (),
 			}
 		}
 

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -47,7 +47,7 @@ pub struct JsonRpcErrorObjectAlloc {
 
 impl From<JsonRpcErrorCode> for JsonRpcErrorObjectAlloc {
 	fn from(code: JsonRpcErrorCode) -> Self {
-		Self { message: code.message().to_owned(), code, data: None }
+		Self { code, message: code.message().to_owned(), data: None }
 	}
 }
 
@@ -66,7 +66,7 @@ pub struct JsonRpcErrorObject<'a> {
 
 impl<'a> From<JsonRpcErrorCode> for JsonRpcErrorObject<'a> {
 	fn from(code: JsonRpcErrorCode) -> Self {
-		Self { message: code.message(), code, data: None }
+		Self { code, message: code.message(), data: None }
 	}
 }
 

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -204,11 +204,6 @@ mod tests {
 		assert_eq!(err.jsonrpc, TwoPointZero);
 		assert_eq!(err.error, ErrorCode::ParseError);
 		assert_eq!(err.id, Id::Null);
-		let ser = r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error", "data":"vegan"},"id":null}"#;
-		let err: JsonRpcErrorAlloc = serde_json::from_str(ser).unwrap();
-		assert_eq!(err.jsonrpc, TwoPointZero);
-		assert_eq!(err.error, ErrorCode::ParseError);
-		assert_eq!(err.id, Id::Null);
 	}
 
 	#[test]

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -42,7 +42,6 @@ pub struct JsonRpcErrorObjectAlloc {
 	/// Message
 	pub message: String,
 	/// Optional data
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub data: Option<JsonValue>,
 }
 
@@ -63,6 +62,12 @@ pub struct JsonRpcErrorObject<'a> {
 	/// Optional data
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub data: Option<&'a RawValue>,
+}
+
+impl<'a> From<JsonRpcErrorCode> for JsonRpcErrorObject<'a> {
+	fn from(code: JsonRpcErrorCode) -> Self {
+		Self { message: code.message(), code, data: None }
+	}
 }
 
 /// Parse error code.
@@ -121,7 +126,7 @@ impl JsonRpcErrorCode {
 	}
 
 	/// Returns the message for the given error code.
-	pub const fn message(&self) -> &str {
+	pub const fn message(&self) -> &'static str {
 		match self {
 			JsonRpcErrorCode::ParseError => PARSE_ERROR_MSG,
 			JsonRpcErrorCode::InvalidRequest => INVALID_REQUEST_MSG,

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -1,5 +1,5 @@
 use crate::v2::params::{Id, TwoPointZero};
-use serde::de::{Deserializer, MapAccess, Visitor, Error as DeserializeError};
+use serde::de::{Deserializer, Error as DeserializeError, MapAccess, Visitor};
 use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
@@ -174,21 +174,21 @@ impl<'de> Visitor<'de> for ErrorCodeVisitor {
 
 		loop {
 			match access.next_entry::<&str, i32>() {
-				Ok(Some((key, val))) if key == ERROR_CODE_KEY && res.is_none() =>  {
+				Ok(Some((key, val))) if key == ERROR_CODE_KEY && res.is_none() => {
 					res = Some(Ok(val.into()));
 				}
-				Ok(Some((key, _))) if key == ERROR_CODE_KEY =>  {
+				Ok(Some((key, _))) if key == ERROR_CODE_KEY => {
 					res = Some(Err(DeserializeError::duplicate_field(ERROR_CODE_KEY)));
 				}
 				Ok(None) => break,
 				// traverse the entire map otherwise it will err,
-				_ => (),
+				_ => break,
 			}
 		}
 
 		match res {
 			Some(res) => res,
-			None => Err(DeserializeError::missing_field(ERROR_CODE_KEY))
+			None => Err(DeserializeError::missing_field(ERROR_CODE_KEY)),
 		}
 	}
 }

--- a/utils/src/server.rs
+++ b/utils/src/server.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for JSON-RPC Servers.
 
 use futures_channel::mpsc;
-use jsonrpsee_types::v2::error::{ErrorCode, JsonRpcError};
+use jsonrpsee_types::v2::error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject};
 use jsonrpsee_types::v2::params::{RpcParams, TwoPointZero};
 use jsonrpsee_types::v2::response::JsonRpcResponse;
 use rustc_hash::FxHashMap;
@@ -26,7 +26,8 @@ pub fn send_response(id: RpcId, tx: RpcSender, result: impl Serialize) {
 		Err(err) => {
 			log::error!("Error serializing response: {:?}", err);
 
-			return send_error(id, tx, ErrorCode::InternalError);
+			let code = JsonRpcErrorCode::InternalError;
+			return send_error(id, tx, JsonRpcErrorObject { code, message: code.message(), data: None });
 		}
 	};
 
@@ -36,7 +37,7 @@ pub fn send_response(id: RpcId, tx: RpcSender, result: impl Serialize) {
 }
 
 /// Helper for sending JSON-RPC errors to the client
-pub fn send_error(id: RpcId, tx: RpcSender, error: ErrorCode) {
+pub fn send_error(id: RpcId, tx: RpcSender, error: JsonRpcErrorObject) {
 	let json = match serde_json::to_string(&JsonRpcError { jsonrpc: TwoPointZero, error, id }) {
 		Ok(json) => json,
 		Err(err) => {

--- a/utils/src/server.rs
+++ b/utils/src/server.rs
@@ -26,8 +26,7 @@ pub fn send_response(id: RpcId, tx: RpcSender, result: impl Serialize) {
 		Err(err) => {
 			log::error!("Error serializing response: {:?}", err);
 
-			let code = JsonRpcErrorCode::InternalError;
-			return send_error(id, tx, JsonRpcErrorObject { code, message: code.message(), data: None });
+			return send_error(id, tx, JsonRpcErrorCode::InternalError.into());
 		}
 	};
 

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -589,7 +589,10 @@ async fn background_task(
 				}
 				// Unparsable response
 				else {
-					log::debug!("[backend]: recv unparseable message: {:?}", serde_json::from_slice::<serde_json::Value>(&raw));
+					log::debug!(
+						"[backend]: recv unparseable message: {:?}",
+						serde_json::from_slice::<serde_json::Value>(&raw)
+					);
 					let _ = front_error.send(Error::Custom("Unparsable response".into()));
 					return;
 				}

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -36,36 +36,31 @@ async fn response_with_wrong_id() {
 #[tokio::test]
 async fn response_method_not_found() {
 	let err = run_request_with_response(method_not_found(Id::Num(0))).await.unwrap_err();
-	let code = JsonRpcErrorCode::MethodNotFound;
-	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
+	assert_error_response(err, JsonRpcErrorCode::MethodNotFound.into());
 }
 
 #[tokio::test]
 async fn parse_error_works() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).await.unwrap_err();
-	let code = JsonRpcErrorCode::ParseError;
-	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
+	assert_error_response(err, JsonRpcErrorCode::ParseError.into());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err = run_request_with_response(invalid_request(Id::Num(0_u64))).await.unwrap_err();
-	let code = JsonRpcErrorCode::InvalidRequest;
-	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
+	assert_error_response(err, JsonRpcErrorCode::InvalidRequest.into());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err = run_request_with_response(invalid_params(Id::Num(0_u64))).await.unwrap_err();
-	let code = JsonRpcErrorCode::InvalidParams;
-	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
+	assert_error_response(err, JsonRpcErrorCode::InvalidParams.into());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err = run_request_with_response(internal_error(Id::Num(0_u64))).await.unwrap_err();
-	let code = JsonRpcErrorCode::InternalError;
-	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
+	assert_error_response(err, JsonRpcErrorCode::InternalError.into());
 }
 
 #[tokio::test]

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 
-use crate::v2::{error::ErrorCode, params::JsonRpcParams};
+use crate::v2::{
+	error::{JsonRpcErrorCode, JsonRpcErrorObjectAlloc},
+	params::JsonRpcParams,
+};
 use crate::{
 	traits::{Client, SubscriptionClient},
 	Error, Subscription, WsClientBuilder,
@@ -33,31 +36,36 @@ async fn response_with_wrong_id() {
 #[tokio::test]
 async fn response_method_not_found() {
 	let err = run_request_with_response(method_not_found(Id::Num(0))).await.unwrap_err();
-	assert_error_response(err, ErrorCode::MethodNotFound);
+	let code = JsonRpcErrorCode::MethodNotFound;
+	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
 }
 
 #[tokio::test]
 async fn parse_error_works() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).await.unwrap_err();
-	assert_error_response(err, ErrorCode::ParseError);
+	let code = JsonRpcErrorCode::ParseError;
+	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err = run_request_with_response(invalid_request(Id::Num(0_u64))).await.unwrap_err();
-	assert_error_response(err, ErrorCode::InvalidRequest);
+	let code = JsonRpcErrorCode::InvalidRequest;
+	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err = run_request_with_response(invalid_params(Id::Num(0_u64))).await.unwrap_err();
-	assert_error_response(err, ErrorCode::InvalidParams);
+	let code = JsonRpcErrorCode::InvalidParams;
+	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err = run_request_with_response(internal_error(Id::Num(0_u64))).await.unwrap_err();
-	assert_error_response(err, ErrorCode::InternalError);
+	let code = JsonRpcErrorCode::InternalError;
+	assert_error_response(err, JsonRpcErrorObjectAlloc { code, message: code.message().to_owned(), data: None });
 }
 
 #[tokio::test]
@@ -135,7 +143,7 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 	client.request("say_hello", JsonRpcParams::NoParams).await
 }
 
-fn assert_error_response(error: Error, code: ErrorCode) {
+fn assert_error_response(error: Error, code: JsonRpcErrorObjectAlloc) {
 	match &error {
 		Error::Request(e) => assert_eq!(e.error, code),
 		e => panic!("Expected error: \"{}\", got: {:?}", error, e),

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -37,13 +37,10 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
+use jsonrpsee_types::error::{Error, RpcError};
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
 use jsonrpsee_types::v2::params::{JsonRpcNotificationParams, RpcParams, TwoPointZero};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest};
-use jsonrpsee_types::{
-	error::{Error, RpcError},
-	v2::error::JsonRpcErrorObject,
-};
 use jsonrpsee_utils::server::{send_error, ConnectionId, Methods};
 
 mod module;
@@ -190,8 +187,7 @@ async fn background_task(socket: tokio::net::TcpStream, methods: Arc<Methods>, i
 				if let Some(method) = methods.get(&*req.method) {
 					(method)(req.id, params, &tx, id)?;
 				} else {
-					let code = JsonRpcErrorCode::MethodNotFound;
-					send_error(req.id, &tx, JsonRpcErrorObject { code, message: code.message(), data: None });
+					send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 				}
 			}
 			Err(_) => {
@@ -200,7 +196,7 @@ async fn background_task(socket: tokio::net::TcpStream, methods: Arc<Methods>, i
 					Err(_) => (None, JsonRpcErrorCode::ParseError),
 				};
 
-				send_error(id, &tx, JsonRpcErrorObject { code, message: code.message(), data: None });
+				send_error(id, &tx, code.into());
 			}
 		}
 	}


### PR DESCRIPTION
Follow up on #285 

Basically when a error response with a `data` field is included it was regarded as bad response which this fixes

For example I tested this with `subxt` and the following was regarded as bad response before this PR:

```
[2021-04-24T10:44:15Z DEBUG jsonrpsee_ws_client::client] [backend]: recv unparseable message: Ok(Object({"error": Object({"code": Number(1014), "data": String("The transaction has too low priority to replace another transaction already in the pool."), "message": String("Priority is too low: (12497117750671931 vs 12497117750671931)")}), "id": Number(12), "jsonrpc": String("2.0")}))

```

//cc @tomusdrw I think this fixes your `InvalidRequestId` messages.



