### PR TITLE
[utils]: add futures util feature to server

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = { version = "1", features = ["raw_value"], optional = true }
 default = []
 hyper_13 = ["hyper13", "futures-util", "jsonrpsee-types"]
 hyper_14 = ["hyper14", "futures-util", "jsonrpsee-types"]
-server = ["anyhow", "futures-channel", "jsonrpsee-types", "rustc-hash", "serde", "serde_json", "log"]
+server = ["anyhow", "futures-channel", "futures-util", "jsonrpsee-types", "rustc-hash", "serde", "serde_json", "log"]
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
After refactoring in #300  a feature was missed which this fixes

Basically, in the servers `futures-util` is direct dependency which circumvents this but if a single crate directly uses the server feature it doesn't compile.
