### PR TITLE
unify error types in the servers.

### DIFF
--- a/http-server/src/module.rs
+++ b/http-server/src/module.rs
@@ -1,4 +1,4 @@
-use jsonrpsee_types::{error::RpcError, traits::RpcMethod, v2::params::RpcParams, Error};
+use jsonrpsee_types::{traits::RpcMethod, v2::params::RpcParams, Error};
 use jsonrpsee_utils::server::{send_response, Methods};
 use serde::Serialize;
 use std::sync::Arc;
@@ -82,7 +82,7 @@ impl<Context> RpcContextModule<Context> {
 	where
 		Context: Send + Sync + 'static,
 		R: Serialize,
-		F: Fn(RpcParams, &Context) -> Result<R, RpcError> + Send + Sync + 'static,
+		F: Fn(RpcParams, &Context) -> Result<R, Error> + Send + Sync + 'static,
 	{
 		self.module.verify_method_name(method_name)?;
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -36,7 +36,7 @@ use hyper::{
 	service::{make_service_fn, service_fn},
 	Error as HyperError,
 };
-use jsonrpsee_types::error::{Error, GenericTransportError, RpcError};
+use jsonrpsee_types::error::{Error, GenericTransportError};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest};
 use jsonrpsee_types::v2::{error::JsonRpcErrorCode, params::RpcParams};
 use jsonrpsee_utils::{hyper_helpers::read_response_to_body, server::send_error};
@@ -124,7 +124,7 @@ impl Server {
 	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize,
-		F: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static,
+		F: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static,
 	{
 		self.root.register_method(method_name, callback)
 	}

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -1,17 +1,6 @@
 use crate::v2::error::JsonRpcErrorAlloc;
 use std::fmt;
 
-/// Error.
-#[derive(thiserror::Error, Debug)]
-pub enum RpcError {
-	/// Unknown error.
-	#[error("unknown rpc error")]
-	Unknown,
-	/// Invalid params in the RPC call.
-	#[error("invalid params")]
-	InvalidParams,
-}
-
 /// Convenience type for displaying errors.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Mismatch<T> {
@@ -54,6 +43,9 @@ pub enum Error {
 	/// Invalid request ID.
 	#[error("Invalid request ID")]
 	InvalidRequestId,
+	/// Invalid params in the RPC call.
+	#[error("Invalid params in the RPC call")]
+	InvalidParams,
 	/// A request with the same request ID has already been registered.
 	#[error("A request with the same request ID has already been registered")]
 	DuplicateRequestId,

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::v2::params::{JsonRpcParams, RpcParams};
-use crate::{error::RpcError, Error, Subscription};
+use crate::{Error, Subscription};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
@@ -47,6 +47,6 @@ pub trait SubscriptionClient: Client {
 }
 
 /// JSON-RPC server interface for managing method calls.
-pub trait RpcMethod<R>: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static {}
+pub trait RpcMethod<R>: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static {}
 
-impl<R, T> RpcMethod<R> for T where T: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static {}
+impl<R, T> RpcMethod<R> for T where T: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static {}

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -1,4 +1,4 @@
-use crate::error::RpcError;
+use crate::error::Error;
 use alloc::collections::BTreeMap;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
@@ -78,18 +78,18 @@ impl<'a> RpcParams<'a> {
 	}
 
 	/// Attempt to parse all parameters as array or map into type T
-	pub fn parse<T>(self) -> Result<T, RpcError>
+	pub fn parse<T>(self) -> Result<T, Error>
 	where
 		T: Deserialize<'a>,
 	{
 		match self.0 {
-			None => Err(RpcError::InvalidParams),
-			Some(params) => serde_json::from_str(params).map_err(|_| RpcError::InvalidParams),
+			None => Err(Error::InvalidParams),
+			Some(params) => serde_json::from_str(params).map_err(|_| Error::InvalidParams),
 		}
 	}
 
 	/// Attempt to parse only the first parameter from an array into type T
-	pub fn one<T>(self) -> Result<T, RpcError>
+	pub fn one<T>(self) -> Result<T, Error>
 	where
 		T: Deserialize<'a>,
 	{

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -37,7 +37,7 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
-use jsonrpsee_types::error::{Error, RpcError};
+use jsonrpsee_types::error::Error;
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
 use jsonrpsee_types::v2::params::{JsonRpcNotificationParams, RpcParams, TwoPointZero};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest};
@@ -105,7 +105,7 @@ impl Server {
 	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize,
-		F: Fn(RpcParams) -> Result<R, RpcError> + Send + Sync + 'static,
+		F: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static,
 	{
 		self.root.register_method(method_name, callback)
 	}

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -1,4 +1,4 @@
-use crate::server::{RpcError, RpcParams, SubscriptionId, SubscriptionSink};
+use crate::server::{RpcParams, SubscriptionId, SubscriptionSink};
 use jsonrpsee_types::error::Error;
 use jsonrpsee_types::traits::RpcMethod;
 use jsonrpsee_utils::server::{send_response, Methods};
@@ -142,7 +142,7 @@ impl<Context> RpcContextModule<Context> {
 	where
 		Context: Send + Sync + 'static,
 		R: Serialize,
-		F: Fn(RpcParams, &Context) -> Result<R, RpcError> + Send + Sync + 'static,
+		F: Fn(RpcParams, &Context) -> Result<R, Error> + Send + Sync + 'static,
 	{
 		self.module.verify_method_name(method_name)?;
 


### PR DESCRIPTION
It was really annoying to deal with when trying to integrate in substrate.

Maybe we should try to split up the error in with different types instead to reduce the scope instead of depending on the big `Error enum`