### PR TITLE
[ws server]: SubscriptionSink: different API for register subscription with or without params.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "0.8"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 log = "0.4"
 tokio = { version = "1", features = ["full"] }
+serde_json = "1"
 
 [[example]]
 name = "http"
@@ -24,6 +25,10 @@ path = "ws.rs"
 [[example]]
 name = "ws_subscription"
 path = "ws_subscription.rs"
+
+[[example]]
+name = "ws_sub_with_params"
+path = "ws_sub_with_params.rs"
 
 [[example]]
 name = "proc_macro"

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -1,0 +1,86 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use jsonrpsee::{
+	ws_client::{traits::SubscriptionClient, v2::params::JsonRpcParams, WsClientBuilder},
+	ws_server::WsServer,
+};
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	env_logger::init();
+	let addr = run_server().await?;
+	let url = format!("ws://{}", addr);
+
+	let client = WsClientBuilder::default().build(&url).await?;
+
+	// Subscription with a single parameter
+	let params = JsonRpcParams::Array(vec![3.into()]);
+	let mut sub_params_one = client.subscribe::<Option<char>>("sub_one_param", params, "unsub_one_param").await?;
+	println!("subscription with one param: {:?}", sub_params_one.next().await);
+
+	// Subscription with multiple parameters
+	let params = JsonRpcParams::Array(vec![2.into(), 5.into()]);
+	let mut sub_params_two = client.subscribe::<String>("sub_params_two", params, "unsub_params_two").await?;
+	println!("subscription with two params: {:?}", sub_params_two.next().await);
+
+	Ok(())
+}
+
+async fn run_server() -> anyhow::Result<SocketAddr> {
+	const LETTERS: &'static str = "abcdefghijklmnopqrstuvxyz";
+	let mut server = WsServer::new("127.0.0.1:0").await?;
+	let one_param = server.register_subscription_with_params("sub_one_param", "unsub_one_param").unwrap();
+	let two_params = server.register_subscription_with_params("sub_params_two", "unsub_params_two").unwrap();
+
+	std::thread::spawn(move || loop {
+		one_param.next().and_then(|inner_sub_sink_params| {
+			let idx = *inner_sub_sink_params.params();
+			let result = LETTERS.chars().nth(idx);
+			let _ = inner_sub_sink_params.send(&result);
+			// TODO: why do I need to return something here? Returning "".into() works just as well...
+			result
+		});
+		std::thread::sleep(std::time::Duration::from_millis(50));
+	});
+
+	std::thread::spawn(move || loop {
+		two_params.next().and_then(|inner_sub_sink_params| {
+			let params: &Vec<usize> = inner_sub_sink_params.params();
+			// Validate your params here: check len, check > 0 etc
+			let result = LETTERS[params[0]..params[1]].to_string();
+			let _ = inner_sub_sink_params.send(&result);
+			// TODO: why do I need to return something here? Returning `Option::<char>::None` works just as well...
+			Some(result)
+		});
+		std::thread::sleep(std::time::Duration::from_millis(100));
+	});
+
+	let addr = server.local_addr();
+	tokio::spawn(async move { server.start().await });
+	addr
+}

--- a/ws-server/src/lib.rs
+++ b/ws-server/src/lib.rs
@@ -32,4 +32,6 @@ mod server;
 mod tests;
 
 pub use jsonrpsee_types::error::Error;
-pub use server::{RpcContextModule, RpcModule, Server as WsServer, SubscriptionSink};
+pub use server::{
+	InnerSubSinkParams, RpcContextModule, RpcModule, Server as WsServer, SubscriptionSink, SubscriptionSinkParams,
+};

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -29,7 +29,7 @@ use futures_util::io::{BufReader, BufWriter};
 use futures_util::stream::StreamExt;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::value::to_raw_value;
 use soketto::handshake::{server::Response, Server as SokettoServer};
 use std::{net::SocketAddr, sync::Arc};
@@ -120,7 +120,7 @@ impl<P> InnerSubSinkParams<P> {
 }
 
 pub struct SubscriptionSinkParams<P> {
-	inner: Arc<Mutex<FxHashMap<SubscriptionId, InnerSubSinkParams<P>>>>
+	inner: Arc<Mutex<FxHashMap<SubscriptionId, InnerSubSinkParams<P>>>>,
 }
 
 impl<P> SubscriptionSinkParams<P> {

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -142,7 +142,8 @@ impl RpcModule {
 			self.methods.insert(
 				subscribe_method_name,
 				Box::new(move |id, params, tx, _| {
-					let params = params.parse().map_err(|_| CallError::InvalidParams)?;
+					log::info!("id: {:?}, params: {:?}", id, params);
+					let params = params.one().map_err(|_| CallError::InvalidParams)?;
 					let sub_id = {
 						const JS_NUM_MASK: SubscriptionId = !0 >> 11;
 

--- a/ws-server/src/server/module.rs
+++ b/ws-server/src/server/module.rs
@@ -141,9 +141,9 @@ impl RpcModule {
 			let subscribers = subscribers.clone();
 			self.methods.insert(
 				subscribe_method_name,
-				Box::new(move |id, params, tx, _| {
-					log::info!("id: {:?}, params: {:?}", id, params);
-					let params = params.one().map_err(|_| CallError::InvalidParams)?;
+				Box::new(move |id, params: RpcParams, tx, _| {
+					log::debug!("subscription to '{}', id: {:?}, params: {:?}", subscribe_method_name, id, params);
+					let params = params.parse().or_else(|_| params.one().map_err(|_| CallError::InvalidParams))?;
 					let sub_id = {
 						const JS_NUM_MASK: SubscriptionId = !0 >> 11;
 


### PR DESCRIPTION
Example design to address to that subscriptions on the server-side needs to expose an API to get params in "subscription request"

This design provides different APIs to register subscriptions with or without params.
Such that if the incorrect param type is received in the request, nothing will be transmitted to the subscriber.

Warning, very boiler-plateyyy

 