### PR TITLE
[ws client] RegisterNotification support

### DIFF
--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -90,6 +90,11 @@ pub fn server_subscription_response(result: Value) -> String {
 	)
 }
 
+/// Server originated notification
+pub fn server_notification(method: &str, params: Value) -> String {
+	format!(r#"{{"jsonrpc":"2.0","method":"{}", "params":{} }}"#, method, serde_json::to_string(&params).unwrap())
+}
+
 pub async fn http_request(body: Body, uri: Uri) -> Result<HttpResponse, String> {
 	let client = hyper::Client::new();
 	let r = hyper::Request::post(uri)

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -56,6 +56,18 @@ pub struct SubscriptionMessage {
 	pub send_back: oneshot::Sender<Result<(mpsc::Receiver<JsonValue>, SubscriptionId), Error>>,
 }
 
+/// OnNotification message.
+#[derive(Debug)]
+pub struct OnNotificationMessage {
+	/// Request ID of the subscribe message.
+	pub sub_id: SubscriptionId,
+	pub req_id: u64,
+	/// We return a [`mpsc::Receiver`] that will receive notifications.
+	/// When we get a response from the server about that subscription, we send the result over
+	/// this channel.
+	pub send_back: oneshot::Sender<Result<(mpsc::Receiver<JsonValue>, SubscriptionId), Error>>,
+}
+
 /// Message that the Client can send to the background task.
 #[derive(Debug)]
 pub enum FrontToBack {
@@ -67,6 +79,8 @@ pub enum FrontToBack {
 	Request(RequestMessage),
 	/// Send a subscription request to the server.
 	Subscribe(SubscriptionMessage),
+	/// Create a notification handler subscription
+	OnNotification(OnNotificationMessage),
 	/// When a subscription channel is closed, we send this message to the background
 	/// task to mark it ready for garbage collection.
 	// NOTE: It is not possible to cancel pending subscriptions or pending requests.

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -60,8 +60,9 @@ pub struct SubscriptionMessage {
 #[derive(Debug)]
 pub struct OnNotificationMessage {
 	/// Request ID of the subscribe message.
-	pub sub_id: SubscriptionId,
 	pub req_id: u64,
+	/// SubscriptionId the method name this notification handler is attached to
+	pub sub_id: SubscriptionId,
 	/// We return a [`mpsc::Receiver`] that will receive notifications.
 	/// When we get a response from the server about that subscription, we send the result over
 	/// this channel.

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -23,7 +23,7 @@ pub struct NotificationHandler<Notif> {
 	pub to_back: mpsc::Sender<FrontToBack>,
 	/// Channel from which we receive notifications from the server, as encoded `JsonValue`s.
 	pub notifs_rx: mpsc::Receiver<JsonValue>,
-	/// Method,
+	/// Method Name
 	pub method: String,
 	/// Marker in order to pin the `Notif` parameter.
 	pub marker: PhantomData<Notif>,

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -138,9 +138,8 @@ impl<Notif> Drop for Subscription<Notif> {
 impl<Notif> Drop for NotificationHandler<Notif> {
 	fn drop(&mut self) {
 		// We can't actually guarantee that this goes through. If the background task is busy, then
-		// the channel's buffer will be full, and our unsubscription request will never make it.
-		// However, when a notification arrives, the background task will realize that the channel
-		// to the `Subscription` has been closed, and will perform the unsubscribe.
-		let _ = self.to_back.send(FrontToBack::UnregisterNotification((&self.method).to_owned())).now_or_never();
+		// the channel's buffer will be full, and our unregister request will never make it.
+		let notif_method = std::mem::take(&mut self.method);
+		let _ = self.to_back.send(FrontToBack::UnregisterNotification(notif_method)).now_or_never();
 	}
 }

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -17,6 +17,18 @@ pub struct Subscription<Notif> {
 	pub marker: PhantomData<Notif>,
 }
 
+/// Active NotificationHandler on a Client.
+pub struct NotificationHandler<Notif> {
+	/// Channel to send requests to the background task.
+	pub to_back: mpsc::Sender<FrontToBack>,
+	/// Channel from which we receive notifications from the server, as encoded `JsonValue`s.
+	pub notifs_rx: mpsc::Receiver<JsonValue>,
+	/// Method,
+	pub method: String,
+	/// Marker in order to pin the `Notif` parameter.
+	pub marker: PhantomData<Notif>,
+}
+
 /// Batch request message.
 #[derive(Debug)]
 pub struct BatchMessage {
@@ -59,14 +71,12 @@ pub struct SubscriptionMessage {
 /// OnNotification message.
 #[derive(Debug)]
 pub struct OnNotificationMessage {
-	/// Request ID of the subscribe message.
-	pub req_id: u64,
-	/// SubscriptionId the method name this notification handler is attached to
-	pub sub_id: SubscriptionId,
+	/// Method name this notification handler is attached to
+	pub method: String,
 	/// We return a [`mpsc::Receiver`] that will receive notifications.
 	/// When we get a response from the server about that subscription, we send the result over
 	/// this channel.
-	pub send_back: oneshot::Sender<Result<(mpsc::Receiver<JsonValue>, SubscriptionId), Error>>,
+	pub send_back: oneshot::Sender<Result<(mpsc::Receiver<JsonValue>, String), Error>>,
 }
 
 /// Message that the Client can send to the background task.

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -68,9 +68,9 @@ pub struct SubscriptionMessage {
 	pub send_back: oneshot::Sender<Result<(mpsc::Receiver<JsonValue>, SubscriptionId), Error>>,
 }
 
-/// OnNotification message.
+/// RegisterNotification message.
 #[derive(Debug)]
-pub struct OnNotificationMessage {
+pub struct RegisterNotificationMessage {
 	/// Method name this notification handler is attached to
 	pub method: String,
 	/// We return a [`mpsc::Receiver`] that will receive notifications.
@@ -90,8 +90,8 @@ pub enum FrontToBack {
 	Request(RequestMessage),
 	/// Send a subscription request to the server.
 	Subscribe(SubscriptionMessage),
-	/// Create a notification handler subscription
-	OnNotification(OnNotificationMessage),
+	/// Register a notification handler
+	RegisterNotification(RegisterNotificationMessage),
 	/// When a subscription channel is closed, we send this message to the background
 	/// task to mark it ready for garbage collection.
 	// NOTE: It is not possible to cancel pending subscriptions or pending requests.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -67,6 +67,9 @@ pub enum Error {
 	/// Invalid request ID.
 	#[error("Invalid request ID")]
 	InvalidRequestId,
+	/// Unregistered notification method
+	#[error("Unregistered notification method")]
+	UnregisteredNotification(String),
 	/// A request with the same request ID has already been registered.
 	#[error("A request with the same request ID has already been registered")]
 	DuplicateRequestId,

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -67,7 +67,7 @@ pub enum Error {
 	/// Invalid request ID.
 	#[error("Invalid request ID")]
 	InvalidRequestId,
-	/// Unregistered notification method
+	/// Client received a notification with an unregistered method
 	#[error("Unregistered notification method")]
 	UnregisteredNotification(String),
 	/// A request with the same request ID has already been registered.

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::v2::params::{JsonRpcParams, RpcParams};
-use crate::{Error, Subscription};
+use crate::{Error, NotificationHandler, Subscription};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
@@ -46,7 +46,7 @@ pub trait SubscriptionClient: Client {
 		Notif: DeserializeOwned;
 
 	/// Register a Subscription<Notif> that will listen for incoming JSON-RPC notifications
-	async fn on_notification<'a, Notif>(&self, method: &'a str) -> Result<Subscription<Notif>, Error>
+	async fn register_notification<'a, Notif>(&self, method: &'a str) -> Result<NotificationHandler<Notif>, Error>
 	where
 		Notif: DeserializeOwned;
 }

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -44,6 +44,11 @@ pub trait SubscriptionClient: Client {
 	) -> Result<Subscription<Notif>, Error>
 	where
 		Notif: DeserializeOwned;
+
+	/// Register a Subscription<Notif> that will listen for incoming JSON-RPC notifications
+	async fn on_notification<'a, Notif>(&self, method: &'a str) -> Result<Subscription<Notif>, Error>
+	where
+		Notif: DeserializeOwned;
 }
 
 /// JSON-RPC server interface for managing method calls.

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -45,7 +45,7 @@ pub trait SubscriptionClient: Client {
 	where
 		Notif: DeserializeOwned;
 
-	/// Register a Subscription<Notif> that will listen for incoming JSON-RPC notifications
+	/// Register a NotificationHandler<Notif> that will listen for incoming JSON-RPC notifications
 	async fn register_notification<'a, Notif>(&self, method: &'a str) -> Result<NotificationHandler<Notif>, Error>
 	where
 		Notif: DeserializeOwned;

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -1,4 +1,5 @@
 use crate::v2::params::{JsonRpcNotificationParamsAlloc, TwoPointZero};
+use beef::Cow;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
@@ -23,11 +24,13 @@ pub struct JsonRpcSubscriptionResponse<T> {
 	pub params: JsonRpcNotificationParamsAlloc<T>,
 }
 
-///// JSON-RPC notification response.
-//#[derive(Deserialize, Debug)]
-//pub struct JsonRpcNotifResponse<T> {
-//	/// JSON-RPC version.
-//	pub jsonrpc: TwoPointZero,
-//	/// Params.
-//	pub params: JsonRpcNotificationParamsAlloc<T>,
-//}
+/// JSON-RPC notification response.
+#[derive(Deserialize, Debug)]
+pub struct JsonRpcNotifResponse<'a, T> {
+	/// JSON-RPC version.
+	pub jsonrpc: TwoPointZero,
+	/// Method
+	pub method: &'a str,
+	/// Params.
+	pub params: T,
+}

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -1,5 +1,4 @@
 use crate::v2::params::{JsonRpcNotificationParamsAlloc, TwoPointZero};
-use beef::Cow;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -14,11 +14,20 @@ pub struct JsonRpcResponse<'a, T> {
 	pub id: Option<&'a RawValue>,
 }
 
-/// JSON-RPC notification response.
+/// JSON-RPC subscription response.
 #[derive(Deserialize, Debug)]
-pub struct JsonRpcNotifResponse<T> {
+pub struct JsonRpcSubscriptionResponse<T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Params.
 	pub params: JsonRpcNotificationParamsAlloc<T>,
 }
+
+///// JSON-RPC notification response.
+//#[derive(Deserialize, Debug)]
+//pub struct JsonRpcNotifResponse<T> {
+//	/// JSON-RPC version.
+//	pub jsonrpc: TwoPointZero,
+//	/// Params.
+//	pub params: JsonRpcNotificationParamsAlloc<T>,
+//}

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -596,7 +596,7 @@ async fn background_task(
 				}
 			}
 
-			// User dopped the notificationHandler for this method
+			// User dropped the notificationHandler for this method
 			Either::Left((Some(FrontToBack::UnregisterNotification(method)), _)) => {
 				log::trace!("[backend] unregistering notification handler: {:?}", method);
 				let _ = manager.remove_notification_handler(method);

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -595,18 +595,16 @@ async fn background_task(
 				let (subscribe_tx, subscribe_rx) = mpsc::channel(max_notifs_per_subscription);
 
 				if manager.insert_notification_handler(&reg.method, subscribe_tx).is_ok() {
-					reg.send_back
-						.send(Ok((subscribe_rx, reg.method)))
-						.expect("error sending response for notification handler");
+					let _ = reg.send_back.send(Ok((subscribe_rx, reg.method)));
 				} else {
 					let _ = reg.send_back.send(Err(Error::MethodAlreadyRegistered(reg.method)));
 				}
 			}
 
-			// User called `on_notification` on the front-end.
+			// User dopped the notificationHandler for this method
 			Either::Left((Some(FrontToBack::UnregisterNotification(method)), _)) => {
 				log::trace!("[backend] unregistering notification handler: {:?}", method);
-				let _ = manager.remove_notification_handler(&method);
+				let _ = manager.remove_notification_handler(method);
 			}
 			Either::Right((Some(Ok(raw)), _)) => {
 				// Single response to a request.

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -486,12 +486,7 @@ impl SubscriptionClient for WsClient {
 			Err(_) => return Err(self.read_error_from_backend().await),
 		};
 
-		Ok(NotificationHandler {
-			to_back: self.to_back.clone(),
-			notifs_rx,
-			marker: PhantomData,
-			method: method.to_owned(),
-		})
+		Ok(NotificationHandler { to_back: self.to_back.clone(), notifs_rx, marker: PhantomData, method })
 	}
 }
 
@@ -632,10 +627,10 @@ async fn background_task(
 				else if let Ok(notif) = serde_json::from_slice::<JsonRpcNotifResponse<_>>(&raw) {
 					log::debug!("[backend]: recv notification {:?}", notif);
 					match process_notification(&mut manager, notif) {
-						Ok(_) => return,
+						Ok(_) => {}
 						Err(err) => {
 							let _ = front_error.send(err);
-							return;
+							break;
 						}
 					}
 				}

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -626,13 +626,7 @@ async fn background_task(
 				// Incoming Notification
 				else if let Ok(notif) = serde_json::from_slice::<JsonRpcNotifResponse<_>>(&raw) {
 					log::debug!("[backend]: recv notification {:?}", notif);
-					match process_notification(&mut manager, notif) {
-						Ok(_) => {}
-						Err(err) => {
-							let _ = front_error.send(err);
-							break;
-						}
-					}
+					let _ = process_notification(&mut manager, notif);
 				}
 				// Batch response.
 				else if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcResponse<_>>>(&raw) {

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -589,7 +589,7 @@ async fn background_task(
 				}
 			}
 
-			// User called `on_notification` on the front-end.
+			// User called `register_notification` on the front-end.
 			Either::Left((Some(FrontToBack::RegisterNotification(reg)), _)) => {
 				log::trace!("[backend] registering notification handler: {:?}", reg.method);
 				let (subscribe_tx, subscribe_rx) = mpsc::channel(max_notifs_per_subscription);
@@ -601,6 +601,12 @@ async fn background_task(
 				} else {
 					let _ = reg.send_back.send(Err(Error::MethodAlreadyRegistered(reg.method)));
 				}
+			}
+
+			// User called `on_notification` on the front-end.
+			Either::Left((Some(FrontToBack::UnregisterNotification(method)), _)) => {
+				log::trace!("[backend] unregistering notification handler: {:?}", method);
+				let _ = manager.remove_notification_handler(&method);
 			}
 			Either::Right((Some(Ok(raw)), _)) => {
 				// Single response to a request.

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -33,7 +33,7 @@ use crate::transport::{parse_url, Receiver as WsReceiver, Sender as WsSender, Ws
 use crate::v2::error::JsonRpcErrorAlloc;
 use crate::v2::params::{Id, JsonRpcParams};
 use crate::v2::request::{JsonRpcCallSer, JsonRpcNotificationSer};
-use crate::v2::response::{JsonRpcNotifResponse, JsonRpcResponse};
+use crate::v2::response::{JsonRpcResponse, JsonRpcSubscriptionResponse};
 use crate::TEN_MB_SIZE_BYTES;
 use crate::{
 	manager::RequestManager, BatchMessage, Error, FrontToBack, RequestMessage, Subscription, SubscriptionMessage,
@@ -566,7 +566,7 @@ async fn background_task(
 					}
 				}
 				// Subscription response.
-				else if let Ok(notif) = serde_json::from_slice::<JsonRpcNotifResponse<_>>(&raw) {
+				else if let Ok(notif) = serde_json::from_slice::<JsonRpcSubscriptionResponse<_>>(&raw) {
 					log::debug!("[backend]: recv subscription {:?}", notif);
 					if let Err(Some(unsub)) = process_subscription_response(&mut manager, notif) {
 						let _ = stop_subscription(&mut sender, &mut manager, unsub).await;

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -76,7 +76,6 @@ pub fn process_subscription_response(
 ///
 /// Returns Ok() if the response was successfully handled
 /// Returns Err() if there was no handler for the method
-
 pub fn process_notification(manager: &mut RequestManager, notif: JsonRpcNotifResponse<JsonValue>) -> Result<(), Error> {
 	match manager.as_notification_handler_mut(&notif.method.to_owned()) {
 		Some(send_back_sink) => match send_back_sink.try_send(notif.params) {

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -84,7 +84,7 @@ pub fn process_notification(manager: &mut RequestManager, notif: JsonRpcNotifRes
 		None => return Err(Error::InvalidSubscriptionId),
 	};
 
-	match manager.as_subscription_mut(&request_id) {
+	match manager.as_notification_handler_mut(&request_id) {
 		Some(send_back_sink) => match send_back_sink.try_send(notif.params) {
 			Ok(()) => Ok(()),
 			Err(err) => {

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -4,7 +4,7 @@ use futures::channel::mpsc;
 use jsonrpsee_types::v2::params::{Id, JsonRpcParams, SubscriptionId};
 use jsonrpsee_types::v2::parse_request_id;
 use jsonrpsee_types::v2::request::JsonRpcCallSer;
-use jsonrpsee_types::v2::response::{JsonRpcResponse, JsonRpcSubscriptionResponse};
+use jsonrpsee_types::v2::response::{JsonRpcNotifResponse, JsonRpcResponse, JsonRpcSubscriptionResponse};
 use jsonrpsee_types::{v2::error::JsonRpcErrorAlloc, Error, RequestMessage};
 use serde_json::Value as JsonValue;
 
@@ -68,6 +68,33 @@ pub fn process_subscription_response(
 		None => {
 			log::error!("Subscription ID: {:?} not an active subscription", sub_id);
 			Err(None)
+		}
+	}
+}
+
+/// Attempts to process an incoming notification
+///
+/// Returns Ok() if the response was successfully handled
+/// Returns Err() if there was no handler for the method
+
+pub fn process_notification(manager: &mut RequestManager, notif: JsonRpcNotifResponse<JsonValue>) -> Result<(), Error> {
+	let sub_id: SubscriptionId = SubscriptionId::Str(notif.method.to_owned());
+	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
+		Some(request_id) => request_id,
+		None => return Err(Error::InvalidSubscriptionId),
+	};
+
+	match manager.as_subscription_mut(&request_id) {
+		Some(send_back_sink) => match send_back_sink.try_send(notif.params) {
+			Ok(()) => Ok(()),
+			Err(err) => {
+				log::error!("Error sending notification subscription {:?} error: {:?}", sub_id, err);
+				Err(Error::Internal(err.into_send_error()))
+			}
+		},
+		None => {
+			log::error!("Subscription ID: {:?} not an active subscription", sub_id);
+			Err(Error::InvalidSubscriptionId)
 		}
 	}
 }

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -4,7 +4,7 @@ use futures::channel::mpsc;
 use jsonrpsee_types::v2::params::{Id, JsonRpcParams, SubscriptionId};
 use jsonrpsee_types::v2::parse_request_id;
 use jsonrpsee_types::v2::request::JsonRpcCallSer;
-use jsonrpsee_types::v2::response::{JsonRpcNotifResponse, JsonRpcResponse};
+use jsonrpsee_types::v2::response::{JsonRpcResponse, JsonRpcSubscriptionResponse};
 use jsonrpsee_types::{v2::error::JsonRpcErrorAlloc, Error, RequestMessage};
 use serde_json::Value as JsonValue;
 
@@ -47,7 +47,7 @@ pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<JsonRpcResp
 /// Returns `Err(Some(msg))` if the subscription was full.
 pub fn process_subscription_response(
 	manager: &mut RequestManager,
-	notif: JsonRpcNotifResponse<JsonValue>,
+	notif: JsonRpcSubscriptionResponse<JsonValue>,
 ) -> Result<(), Option<RequestMessage>> {
 	let sub_id = notif.params.subscription;
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -77,7 +77,7 @@ pub fn process_subscription_response(
 /// Returns Ok() if the response was successfully handled
 /// Returns Err() if there was no handler for the method
 pub fn process_notification(manager: &mut RequestManager, notif: JsonRpcNotifResponse<JsonValue>) -> Result<(), Error> {
-	match manager.as_notification_handler_mut(&notif.method.to_owned()) {
+	match manager.as_notification_handler_mut(notif.method.to_owned()) {
 		Some(send_back_sink) => match send_back_sink.try_send(notif.params) {
 			Ok(()) => Ok(()),
 			Err(err) => {

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -81,7 +81,8 @@ pub fn process_notification(manager: &mut RequestManager, notif: JsonRpcNotifRes
 		Some(send_back_sink) => match send_back_sink.try_send(notif.params) {
 			Ok(()) => Ok(()),
 			Err(err) => {
-				log::error!("Error sending notification subscription {:?} error: {:?}", notif.method, err);
+				log::error!("Error sending notification, dropping handler for {:?} error: {:?}", notif.method, err);
+				let _ = manager.remove_notification_handler(notif.method.to_owned());
 				Err(Error::Internal(err.into_send_error()))
 			}
 		},

--- a/ws-client/src/manager.rs
+++ b/ws-client/src/manager.rs
@@ -148,13 +148,22 @@ impl RequestManager {
 		}
 	}
 
-	/// Inserts a subscription for handling incoming notifications
+	/// Inserts a handler for incoming notifications
 	pub fn insert_notification_handler(&mut self, method: &str, send_back: SubscriptionSink) -> Result<(), Error> {
 		if let Entry::Vacant(handle) = self.notification_handlers.entry(method.to_owned()) {
 			handle.insert(send_back);
 			Ok(())
 		} else {
 			Err(Error::MethodAlreadyRegistered(method.to_owned()))
+		}
+	}
+
+	/// Removes a notification handler
+	pub fn remove_notification_handler(&mut self, method: &str) -> Result<(), Error> {
+		if let Some(_) = self.notification_handlers.remove(&method.to_owned()) {
+			Ok(())
+		} else {
+			Err(Error::UnregisteredNotification(method.to_owned()))
 		}
 	}
 

--- a/ws-client/src/manager.rs
+++ b/ws-client/src/manager.rs
@@ -263,9 +263,9 @@ impl RequestManager {
 
 	/// Get a mutable reference to underlying `Sink` in order to send incmoing notifications to the subscription.
 	///
-	/// Returns `Some` if the `request_id` was registered as a NotificationHandler otherwise `None`.
-	pub fn as_notification_handler_mut(&mut self, method: &str) -> Option<&mut SubscriptionSink> {
-		self.notification_handlers.get_mut(&method.to_owned())
+	/// Returns `Some` if the `method` was registered as a NotificationHandler otherwise `None`.
+	pub fn as_notification_handler_mut(&mut self, method: String) -> Option<&mut SubscriptionSink> {
+		self.notification_handlers.get_mut(&method)
 	}
 
 	/// Reverse lookup to get the request ID for a subscription ID.

--- a/ws-client/src/manager.rs
+++ b/ws-client/src/manager.rs
@@ -16,6 +16,7 @@ enum Kind {
 	PendingMethodCall(PendingCallOneshot),
 	PendingSubscription((RequestId, PendingSubscriptionOneshot, UnsubscribeMethod)),
 	Subscription((RequestId, SubscriptionSink, UnsubscribeMethod)),
+	Notificationhandler(SubscriptionSink),
 }
 
 #[derive(Debug)]
@@ -143,6 +144,24 @@ impl RequestManager {
 			Ok(())
 		} else {
 			Err(send_back)
+		}
+	}
+
+	/// Inserts a subscription for handling incoming notifications
+	pub fn insert_notification_handler(
+		&mut self,
+		sub_req_id: RequestId,
+		subscription_id: SubscriptionId,
+		send_back: SubscriptionSink,
+	) -> Result<(), Error> {
+		if let (Entry::Vacant(request), Entry::Vacant(subscription)) =
+			(self.requests.entry(sub_req_id), self.subscriptions.entry(subscription_id))
+		{
+			request.insert(Kind::Notificationhandler(send_back));
+			subscription.insert(sub_req_id);
+			Ok(())
+		} else {
+			Err(Error::InvalidRequestId)
 		}
 	}
 

--- a/ws-client/src/manager.rs
+++ b/ws-client/src/manager.rs
@@ -265,11 +265,7 @@ impl RequestManager {
 	///
 	/// Returns `Some` if the `request_id` was registered as a NotificationHandler otherwise `None`.
 	pub fn as_notification_handler_mut(&mut self, method: &str) -> Option<&mut SubscriptionSink> {
-		if let Some(sink) = self.notification_handlers.get_mut(&method.to_owned()) {
-			Some(sink)
-		} else {
-			None
-		}
+		self.notification_handlers.get_mut(&method.to_owned())
 	}
 
 	/// Reverse lookup to get the request ID for a subscription ID.

--- a/ws-client/src/manager.rs
+++ b/ws-client/src/manager.rs
@@ -159,8 +159,8 @@ impl RequestManager {
 	}
 
 	/// Removes a notification handler
-	pub fn remove_notification_handler(&mut self, method: &str) -> Result<(), Error> {
-		if let Some(_) = self.notification_handlers.remove(&method.to_owned()) {
+	pub fn remove_notification_handler(&mut self, method: String) -> Result<(), Error> {
+		if let Some(_) = self.notification_handlers.remove(&method) {
 			Ok(())
 		} else {
 			Err(Error::UnregisteredNotification(method.to_owned()))


### PR DESCRIPTION
This adds the ability to register a NotificationHandler\<T\> for a method name, allowing jsonrpsee ws clients to support server originated notifications!  #301 

Usage:

```
let mut offers: NotificationHandler<SessionDescription> = client.register_notification("offer").await?;
```

This is my first PR on jsonrpsee so let me know what you think :). I think the error cases could use a second glance by someone more experienced on the project but it does work ATM.


@niklasad1 @dvdplm 

fixes #301 