### PR TITLE
[http server] Batch requests

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -51,7 +51,7 @@ pub fn batched_http_requests(crit: &mut Criterion) {
 	let rt = TokioRuntime::new().unwrap();
 	let url = rt.block_on(helpers::http_server());
 	let client = Arc::new(HttpClientBuilder::default().build(&url).unwrap());
-	run_round_trip_with_batch(&rt, crit, client.clone(), "batched_http_round_trip", 10);
+	run_round_trip_with_batch(&rt, crit, client.clone(), "http batch requests");
 }
 
 pub fn websocket_requests(crit: &mut Criterion) {
@@ -73,21 +73,26 @@ fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Clie
 	});
 }
 
+/// Benchmark http batch requests over batch sizes of 2, 5, 10, 50 and 100 RPCs in each batch.
 fn run_round_trip_with_batch(
 	rt: &TokioRuntime,
 	crit: &mut Criterion,
 	client: Arc<impl Client>,
 	name: &str,
-	batch_size: usize,
 ) {
-	let batch = vec![("say_hello", JsonRpcParams::NoParams); batch_size];
-	crit.bench_function(name, |b| {
-		b.iter(|| {
-			rt.block_on(async {
-				black_box(client.batch_request::<String>(batch.clone()).await.unwrap());
+	let mut group = crit.benchmark_group(name);
+	for batch_size in [2, 5, 10, 50, 100usize].iter() {
+		let batch = vec![("say_hello", JsonRpcParams::NoParams); *batch_size];
+		group.throughput(Throughput::Elements(*batch_size as u64));
+		group.bench_with_input(BenchmarkId::from_parameter(batch_size), batch_size, |b, _| {
+			b.iter(|| {
+				rt.block_on( async {
+					client.batch_request::<String>(batch.clone()).await.unwrap()
+				})
 			})
-		})
-	});
+		});
+	}
+	group.finish();
 }
 
 fn run_concurrent_round_trip<C: 'static + Client + Send + Sync>(

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -74,7 +74,13 @@ fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Clie
 	});
 }
 
