### PR TITLE
[servers] return error if context or params fails

### DIFF
--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -27,8 +27,8 @@ impl HttpClientBuilder {
 
 	/// Build the HTTP client with target to connect to.
 	pub fn build(self, target: impl AsRef<str>) -> Result<HttpClient, Error> {
-		let transport = HttpTransportClient::new(target, self.max_request_body_size)
-			.map_err(|e| Error::TransportError(Box::new(e)))?;
+		let transport =
+			HttpTransportClient::new(target, self.max_request_body_size).map_err(|e| Error::Transport(Box::new(e)))?;
 		Ok(HttpClient { transport, request_id: AtomicU64::new(0) })
 	}
 }
@@ -55,7 +55,7 @@ impl Client for HttpClient {
 		self.transport
 			.send(serde_json::to_string(&notif).map_err(Error::ParseError)?)
 			.await
-			.map_err(|e| Error::TransportError(Box::new(e)))
+			.map_err(|e| Error::Transport(Box::new(e)))
 	}
 
 	/// Perform a request towards the server.
@@ -71,7 +71,7 @@ impl Client for HttpClient {
 			.transport
 			.send_and_read_body(serde_json::to_string(&request).map_err(Error::ParseError)?)
 			.await
-			.map_err(|e| Error::TransportError(Box::new(e)))?;
+			.map_err(|e| Error::Transport(Box::new(e)))?;
 
 		let response: JsonRpcResponse<_> = match serde_json::from_slice(&body) {
 			Ok(response) => response,
@@ -110,7 +110,7 @@ impl Client for HttpClient {
 			.transport
 			.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?)
 			.await
-			.map_err(|e| Error::TransportError(Box::new(e)))?;
+			.map_err(|e| Error::Transport(Box::new(e)))?;
 
 		let rps: Vec<JsonRpcResponse<_>> = match serde_json::from_slice(&body) {
 			Ok(response) => response,

--- a/http-server/src/module.rs
+++ b/http-server/src/module.rs
@@ -1,4 +1,4 @@
-use jsonrpsee_types::v2::error::{JsonRpcErrorCode, JsonRpcErrorObject};
+use jsonrpsee_types::v2::error::{JsonRpcErrorCode, JsonRpcErrorObject, CONTEXT_EXECUTION_FAILED_CODE};
 use jsonrpsee_types::{
 	error::{Error, InvalidParams, ServerCallError},
 	traits::RpcMethod,
@@ -103,7 +103,7 @@ impl<Context> RpcContextModule<Context> {
 						send_error(id, tx, JsonRpcErrorCode::InvalidParams.into())
 					}
 					Err(ServerCallError::ContextFailed(err)) => {
-						let err = JsonRpcErrorObject { code: 1.into(), message: &err.to_string(), data: None };
+						let err = JsonRpcErrorObject { code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE), message: &err.to_string(), data: None };
 						send_error(id, tx, err)
 					}
 				};

--- a/http-server/src/module.rs
+++ b/http-server/src/module.rs
@@ -1,4 +1,4 @@
-use jsonrpsee_types::v2::error::{JsonRpcErrorCode, JsonRpcErrorObject, CONTEXT_EXECUTION_FAILED_CODE};
+use jsonrpsee_types::v2::error::{JsonRpcErrorCode, JsonRpcErrorObject, CALL_EXECUTION_FAILED_CODE};
 use jsonrpsee_types::{
 	error::{CallError, Error, InvalidParams},
 	traits::RpcMethod,
@@ -102,7 +102,7 @@ impl<Context> RpcContextModule<Context> {
 					Err(CallError::InvalidParams(_)) => send_error(id, tx, JsonRpcErrorCode::InvalidParams.into()),
 					Err(CallError::Failed(err)) => {
 						let err = JsonRpcErrorObject {
-							code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE),
+							code: JsonRpcErrorCode::ServerError(CALL_EXECUTION_FAILED_CODE),
 							message: &err.to_string(),
 							data: None,
 						};

--- a/http-server/src/module.rs
+++ b/http-server/src/module.rs
@@ -1,5 +1,10 @@
-use jsonrpsee_types::{traits::RpcMethod, v2::params::RpcParams, Error};
-use jsonrpsee_utils::server::{send_response, Methods};
+use jsonrpsee_types::v2::error::{JsonRpcErrorCode, JsonRpcErrorObject};
+use jsonrpsee_types::{
+	error::{Error, InvalidParams, ServerCallError},
+	traits::RpcMethod,
+	v2::params::RpcParams,
+};
+use jsonrpsee_utils::server::{send_error, send_response, Methods};
 use serde::Serialize;
 use std::sync::Arc;
 
@@ -31,16 +36,17 @@ impl RpcModule {
 	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize,
-		F: RpcMethod<R>,
+		F: RpcMethod<R, InvalidParams>,
 	{
 		self.verify_method_name(method_name)?;
 
 		self.methods.insert(
 			method_name,
 			Box::new(move |id, params, tx, _| {
-				let result = callback(params)?;
-
-				send_response(id, tx, result);
+				match callback(params) {
+					Ok(res) => send_response(id, tx, res),
+					Err(InvalidParams) => send_error(id, tx, JsonRpcErrorCode::InvalidParams.into()),
+				};
 
 				Ok(())
 			}),
@@ -82,7 +88,7 @@ impl<Context> RpcContextModule<Context> {
 	where
 		Context: Send + Sync + 'static,
 		R: Serialize,
-		F: Fn(RpcParams, &Context) -> Result<R, Error> + Send + Sync + 'static,
+		F: Fn(RpcParams, &Context) -> Result<R, ServerCallError> + Send + Sync + 'static,
 	{
 		self.module.verify_method_name(method_name)?;
 
@@ -91,10 +97,16 @@ impl<Context> RpcContextModule<Context> {
 		self.module.methods.insert(
 			method_name,
 			Box::new(move |id, params, tx, _| {
-				let result = callback(params, &*ctx)?;
-
-				send_response(id, tx, result);
-
+				match callback(params, &*ctx) {
+					Ok(res) => send_response(id, tx, res),
+					Err(ServerCallError::InvalidParams(_)) => {
+						send_error(id, tx, JsonRpcErrorCode::InvalidParams.into())
+					}
+					Err(ServerCallError::ContextFailed(err)) => {
+						let err = JsonRpcErrorObject { code: 1.into(), message: &err.to_string(), data: None };
+						send_error(id, tx, err)
+					}
+				};
 				Ok(())
 			}),
 		);

--- a/http-server/src/module.rs
+++ b/http-server/src/module.rs
@@ -103,7 +103,11 @@ impl<Context> RpcContextModule<Context> {
 						send_error(id, tx, JsonRpcErrorCode::InvalidParams.into())
 					}
 					Err(ServerCallError::ContextFailed(err)) => {
-						let err = JsonRpcErrorObject { code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE), message: &err.to_string(), data: None };
+						let err = JsonRpcErrorObject {
+							code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE),
+							message: &err.to_string(),
+							data: None,
+						};
 						send_error(id, tx, err)
 					}
 				};

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -36,7 +36,7 @@ use hyper::{
 	service::{make_service_fn, service_fn},
 	Error as HyperError,
 };
-use jsonrpsee_types::error::{Error, GenericTransportError};
+use jsonrpsee_types::error::{Error, GenericTransportError, InvalidParams};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest};
 use jsonrpsee_types::v2::{error::JsonRpcErrorCode, params::RpcParams};
 use jsonrpsee_utils::{hyper_helpers::read_response_to_body, server::send_error};
@@ -124,7 +124,7 @@ impl Server {
 	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize,
-		F: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static,
+		F: Fn(RpcParams) -> Result<R, InvalidParams> + Send + Sync + 'static,
 	{
 		self.root.register_method(method_name, callback)
 	}

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -2,9 +2,10 @@
 
 use std::net::SocketAddr;
 
-use crate::HttpServerBuilder;
+use crate::{HttpServerBuilder, RpcContextModule};
 use jsonrpsee_test_utils::helpers::*;
-use jsonrpsee_test_utils::types::{Id, StatusCode};
+use jsonrpsee_test_utils::types::{Id, StatusCode, TestContext};
+use jsonrpsee_types::error::ServerCallError;
 use serde_json::Value as JsonValue;
 
 async fn server() -> SocketAddr {
@@ -20,6 +21,35 @@ async fn server() -> SocketAddr {
 		.unwrap();
 	server.register_method("notif", |_| Ok("")).unwrap();
 	tokio::spawn(async move { server.start().await.unwrap() });
+	addr
+}
+
+/// Run server with user provided context.
+pub async fn server_with_context() -> SocketAddr {
+	let mut server = HttpServerBuilder::default().build("127.0.0.1:0".parse().unwrap()).unwrap();
+
+	let ctx = TestContext;
+	let mut rpc_ctx = RpcContextModule::new(ctx);
+
+	rpc_ctx
+		.register_method("should_err", |_p, ctx| {
+			let _ = ctx.err().map_err(|e| ServerCallError::ContextFailed(e.into()))?;
+			Ok("err")
+		})
+		.unwrap();
+
+	rpc_ctx
+		.register_method("should_ok", |_p, ctx| {
+			let _ = ctx.ok().map_err(|e| ServerCallError::ContextFailed(e.into()))?;
+			Ok("ok")
+		})
+		.unwrap();
+
+	let rpc_module = rpc_ctx.into_module();
+	server.register_module(rpc_module).unwrap();
+	let addr = server.local_addr().unwrap();
+
+	tokio::spawn(async { server.start().await });
 	addr
 }
 
@@ -57,6 +87,28 @@ async fn single_method_call_with_faulty_params_returns_err() {
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_params(Id::Num(1)));
+}
+
+#[tokio::test]
+async fn single_method_call_with_faulty_context() {
+	let addr = server_with_context().await;
+	let uri = to_http_uri(addr);
+
+	let req = r#"{"jsonrpc":"2.0","method":"should_err", "params":[],"id":1}"#;
+	let response = http_request(req.into(), uri).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, invalid_context("RPC context failed", Id::Num(1)));
+}
+
+#[tokio::test]
+async fn single_method_call_with_ok_context() {
+	let addr = server_with_context().await;
+	let uri = to_http_uri(addr);
+
+	let req = r#"{"jsonrpc":"2.0","method":"should_ok", "params":[],"id":1}"#;
+	let response = http_request(req.into(), uri).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, ok_response("ok".into(), Id::Num(1)));
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -42,12 +42,21 @@ async fn single_method_call_with_params() {
 	let addr = server().await;
 	let uri = to_http_uri(addr);
 
-	std::thread::sleep(std::time::Duration::from_secs(2));
-
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
+}
+
+#[tokio::test]
+async fn single_method_call_with_faulty_params_returns_err() {
+	let addr = server().await;
+	let uri = to_http_uri(addr);
+
+	let req = r#"{"jsonrpc":"2.0","method":"add", "params":["Invalid"],"id":1}"#;
+	let response = http_request(req.into(), uri).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, invalid_params(Id::Num(1)));
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use crate::{HttpServerBuilder, RpcContextModule};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, StatusCode, TestContext};
-use jsonrpsee_types::error::ServerCallError;
+use jsonrpsee_types::error::CallError;
 use serde_json::Value as JsonValue;
 
 async fn server() -> SocketAddr {
@@ -33,14 +33,14 @@ pub async fn server_with_context() -> SocketAddr {
 
 	rpc_ctx
 		.register_method("should_err", |_p, ctx| {
-			let _ = ctx.err().map_err(|e| ServerCallError::ContextFailed(e.into()))?;
+			let _ = ctx.err().map_err(|e| CallError::Failed(e.into()))?;
 			Ok("err")
 		})
 		.unwrap();
 
 	rpc_ctx
 		.register_method("should_ok", |_p, ctx| {
-			let _ = ctx.ok().map_err(|e| ServerCallError::ContextFailed(e.into()))?;
+			let _ = ctx.ok().map_err(|e| CallError::Failed(e.into()))?;
 			Ok("ok")
 		})
 		.unwrap();

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 async-std = "1.9"
+anyhow = "1"
 futures-channel = "0.3"
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -57,6 +57,14 @@ pub fn invalid_params(id: Id) -> String {
 	)
 }
 
+pub fn invalid_context(msg: &str, id: Id) -> String {
+	format!(
+		r#"{{"jsonrpc":"2.0","error":{{"code":-32000,"message":"{}"}},"id":{}}}"#,
+		msg,
+		serde_json::to_string(&id).unwrap()
+	)
+}
+
 pub fn internal_error(id: Id) -> String {
 	format!(
 		r#"{{"jsonrpc":"2.0","error":{{"code":-32603,"message":"Internal error"}},"id":{}}}"#,

--- a/test-utils/src/types.rs
+++ b/test-utils/src/types.rs
@@ -18,6 +18,17 @@ pub use hyper::{Body, HeaderMap, StatusCode, Uri};
 
 type Error = Box<dyn std::error::Error>;
 
+pub struct TestContext;
+
+impl TestContext {
+	pub fn ok(&self) -> Result<(), anyhow::Error> {
+		Ok(())
+	}
+	pub fn err(&self) -> Result<(), anyhow::Error> {
+		Err(anyhow::anyhow!("RPC context failed"))
+	}
+}
+
 /// Request Id
 #[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -203,14 +203,14 @@ async fn wss_works() {
 #[tokio::test]
 async fn ws_with_non_ascii_url_doesnt_hang_or_panic() {
 	let err = WsClientBuilder::default().build("wss://♥♥♥♥♥♥∀∂").await;
-	assert!(matches!(err, Err(Error::TransportError(_))));
+	assert!(matches!(err, Err(Error::Transport(_))));
 }
 
 #[tokio::test]
 async fn http_with_non_ascii_url_doesnt_hang_or_panic() {
 	let client = HttpClientBuilder::default().build("http://♥♥♥♥♥♥∀∂").unwrap();
 	let err: Result<(), Error> = client.request("system_chain", JsonRpcParams::NoParams).await;
-	assert!(matches!(err, Err(Error::TransportError(_))));
+	assert!(matches!(err, Err(Error::Transport(_))));
 }
 
 #[tokio::test]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/jsonrpsee-types"
 
 [dependencies]
 async-trait = "0.1"
+anyhow = "1"
 beef = "0.5"
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink", "channel"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/jsonrpsee-types"
 
 [dependencies]
 async-trait = "0.1"
-anyhow = "1"
 beef = "0.5"
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink", "channel"] }

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -20,7 +20,7 @@ impl<T: fmt::Display> fmt::Display for Mismatch<T> {
 #[derive(Debug)]
 pub struct InvalidParams;
 
-/// Error that may occur when a server fails to execute provided closure/callback.
+/// Error that may occur when a server fails to execute a call.
 #[derive(Debug, thiserror::Error)]
 pub enum ServerCallError {
 	#[error("Invalid params in the RPC call")]
@@ -40,8 +40,7 @@ impl From<InvalidParams> for ServerCallError {
 /// Error type.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	/// Error that may occur when a server fails to execute provided closure/callback.
-	/// Note, will most likely imply that the JSON-RPC request was valid.
+	/// Error that may occur when a server fails to execute a call.
 	#[error("Server call failed: {0}")]
 	ServerCall(ServerCallError),
 	/// Networking error or error on the low-level protocol layer.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -20,18 +20,18 @@ impl<T: fmt::Display> fmt::Display for Mismatch<T> {
 #[derive(Debug)]
 pub struct InvalidParams;
 
-/// Error that may occur when a server fails to execute a call.
+/// Error that occurs when a call failed.
 #[derive(Debug, thiserror::Error)]
-pub enum ServerCallError {
+pub enum CallError {
 	#[error("Invalid params in the RPC call")]
-	/// InvalidParams,
+	/// Invalid params in the call.
 	InvalidParams(InvalidParams),
-	#[error("Provided context failed: {0}")]
-	/// Provided context/metadata failed.
-	ContextFailed(#[source] Box<dyn std::error::Error + Send + Sync>),
+	#[error("RPC Call failed: {0}")]
+	/// The call failed.
+	Failed(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
-impl From<InvalidParams> for ServerCallError {
+impl From<InvalidParams> for CallError {
 	fn from(params: InvalidParams) -> Self {
 		Self::InvalidParams(params)
 	}
@@ -40,9 +40,9 @@ impl From<InvalidParams> for ServerCallError {
 /// Error type.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	/// Error that may occur when a server fails to execute a call.
+	/// Error that occurs when a call failed.
 	#[error("Server call failed: {0}")]
-	ServerCall(ServerCallError),
+	Call(CallError),
 	/// Networking error or error on the low-level protocol layer.
 	#[error("Networking or low-level protocol error: {0}")]
 	Transport(#[source] Box<dyn std::error::Error + Send + Sync>),
@@ -67,9 +67,6 @@ pub enum Error {
 	/// Invalid request ID.
 	#[error("Invalid request ID")]
 	InvalidRequestId,
-	/// Invalid params in the RPC call.
-	#[error("Invalid params in the RPC call")]
-	InvalidParams,
 	/// A request with the same request ID has already been registered.
 	#[error("A request with the same request ID has already been registered")]
 	DuplicateRequestId,

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -47,6 +47,6 @@ pub trait SubscriptionClient: Client {
 }
 
 /// JSON-RPC server interface for managing method calls.
-pub trait RpcMethod<R>: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static {}
+pub trait RpcMethod<R, E>: Fn(RpcParams) -> Result<R, E> + Send + Sync + 'static {}
 
-impl<R, T> RpcMethod<R> for T where T: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static {}
+impl<R, T, E> RpcMethod<R, E> for T where T: Fn(RpcParams) -> Result<R, E> + Send + Sync + 'static {}

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -80,8 +80,8 @@ pub const INVALID_PARAMS_CODE: i32 = -32602;
 pub const INVALID_REQUEST_CODE: i32 = -32600;
 /// Method not found error code.
 pub const METHOD_NOT_FOUND_CODE: i32 = -32601;
-/// Custom server error when the user provided context failed during a call.
-pub const CONTEXT_EXECUTION_FAILED_CODE: i32 = -32000;
+/// Custom server error when a call failed.
+pub const CALL_EXECUTION_FAILED_CODE: i32 = -32000;
 
 /// Parse error message
 pub const PARSE_ERROR_MSG: &str = "Parse error";

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -96,7 +96,6 @@ pub const METHOD_NOT_FOUND_MSG: &str = "Method not found";
 /// Reserved for implementation-defined server-errors.
 pub const SERVER_ERROR_MSG: &str = "Server error";
 
-
 /// JSONRPC error code
 #[derive(Error, Debug, PartialEq, Copy, Clone)]
 pub enum JsonRpcErrorCode {

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -80,6 +80,8 @@ pub const INVALID_PARAMS_CODE: i32 = -32602;
 pub const INVALID_REQUEST_CODE: i32 = -32600;
 /// Method not found error code.
 pub const METHOD_NOT_FOUND_CODE: i32 = -32601;
+/// Custom server error when the user provided context failed during a call.
+pub const CONTEXT_EXECUTION_FAILED_CODE: i32 = -32000;
 
 /// Parse error message
 pub const PARSE_ERROR_MSG: &str = "Parse error";
@@ -93,6 +95,7 @@ pub const INVALID_REQUEST_MSG: &str = "Invalid request";
 pub const METHOD_NOT_FOUND_MSG: &str = "Method not found";
 /// Reserved for implementation-defined server-errors.
 pub const SERVER_ERROR_MSG: &str = "Server error";
+
 
 /// JSONRPC error code
 #[derive(Error, Debug, PartialEq, Copy, Clone)]

--- a/types/src/v2/mod.rs
+++ b/types/src/v2/mod.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::error::Error;
 use serde::de::DeserializeOwned;
 use serde_json::value::RawValue;
 
@@ -12,11 +12,11 @@ pub mod request;
 pub mod response;
 
 /// Parse request ID from RawValue.
-pub fn parse_request_id<T: DeserializeOwned>(raw: Option<&RawValue>) -> Result<T, crate::Error> {
+pub fn parse_request_id<T: DeserializeOwned>(raw: Option<&RawValue>) -> Result<T, Error> {
 	match raw {
 		None => Err(Error::InvalidRequestId),
 		Some(v) => {
-			let val = serde_json::from_str(v.get()).map_err(Error::ParseError)?;
+			let val = serde_json::from_str(v.get()).map_err(|_| Error::InvalidRequestId)?;
 			Ok(val)
 		}
 	}

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::InvalidParams;
 use alloc::collections::BTreeMap;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
@@ -78,18 +78,18 @@ impl<'a> RpcParams<'a> {
 	}
 
 	/// Attempt to parse all parameters as array or map into type T
-	pub fn parse<T>(self) -> Result<T, Error>
+	pub fn parse<T>(self) -> Result<T, InvalidParams>
 	where
 		T: Deserialize<'a>,
 	{
 		match self.0 {
-			None => Err(Error::InvalidParams),
-			Some(params) => serde_json::from_str(params).map_err(|_| Error::InvalidParams),
+			None => Err(InvalidParams),
+			Some(params) => serde_json::from_str(params).map_err(|_| InvalidParams),
 		}
 	}
 
 	/// Attempt to parse only the first parameter from an array into type T
-	pub fn one<T>(self) -> Result<T, Error>
+	pub fn one<T>(self) -> Result<T, InvalidParams>
 	where
 		T: Deserialize<'a>,
 	{

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 
 [dependencies]
 anyhow = "1.0.34"
-env_logger = "0.8"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.6" }
@@ -28,5 +27,6 @@ tokio-stream = { version = "0.1.1", features = ["net"] }
 tokio-util = { version = "0.6", features = ["compat"] }
 
 [dev-dependencies]
+env_logger = "0.8"
 jsonrpsee-test-utils = { path = "../test-utils" }
 jsonrpsee-ws-client = { path = "../ws-client" }

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 
 [dependencies]
 anyhow = "1.0.34"
+env_logger = "0.8"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.6" }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -37,7 +37,7 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
-use jsonrpsee_types::error::Error;
+use jsonrpsee_types::error::{Error, InvalidParams};
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
 use jsonrpsee_types::v2::params::{JsonRpcNotificationParams, RpcParams, TwoPointZero};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest};
@@ -105,7 +105,7 @@ impl Server {
 	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize,
-		F: Fn(RpcParams) -> Result<R, Error> + Send + Sync + 'static,
+		F: Fn(RpcParams) -> Result<R, InvalidParams> + Send + Sync + 'static,
 	{
 		self.root.register_method(method_name, callback)
 	}

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -1,5 +1,5 @@
 use crate::server::{RpcParams, SubscriptionId, SubscriptionSink};
-use jsonrpsee_types::{error::InvalidParams, traits::RpcMethod, v2::error::CONTEXT_EXECUTION_FAILED_CODE};
+use jsonrpsee_types::{error::InvalidParams, traits::RpcMethod, v2::error::CALL_EXECUTION_FAILED_CODE};
 use jsonrpsee_types::{
 	error::{CallError, Error},
 	v2::error::{JsonRpcErrorCode, JsonRpcErrorObject},
@@ -160,7 +160,7 @@ impl<Context> RpcContextModule<Context> {
 					Err(CallError::InvalidParams(_)) => send_error(id, tx, JsonRpcErrorCode::InvalidParams.into()),
 					Err(CallError::Failed(err)) => {
 						let err = JsonRpcErrorObject {
-							code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE),
+							code: JsonRpcErrorCode::ServerError(CALL_EXECUTION_FAILED_CODE),
 							message: &err.to_string(),
 							data: None,
 						};

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -1,5 +1,5 @@
 use crate::server::{RpcParams, SubscriptionId, SubscriptionSink};
-use jsonrpsee_types::{error::InvalidParams, traits::RpcMethod};
+use jsonrpsee_types::{error::InvalidParams, traits::RpcMethod, v2::error::CONTEXT_EXECUTION_FAILED_CODE};
 use jsonrpsee_types::{
 	error::{Error, ServerCallError},
 	v2::error::{JsonRpcErrorCode, JsonRpcErrorObject},
@@ -161,7 +161,7 @@ impl<Context> RpcContextModule<Context> {
 						send_error(id, tx, JsonRpcErrorCode::InvalidParams.into())
 					}
 					Err(ServerCallError::ContextFailed(err)) => {
-						let err = JsonRpcErrorObject { code: 1.into(), message: &err.to_string(), data: None };
+						let err = JsonRpcErrorObject { code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE), message: &err.to_string(), data: None };
 						send_error(id, tx, err)
 					}
 				};

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -161,7 +161,11 @@ impl<Context> RpcContextModule<Context> {
 						send_error(id, tx, JsonRpcErrorCode::InvalidParams.into())
 					}
 					Err(ServerCallError::ContextFailed(err)) => {
-						let err = JsonRpcErrorObject { code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE), message: &err.to_string(), data: None };
+						let err = JsonRpcErrorObject {
+							code: JsonRpcErrorCode::ServerError(CONTEXT_EXECUTION_FAILED_CODE),
+							message: &err.to_string(),
+							data: None,
+						};
 						send_error(id, tx, err)
 					}
 				};

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -59,6 +59,19 @@ async fn single_method_call_with_params_works() {
 }
 
 #[tokio::test]
+async fn single_method_call_with_faulty_params_returns_err() {
+	let _ = env_logger::try_init();
+	let (server_started_tx, server_started_rx) = oneshot::channel::<SocketAddr>();
+	tokio::spawn(server(server_started_tx));
+	let server_addr = server_started_rx.await.unwrap();
+	let mut client = WebSocketTestClient::new(server_addr).await.unwrap();
+
+	let req = r#"{"jsonrpc":"2.0","method":"add", "params":["Invalid"],"id":1}"#;
+	let response = client.send_request_text(req).await.unwrap();
+	assert_eq!(response, invalid_params(Id::Num(1)));
+}
+
+#[tokio::test]
 async fn single_method_send_binary() {
 	let (server_started_tx, server_started_rx) = oneshot::channel::<SocketAddr>();
 	tokio::spawn(server(server_started_tx));

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -3,7 +3,7 @@
 use crate::{RpcContextModule, WsServer};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
-use jsonrpsee_types::error::{Error, ServerCallError};
+use jsonrpsee_types::error::{CallError, Error};
 use serde_json::Value as JsonValue;
 use std::net::SocketAddr;
 
@@ -40,14 +40,14 @@ pub async fn server_with_context() -> SocketAddr {
 
 	rpc_ctx
 		.register_method("should_err", |_p, ctx| {
-			let _ = ctx.err().map_err(|e| ServerCallError::ContextFailed(e.into()))?;
+			let _ = ctx.err().map_err(|e| CallError::Failed(e.into()))?;
 			Ok("err")
 		})
 		.unwrap();
 
 	rpc_ctx
 		.register_method("should_ok", |_p, ctx| {
-			let _ = ctx.ok().map_err(|e| ServerCallError::ContextFailed(e.into()))?;
+			let _ = ctx.ok().map_err(|e| CallError::Failed(e.into()))?;
 			Ok("ok")
 		})
 		.unwrap();


### PR DESCRIPTION
This PR changes the servers behavior when they get a response with params or user provided context that fails. 
Instead of just terminating the connection we now return back a `JSON-RPC error`.

I changed the `RpcMethod trait` to take an generic Error instead such that we can configure it statically instead of matching of the entire enum when the is just one or two possible errors.

