### PR TITLE
Change order of type params to register_method

### DIFF
--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -103,7 +103,7 @@ impl Server {
 	}
 
 	/// Register a new RPC method, which responds with a given callback.
-	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
+	pub fn register_method<R, F>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize,
 		F: Fn(RpcParams) -> Result<R, CallError> + Send + Sync + 'static,

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -35,7 +35,7 @@ impl RpcModule {
 	}
 
 	/// Register a new RPC method, which responds with a given callback.
-	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
+	pub fn register_method<R, F>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize,
 		F: RpcMethod<R, CallError>,
@@ -151,7 +151,7 @@ impl<Context> RpcContextModule<Context> {
 	}
 
 	/// Register a new RPC method, which responds with a given callback.
-	pub fn register_method<F, R>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
+	pub fn register_method<R, F>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		Context: Send + Sync + 'static,
 		R: Serialize,

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -5,6 +5,7 @@ use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
 use jsonrpsee_types::error::{CallError, Error};
 use serde_json::Value as JsonValue;
+use serde::Serialize;
 use std::fmt;
 use std::net::SocketAddr;
 
@@ -45,6 +46,19 @@ pub async fn server() -> SocketAddr {
 			Ok("Yawn!")
 		})
 		.unwrap();
+
+	#[derive(Serialize)]
+	struct A { a: u8 }
+	#[derive(Serialize)]
+	enum B {
+		One(A),
+		Two,
+	}
+
+	server.register_method::<B, _>("advanced_params", |params| {
+		let a = params.one()?;
+		Ok(B::One(A { a }))
+	}).unwrap();
 	let addr = server.local_addr().unwrap();
 
 	tokio::spawn(async { server.start().await });

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -4,7 +4,6 @@ use crate::{RpcContextModule, WsServer};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
 use jsonrpsee_types::error::{CallError, Error};
-use serde::Serialize;
 use serde_json::Value as JsonValue;
 use std::fmt;
 use std::net::SocketAddr;

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -4,8 +4,8 @@ use crate::{RpcContextModule, WsServer};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
 use jsonrpsee_types::error::{CallError, Error};
-use serde_json::Value as JsonValue;
 use serde::Serialize;
+use serde_json::Value as JsonValue;
 use std::fmt;
 use std::net::SocketAddr;
 
@@ -47,18 +47,6 @@ pub async fn server() -> SocketAddr {
 		})
 		.unwrap();
 
-	#[derive(Serialize)]
-	struct A { a: u8 }
-	#[derive(Serialize)]
-	enum B {
-		One(A),
-		Two,
-	}
-
-	server.register_method::<B, _>("advanced_params", |params| {
-		let a = params.one()?;
-		Ok(B::One(A { a }))
-	}).unwrap();
 	let addr = server.local_addr().unwrap();
 
 	tokio::spawn(async { server.start().await });


### PR DESCRIPTION
I think it reads a bit better with the return type being the first type param and the second anonymous, i.e. `register_method::<MyReturnType, _>(… …)` than `register_method::<_, MyReturnType>(… …)`. ﻿
