### PR TITLE
Use SeqCst everywhere

### DIFF
--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -64,7 +64,7 @@ impl Client for HttpClient {
 		R: DeserializeOwned,
 	{
 		// NOTE: `fetch_add` wraps on overflow which is intended.
-		let id = self.request_id.fetch_add(1, Ordering::Relaxed);
+		let id = self.request_id.fetch_add(1, Ordering::SeqCst);
 		let request = JsonRpcCallSer::new(Id::Number(id), method, params);
 
 		let body = self

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -135,7 +135,7 @@ impl RequestIdGuard {
 	/// Fails if request limit has been exceeded.
 	fn next_request_id(&self) -> Result<u64, Error> {
 		self.get_slot()?;
-		let id = self.current_id.fetch_add(1, Ordering::Relaxed);
+		let id = self.current_id.fetch_add(1, Ordering::SeqCst);
 		Ok(id)
 	}
 
@@ -146,7 +146,7 @@ impl RequestIdGuard {
 		self.get_slot()?;
 		let mut batch = Vec::with_capacity(len);
 		for _ in 0..len {
-			batch.push(self.current_id.fetch_add(1, Ordering::Relaxed));
+			batch.push(self.current_id.fetch_add(1, Ordering::SeqCst));
 		}
 		Ok(batch)
 	}


### PR DESCRIPTION
See https://github.com/paritytech/jsonrpsee/pull/285

I went over all the atomic operations and realised I could not convince myself that all uses of `Relaxed` were ok, so better safe than sorry: let's switch to `SeqCst`.