-fn run_round_trip_with_batch(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str, batch_size: usize) {
+fn run_round_trip_with_batch(
+	rt: &TokioRuntime,
+	crit: &mut Criterion,
+	client: Arc<impl Client>,
+	name: &str,
+	batch_size: usize,
+) {
 	let batch = vec![("say_hello", JsonRpcParams::NoParams); batch_size];
 	crit.bench_function(name, |b| {
 		b.iter(|| {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,6 @@ use jsonrpsee::{
 	ws_client::WsClientBuilder,
 };
 use std::sync::Arc;
-use std::time::Instant;
 use tokio::runtime::Runtime as TokioRuntime;
 
 mod helpers;

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -169,7 +169,7 @@ impl Server {
 								// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
 								if let Err(err) = (method)(id, params, &tx, 0) {
 									log::error!(
-										"execution of method call {} failed: {:?}, request id={:?}",
+										"execution of method call '{}' failed: {:?}, request id={:?}",
 										method_name,
 										err,
 										id

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -197,13 +197,14 @@ impl Server {
 
 						// NOTE(niklasad1): it's a channel because it's needed for batch requests.
 						let (tx, mut rx) = mpsc::unbounded();
+						// Is this a single request or a batch (or error)?
+						let mut single = true;
 
 						// For [technical reasons](https://github.com/serde-rs/json/issues/497), `RawValue` can't be
 						// used with untagged enums at the moment. This means we can't use an `SingleOrBatch` untagged
 						// enum here and have to try each case individually: first the single request case, then the
 						// batch case and lastly the error. For the worst case – unparseable input – we make three calls
 						// to [`serde_json::from_slice`] which is pretty annoying.
-						let mut single = true;
 						if let Ok(JsonRpcRequest { id, method: method_name, params, .. }) =
 							serde_json::from_slice::<JsonRpcRequest>(&body)
 						{

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -257,7 +257,8 @@ impl Server {
 	}
 }
 
-// Collect the results of all computations sent back on the ['Stream'] into a single `String` appropriately mapped in `[`/`]`.
+// Collect the results of all computations sent back on the ['Stream'] into a single `String` appropriately wrapped in
+// `[`/`]`.
 async fn collect_batch_responses(rx: mpsc::UnboundedReceiver<String>) -> String {
 	let mut buf = String::with_capacity(2048);
 	buf.push('[');

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -201,10 +201,8 @@ impl Server {
 						if let Ok(JsonRpcRequest { id, method: method_name, params, .. }) =
 							serde_json::from_slice::<JsonRpcRequest>(&body)
 						{
-							log::debug!("SINGLE");
 							execute(id, &tx, &method_name, params);
 						} else if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&body) {
-							log::debug!("BATCH len={}", batch.len());
 							for JsonRpcRequest { id, method: method_name, params, .. } in batch {
 								execute(id, &tx, &method_name, params);
 							}

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -227,6 +227,7 @@ impl Server {
 							};
 							send_error(id, &tx, code.into());
 						}
+						// Closes the receiving half of a channel without dropping it. This prevents any further messages from being sent on the channel.
 						rx.close();
 						let response = if single {
 							rx.next().await.expect("Sender is still alive managed by us above; qed")

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -227,21 +227,22 @@ impl Server {
 							send_error(id, &tx, code.into());
 						}
 						rx.close();
-						let response =
-							if single {
-								rx.next().await.expect("Sender is still alive managed by us above; qed")
-							} else {
-								let mut buf = String::with_capacity(2048);
-								buf.push('[');
-								let mut buf = rx.fold(buf, move |mut acc, response| async move {
+						let response = if single {
+							rx.next().await.expect("Sender is still alive managed by us above; qed")
+						} else {
+							let mut buf = String::with_capacity(2048);
+							buf.push('[');
+							let mut buf = rx
+								.fold(buf, move |mut acc, response| async move {
 									acc = [acc, response].concat();
 									acc.push(',');
 									acc
-								}).await;
-								buf.pop();
-								buf.push(']');
-								buf
-							};
+								})
+								.await;
+							buf.pop();
+							buf.push(']');
+							buf
+						};
 						log::debug!("[service_fn] sending back: {:?}", response);
 						Ok::<_, HyperError>(response::ok_response(response))
 					}

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -210,7 +210,7 @@ impl Server {
 						{
 							execute(id, &tx, &method_name, params);
 						} else if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&body) {
-							if batch.len() > 0 {
+							if !batch.is_empty() {
 								single = false;
 								for JsonRpcRequest { id, method: method_name, params, .. } in batch {
 									execute(id, &tx, &method_name, params);

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -205,6 +205,7 @@ impl Server {
 						// enum here and have to try each case individually: first the single request case, then the
 						// batch case and lastly the error. For the worst case – unparseable input – we make three calls
 						// to [`serde_json::from_slice`] which is pretty annoying.
+						// Our [issue](https://github.com/paritytech/jsonrpsee/issues/296).
 						if let Ok(JsonRpcRequest { id, method: method_name, params, .. }) =
 							serde_json::from_slice::<JsonRpcRequest>(&body)
 						{

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -38,6 +38,18 @@ async fn single_method_call_works() {
 }
 
 #[tokio::test]
+async fn invalid_single_method_call() {
+	let _ = env_logger::try_init();
+	let addr = server().await;
+	let uri = to_http_uri(addr);
+
+	let req = r#"{"jsonrpc":"2.0","method":1, "params": "bar"}"#;
+	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, invalid_request(Id::Null));
+}
+
+#[tokio::test]
 async fn single_method_call_with_params() {
 	let addr = server().await;
 	let uri = to_http_uri(addr);
@@ -50,24 +62,8 @@ async fn single_method_call_with_params() {
 	assert_eq!(response.body, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
 }
 
-// Batch request example from spec (https://www.jsonrpc.org/specification)
-// --> [
-//         {"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
-//         {"jsonrpc": "2.0", "method": "notify_hello", "params": [7]},
-//         {"jsonrpc": "2.0", "method": "subtract", "params": [42,23], "id": "2"},
-//         {"foo": "boo"},
-//         {"jsonrpc": "2.0", "method": "foo.get", "params": {"name": "myself"}, "id": "5"},
-//         {"jsonrpc": "2.0", "method": "get_data", "id": "9"}
-//     ]
-// <-- [
-//         {"jsonrpc": "2.0", "result": 7, "id": "1"},
-//         {"jsonrpc": "2.0", "result": 19, "id": "2"},
-//         {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null},
-//         {"jsonrpc": "2.0", "error": {"code": -32601, "message": "Method not found"}, "id": "5"},
-//         {"jsonrpc": "2.0", "result": ["hello", 5], "id": "9"}
-//     ]
 #[tokio::test]
-async fn batched_method_calls() {
+async fn valid_batched_method_calls() {
 	let _ = env_logger::try_init();
 
 	let addr = server().await;
@@ -85,6 +81,63 @@ async fn batched_method_calls() {
 		response.body,
 		r#"[{"jsonrpc":"2.0","result":3,"id":1},{"jsonrpc":"2.0","result":7,"id":2},{"jsonrpc":"2.0","result":"lo","id":3},{"jsonrpc":"2.0","result":11,"id":4}]"#
 	);
+}
+
+#[tokio::test]
+async fn batched_notifications() {
+	let _ = env_logger::try_init();
+
+	let addr = server().await;
+	let uri = to_http_uri(addr);
+
+	let req = r#"[
+        {"jsonrpc": "2.0", "method": "notif", "params": [1,2,4]},
+        {"jsonrpc": "2.0", "method": "notif", "params": [7]}
+	]"#;
+	let response = http_request(req.into(), uri).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	// Note: this is *not* according to spec. Response should be the empty string, `""`.
+	assert_eq!(
+		response.body,
+		r#"[{"jsonrpc":"2.0","result":"","id":null},{"jsonrpc":"2.0","result":"","id":null}]"#
+	);
+}
+
+#[tokio::test]
+async fn invalid_batched_method_calls() {
+	let _ = env_logger::try_init();
+
+	let addr = server().await;
+	let uri = to_http_uri(addr);
+
+	// batch with no requests
+	let req = r#"[]"#;
+	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, invalid_request(Id::Null));
+
+	// batch with invalid request
+	let req = r#"[123]"#;
+	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	// Note: according to the spec the `id` should be `null` here, not 123.
+	assert_eq!(response.body, invalid_request(Id::Num(123)));
+
+	// batch with invalid request
+	let req = r#"[1, 2, 3]"#;
+	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	// Note: according to the spec this should return an array of three `Invalid Request`s
+	assert_eq!(response.body, parse_error(Id::Null));
+
+	// invalid JSON in batch
+	let req = r#"[
+		{"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
+		{"jsonrpc": "2.0", "method"
+	  ]"#;
+	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, parse_error(Id::Null));
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -83,7 +83,10 @@ async fn batched_method_calls() {
 	assert_eq!(response.status, StatusCode::OK);
 	log::info!("[test] Response body: {:?}", response.body);
 	// TODO: the response should be wrapped in `[]`, but it's a straight up `String`
-	assert_eq!(response.body, r#"[{"jsonrpc":"2.0","result":3,"id":1},{"jsonrpc":"2.0","result":7,"id":2},{"jsonrpc":"2.0","result":"lo","id":3},{"jsonrpc":"2.0","result":11,"id":4}]"#);
+	assert_eq!(
+		response.body,
+		r#"[{"jsonrpc":"2.0","result":3,"id":1},{"jsonrpc":"2.0","result":7,"id":2},{"jsonrpc":"2.0","result":"lo","id":3},{"jsonrpc":"2.0","result":11,"id":4}]"#
+	);
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -97,10 +97,7 @@ async fn batched_notifications() {
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	// Note: this is *not* according to spec. Response should be the empty string, `""`.
-	assert_eq!(
-		response.body,
-		r#"[{"jsonrpc":"2.0","result":"","id":null},{"jsonrpc":"2.0","result":"","id":null}]"#
-	);
+	assert_eq!(response.body, r#"[{"jsonrpc":"2.0","result":"","id":null},{"jsonrpc":"2.0","result":"","id":null}]"#);
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -50,6 +50,7 @@ async fn single_method_call_with_params() {
 	assert_eq!(response.body, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
 }
 
+// Batch request example from spec (https://www.jsonrpc.org/specification)
 // --> [
 //         {"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
 //         {"jsonrpc": "2.0", "method": "notify_hello", "params": [7]},
@@ -72,18 +73,17 @@ async fn batched_method_calls() {
 	let addr = server().await;
 	let uri = to_http_uri(addr);
 
-	let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-	// let req = r#"[{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}]"#;
-	// let req = r#"[
-	// 	{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1},
-	// 	{"jsonrpc":"2.0","method":"add", "params":[3, 4],"id":2},
-	// 	{"jsonrpc":"2.0","method":"say_hello","id":3},
-	// 	{"jsonrpc":"2.0","method":"add", "params":[5, 6],"id":4}
-	// ]"#;
+	let req = r#"[
+		{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1},
+		{"jsonrpc":"2.0","method":"add", "params":[3, 4],"id":2},
+		{"jsonrpc":"2.0","method":"say_hello","id":3},
+		{"jsonrpc":"2.0","method":"add", "params":[5, 6],"id":4}
+	]"#;
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	log::info!("Response body: {:?}", response.body);
-	// assert_eq!(response.body, method_not_found(Id::Str("foo".into())));
+	log::info!("[test] Response body: {:?}", response.body);
+	// TODO: the response should be wrapped in `[]`, but it's a straight up `String`
+	assert_eq!(response.body, r#"[{"jsonrpc":"2.0","result":3,"id":1},{"jsonrpc":"2.0","result":7,"id":2},{"jsonrpc":"2.0","result":"lo","id":3},{"jsonrpc":"2.0","result":11,"id":4}]"#);
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -81,8 +81,6 @@ async fn batched_method_calls() {
 	]"#;
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	log::info!("[test] Response body: {:?}", response.body);
-	// TODO: the response should be wrapped in `[]`, but it's a straight up `String`
 	assert_eq!(
 		response.body,
 		r#"[{"jsonrpc":"2.0","result":3,"id":1},{"jsonrpc":"2.0","result":7,"id":2},{"jsonrpc":"2.0","result":"lo","id":3},{"jsonrpc":"2.0","result":11,"id":4}]"#

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -102,7 +102,7 @@ impl<'a> RpcParams<'a> {
 /// If your type implement `Into<JsonValue>` call that favor of `serde_json::to:value` to
 /// construct the parameters. Because `serde_json::to_value` serializes the type which
 /// allocates whereas `Into<JsonValue>` doesn't in most cases.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum JsonRpcParams<'a> {
 	/// No params.

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -20,23 +20,6 @@ pub struct JsonRpcRequest<'a> {
 	pub params: Option<&'a RawValue>,
 }
 
-// /// TODO: docs
-// #[derive(Deserialize, Debug)]
-// pub struct JsonRpcBatchRequest<'a>(
-// 	#[serde(borrow)]
-// 	pub
-// 	Vec<JsonRpcRequest<'a>>
-// );
-
-/// TODO: docs
-#[derive(Deserialize, Debug)]
-#[serde(untagged)]
-pub enum SingleOrBatch<'a> {
-	Single(#[serde(borrow)] JsonRpcRequest<'a>),
-	Batch(#[serde(borrow)] Vec<JsonRpcRequest<'a>>),
-	// Batch(JsonRpcBatchRequest<'a>),
-}
-
 /// Invalid request with known request ID.
 #[derive(Deserialize, Debug)]
 pub struct JsonRpcInvalidRequest<'a> {

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -20,6 +20,23 @@ pub struct JsonRpcRequest<'a> {
 	pub params: Option<&'a RawValue>,
 }
 
+// /// TODO: docs
+// #[derive(Deserialize, Debug)]
+// pub struct JsonRpcBatchRequest<'a>(
+// 	#[serde(borrow)]
+// 	pub
+// 	Vec<JsonRpcRequest<'a>>
+// );
+
+/// TODO: docs
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum SingleOrBatch<'a> {
+	Single(#[serde(borrow)] JsonRpcRequest<'a>),
+	Batch(#[serde(borrow)]Vec<JsonRpcRequest<'a>>),
+	// Batch(JsonRpcBatchRequest<'a>),
+}
+
 /// Invalid request with known request ID.
 #[derive(Deserialize, Debug)]
 pub struct JsonRpcInvalidRequest<'a> {


### PR DESCRIPTION
Implement http server batch requests.

[Spec](https://www.jsonrpc.org/specification#batch).

We diverge from the spec in a few places:
- sending a batch of notifications should receive the empty string, `""`, in response. Instead we return `{"jsonrpc":"2.0","result":"","id":null}` for each notification
- sending an invalid batch with numbers, e.g. `[123]` we should return an `Invalid Request` error (which we do) with the `id` set to `null` (which we don't; somehow serde parses the `123` into the `id` and I don't think it's worth the hassle to fix that)
- sending a batch of several invalid requests, e.g. `[1, 2, 3]`, should return one `Invalid Request` for each, but to us that's a `Parse Error`. Again I think that it's not really worth the hassle to fix.

One thing that annoys me with this PR is that if we decide to support notifications properly, the number of `serde_json::from_slice` calls will be even bigger than it is now (3 for the worst case), so the lack of support for `untagged` enums with `RawValue` becomes really problematic. We'd have to get pretty creative at that point. :/
