### PR TITLE
[types]: ID type instead of serde_json::RawValue

### DIFF
--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::v2::{
-	error::{JsonRpcErrorCode, JsonRpcErrorObjectAlloc},
+	error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject},
 	params::JsonRpcParams,
 };
 use crate::{traits::Client, Error, HttpClientBuilder, JsonValue};
@@ -107,9 +107,14 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 	client.request("say_hello", JsonRpcParams::NoParams).await
 }
 
-fn assert_jsonrpc_error_response(error: Error, code: JsonRpcErrorObjectAlloc) {
-	match &error {
-		Error::Request(e) => assert_eq!(e.error, code),
-		e => panic!("Expected error: \"{}\", got: {:?}", error, e),
+fn assert_jsonrpc_error_response(err: Error, exp: JsonRpcErrorObject) {
+	match &err {
+		Error::Request(e) => {
+			let this: JsonRpcError = serde_json::from_str(&e).unwrap();
+			// NOTE: `RawValue` doesn't implement PartialEq.
+			assert_eq!(this.error.code, exp.code);
+			assert_eq!(this.error.message, exp.message);
+		}
+		e => panic!("Expected error: \"{}\", got: {:?}", err, e),
 	};
 }

--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -111,9 +111,7 @@ fn assert_jsonrpc_error_response(err: Error, exp: JsonRpcErrorObject) {
 	match &err {
 		Error::Request(e) => {
 			let this: JsonRpcError = serde_json::from_str(&e).unwrap();
-			// NOTE: `RawValue` doesn't implement PartialEq.
-			assert_eq!(this.error.code, exp.code);
-			assert_eq!(this.error.message, exp.message);
+			assert_eq!(this.error, exp);
 		}
 		e => panic!("Expected error: \"{}\", got: {:?}", err, e),
 	};

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -36,7 +36,7 @@ use hyper::{
 use jsonrpsee_types::error::{CallError, Error, GenericTransportError};
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
 use jsonrpsee_types::v2::params::{Id, RpcParams};
-use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest, JsonRpcNotification};
+use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest};
 use jsonrpsee_utils::hyper_helpers::read_response_to_body;
 use jsonrpsee_utils::server::helpers::{collect_batch_response, send_error};
 use jsonrpsee_utils::server::rpc_module::{MethodSink, RpcModule};

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -170,10 +170,10 @@ impl Server {
 									err,
 									req.id
 								);
-								send_error(req.id.clone(), &tx, JsonRpcErrorCode::ServerError(-1).into());
+								send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
 							}
 						} else {
-							send_error(req.id.clone(), &tx, JsonRpcErrorCode::MethodNotFound.into());
+							send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 						}
 					};
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -163,17 +163,17 @@ impl Server {
 						if let Some(method) = methods.get(&*req.method) {
 							let params = RpcParams::new(req.params.map(|params| params.get()));
 							// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
-							if let Err(err) = (method)(req.id.to_owned(), params, &tx, 0) {
+							if let Err(err) = (method)(req.id.clone(), params, &tx, 0) {
 								log::error!(
 									"execution of method call '{}' failed: {:?}, request id={:?}",
 									req.method,
 									err,
 									req.id
 								);
-								send_error(req.id.to_owned(), &tx, JsonRpcErrorCode::ServerError(-1).into());
+								send_error(req.id.clone(), &tx, JsonRpcErrorCode::ServerError(-1).into());
 							}
 						} else {
-							send_error(req.id.to_owned(), &tx, JsonRpcErrorCode::MethodNotFound.into());
+							send_error(req.id.clone(), &tx, JsonRpcErrorCode::MethodNotFound.into());
 						}
 					};
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -37,7 +37,7 @@ use jsonrpsee_types::error::{CallError, Error, GenericTransportError};
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
 use jsonrpsee_types::v2::params::{Id, RpcParams};
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest, JsonRpcNotification};
-use jsonrpsee_utils::{hyper_helpers::read_response_to_body, server::helpers::send_response};
+use jsonrpsee_utils::hyper_helpers::read_response_to_body;
 use jsonrpsee_utils::server::helpers::{collect_batch_response, send_error};
 use jsonrpsee_utils::server::rpc_module::{MethodSink, RpcModule};
 

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -83,7 +83,7 @@ async fn invalid_single_method_call() {
 	let req = r#"{"jsonrpc":"2.0","method":1, "params": "bar"}"#;
 	let response = http_request(req.into(), uri.clone()).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	assert_eq!(response.body, invalid_request(Id::Null));
+	assert_eq!(response.body, parse_error(Id::Null));
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -169,14 +169,11 @@ async fn batched_notifications() {
 	let addr = server().await;
 	let uri = to_http_uri(addr);
 
-	let req = r#"[
-        {"jsonrpc": "2.0", "method": "notif", "params": [1,2,4]},
-        {"jsonrpc": "2.0", "method": "notif", "params": [7]}
-	]"#;
+	let req = r#"[{"jsonrpc": "2.0", "method": "notif", "params": [1,2,4]},{"jsonrpc": "2.0", "method": "notif", "params": [7]}]"#;
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	// Note: this is *not* according to spec. Response should be the empty string, `""`.
-	assert_eq!(response.body, r#"[{"jsonrpc":"2.0","result":"","id":null},{"jsonrpc":"2.0","result":"","id":null}]"#);
+	// Note: on HTTP we ack the notification with an empty response.
+	assert_eq!(response.body, "");
 }
 
 #[tokio::test]
@@ -247,4 +244,15 @@ async fn invalid_request_object() {
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_request(Id::Num(1)));
+}
+
+#[tokio::test]
+async fn notif_works() {
+	let addr = server().await;
+	let uri = to_http_uri(addr);
+
+	let req = r#"{"jsonrpc":"2.0","method":"bar"}"#;
+	let response = http_request(req.into(), uri).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, "");
 }

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -172,7 +172,7 @@ async fn batched_notifications() {
 	let req = r#"[{"jsonrpc": "2.0", "method": "notif", "params": [1,2,4]},{"jsonrpc": "2.0", "method": "notif", "params": [7]}]"#;
 	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	// Note: on HTTP we ack the notification with an empty response.
+	// Note: on HTTP acknowledge the notification with an empty response.
 	assert_eq!(response.body, "");
 }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/jsonrpsee-types"
 
 [dependencies]
 async-trait = "0.1"
-beef = "0.5"
+beef = { version = "0.5", features = ["impl_serde"] }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink", "channel"] }
 log = { version = "0.4", default-features = false }

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -1,6 +1,4 @@
-use crate::v2::error::JsonRpcErrorAlloc;
 use std::fmt;
-
 /// Convenience type for displaying errors.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Mismatch<T> {
@@ -48,7 +46,7 @@ pub enum Error {
 	Transport(#[source] Box<dyn std::error::Error + Send + Sync>),
 	/// JSON-RPC request error.
 	#[error("JSON-RPC request error: {0:?}")]
-	Request(#[source] JsonRpcErrorAlloc),
+	Request(String),
 	/// Frontend/backend channel error.
 	#[error("Frontend/backend channel error: {0}")]
 	Internal(#[source] futures_channel::mpsc::SendError),

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -14,10 +14,6 @@ impl<T: fmt::Display> fmt::Display for Mismatch<T> {
 	}
 }
 
-/// Invalid params.
-#[derive(Debug)]
-pub struct InvalidParams;
-
 /// Error that occurs when a call failed.
 #[derive(Debug, thiserror::Error)]
 pub enum CallError {
@@ -27,12 +23,6 @@ pub enum CallError {
 	#[error("RPC Call failed: {0}")]
 	/// The call failed.
 	Failed(#[source] Box<dyn std::error::Error + Send + Sync>),
-}
-
-impl From<InvalidParams> for CallError {
-	fn from(_params: InvalidParams) -> Self {
-		Self::InvalidParams
-	}
 }
 
 /// Error type.

--- a/types/src/v2/mod.rs
+++ b/types/src/v2/mod.rs
@@ -1,7 +1,3 @@
-use crate::error::Error;
-use serde::de::DeserializeOwned;
-use serde_json::value::RawValue;
-
 /// JSON-RPC error related types.
 pub mod error;
 /// JSON_RPC params related types.
@@ -10,14 +6,3 @@ pub mod params;
 pub mod request;
 /// JSON-RPC response object related types.
 pub mod response;
-
-/// Parse request ID from RawValue.
-pub fn parse_request_id<T: DeserializeOwned>(raw: Option<&RawValue>) -> Result<T, Error> {
-	match raw {
-		None => Err(Error::InvalidRequestId),
-		Some(v) => {
-			let val = serde_json::from_str(v.get()).map_err(|_| Error::InvalidRequestId)?;
-			Ok(val)
-		}
-	}
-}

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -1,10 +1,10 @@
 use crate::error::CallError;
 use alloc::collections::BTreeMap;
+use beef::Cow;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::{value::RawValue, Value as JsonValue};
-use std::borrow::Cow;
 use std::fmt;
 
 /// JSON-RPC parameter values for subscriptions.
@@ -210,7 +210,7 @@ mod test {
 
 		let s = r#""2x""#;
 		let deserialized: Id = serde_json::from_str(s).unwrap();
-		assert_eq!(deserialized, Id::Str(Cow::Borrowed("2x")));
+		assert_eq!(deserialized, Id::Str(Cow::const_str("2x")));
 
 		let s = r#"[1337]"#;
 		assert!(serde_json::from_str::<Id>(s).is_err());

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -193,12 +193,11 @@ impl<'a> Id<'a> {
 			_ => None,
 		}
 	}
-
 }
 
 #[cfg(test)]
 mod test {
-	use super::{Cow, Id, RpcParams, JsonValue};
+	use super::{Cow, Id, JsonValue, RpcParams};
 
 	#[test]
 	fn id_deserialization() {
@@ -229,7 +228,6 @@ mod test {
 		let serialized = serde_json::to_string(&d).unwrap();
 		assert_eq!(serialized, r#"[null,0,2,3,"3","test"]"#);
 	}
-
 
 	#[test]
 	fn params_parse() {

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -1,4 +1,4 @@
-use crate::error::InvalidParams;
+use crate::error::CallError;
 use alloc::collections::BTreeMap;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
@@ -79,18 +79,18 @@ impl<'a> RpcParams<'a> {
 	}
 
 	/// Attempt to parse all parameters as array or map into type T
-	pub fn parse<T>(self) -> Result<T, InvalidParams>
+	pub fn parse<T>(self) -> Result<T, CallError>
 	where
 		T: Deserialize<'a>,
 	{
 		match self.0 {
-			None => Err(InvalidParams),
-			Some(params) => serde_json::from_str(params).map_err(|_| InvalidParams),
+			None => Err(CallError::InvalidParams),
+			Some(params) => serde_json::from_str(params).map_err(|_| CallError::InvalidParams),
 		}
 	}
 
 	/// Attempt to parse only the first parameter from an array into type T
-	pub fn one<T>(self) -> Result<T, InvalidParams>
+	pub fn one<T>(self) -> Result<T, CallError>
 	where
 		T: Deserialize<'a>,
 	{

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -221,6 +221,9 @@ mod test {
 		let deserialized: Id = serde_json::from_str(s).unwrap();
 		assert_eq!(deserialized, Id::Str(Cow::Borrowed("2x")));
 
+		let s = r#"[1337]"#;
+		assert!(serde_json::from_str::<Id>(s).is_err());
+
 		let s = r#"[null, 0, 2, "3"]"#;
 		let deserialized: Vec<Id> = serde_json::from_str(s).unwrap();
 		assert_eq!(deserialized, vec![Id::Null, Id::Number(0), Id::Number(2), Id::Str("3".into())]);

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -1,10 +1,11 @@
 use crate::error::InvalidParams;
 use alloc::collections::BTreeMap;
+use std::borrow::Cow;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::{value::RawValue, Value as JsonValue};
-use std::borrow::Cow;
+
 use std::fmt;
 
 /// JSON-RPC parameter values for subscriptions.
@@ -164,6 +165,7 @@ pub enum Id<'a> {
 	/// Numeric id
 	Number(u64),
 	/// String id
+	#[serde(borrow)]
 	Str(Cow<'a, str>),
 }
 

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -1,10 +1,10 @@
 use crate::error::InvalidParams;
 use alloc::collections::BTreeMap;
-use std::borrow::Cow;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::{value::RawValue, Value as JsonValue};
+use std::borrow::Cow;
 
 use std::fmt;
 

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -11,7 +11,7 @@ pub struct JsonRpcRequest<'a> {
 	pub jsonrpc: TwoPointZero,
 	/// Request ID
 	#[serde(borrow)]
-	pub id: Option<&'a RawValue>,
+	pub id: Id<'a>,
 	/// Name of the method to be invoked.
 	#[serde(borrow)]
 	pub method: Cow<'a, str>,
@@ -25,7 +25,7 @@ pub struct JsonRpcRequest<'a> {
 pub struct JsonRpcInvalidRequest<'a> {
 	/// Request ID
 	#[serde(borrow)]
-	pub id: Option<&'a RawValue>,
+	pub id: Id<'a>,
 }
 
 /// JSON-RPC notification (a request object without a request ID).
@@ -47,14 +47,14 @@ pub struct JsonRpcCallSer<'a> {
 	/// Name of the method to be invoked.
 	pub method: &'a str,
 	/// Request ID
-	pub id: Id,
+	pub id: Id<'a>,
 	/// Parameter values of the request.
 	pub params: JsonRpcParams<'a>,
 }
 
 impl<'a> JsonRpcCallSer<'a> {
 	/// Create a new serializable JSON-RPC request.
-	pub fn new(id: Id, method: &'a str, params: JsonRpcParams<'a>) -> Self {
+	pub fn new(id: Id<'a>, method: &'a str, params: JsonRpcParams<'a>) -> Self {
 		Self { jsonrpc: TwoPointZero, id, method, params }
 	}
 }
@@ -74,5 +74,38 @@ impl<'a> JsonRpcNotificationSer<'a> {
 	/// Create a new serializable JSON-RPC request.
 	pub fn new(method: &'a str, params: JsonRpcParams<'a>) -> Self {
 		Self { jsonrpc: TwoPointZero, method, params }
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::{JsonRpcRequest, TwoPointZero};
+
+	#[test]
+	fn deserialize_valid_request_works() {
+		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[1,"bar"],"id":1}"#;
+		let dsr: JsonRpcRequest = serde_json::from_str(ser).unwrap();
+		assert_eq!(dsr.method, "say_hello");
+		assert_eq!(dsr.jsonrpc, TwoPointZero);
+	}
+
+	#[test]
+	fn deserialize_valid_request_without_params_works() {
+		let ser = r#"{"jsonrpc":"2.0","method":"say_hello", "id":1}"#;
+		let dsr: JsonRpcRequest = serde_json::from_str(ser).unwrap();
+		assert_eq!(dsr.method, "say_hello");
+		assert_eq!(dsr.jsonrpc, TwoPointZero);
+	}
+
+	#[test]
+	fn deserialize_request_bad_params_should_fail() {
+		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":"lol","id":1}"#;
+		assert!(serde_json::from_str::<JsonRpcRequest>(ser).is_err());
+	}
+
+	#[test]
+	fn deserialize_request_bad_id_should_fail() {
+		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[],"id":{}}"#;
+		assert!(serde_json::from_str::<JsonRpcRequest>(ser).is_err());
 	}
 }

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -81,8 +81,9 @@ impl<'a> JsonRpcNotificationSer<'a> {
 
 #[cfg(test)]
 mod test {
-	use super::{JsonRpcRequest, JsonRpcNotification, JsonRpcInvalidRequest, TwoPointZero, Id,
-		JsonRpcCallSer, JsonRpcNotificationSer
+	use super::{
+		Id, JsonRpcCallSer, JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcNotificationSer, JsonRpcRequest,
+		TwoPointZero,
 	};
 
 	#[test]

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -1,4 +1,4 @@
-use crate::v2::params::{Id, JsonRpcNotificationParams, JsonRpcParams, TwoPointZero};
+use crate::v2::params::{Id, JsonRpcParams, TwoPointZero};
 use beef::Cow;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
@@ -21,7 +21,7 @@ pub struct JsonRpcRequest<'a> {
 }
 
 /// Invalid request with known request ID.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct JsonRpcInvalidRequest<'a> {
 	/// Request ID
 	#[serde(borrow)]
@@ -30,13 +30,15 @@ pub struct JsonRpcInvalidRequest<'a> {
 
 /// JSON-RPC notification (a request object without a request ID).
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct JsonRpcNotification<'a> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Name of the method to be invoked.
 	pub method: &'a str,
 	/// Parameter values of the request.
-	pub params: JsonRpcNotificationParams<'a>,
+	#[serde(borrow)]
+	pub params: Option<&'a RawValue>,
 }
 
 /// Serializable [JSON-RPC object](https://www.jsonrpc.org/specification#request-object)
@@ -79,10 +81,12 @@ impl<'a> JsonRpcNotificationSer<'a> {
 
 #[cfg(test)]
 mod test {
-	use super::{JsonRpcRequest, TwoPointZero};
+	use super::{JsonRpcRequest, JsonRpcNotification, JsonRpcInvalidRequest, TwoPointZero, Id,
+		JsonRpcCallSer, JsonRpcNotificationSer
+	};
 
 	#[test]
-	fn deserialize_valid_request_works() {
+	fn deserialize_valid_call_works() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[1,"bar"],"id":1}"#;
 		let dsr: JsonRpcRequest = serde_json::from_str(ser).unwrap();
 		assert_eq!(dsr.method, "say_hello");
@@ -90,22 +94,55 @@ mod test {
 	}
 
 	#[test]
-	fn deserialize_valid_request_without_params_works() {
+	fn deserialize_valid_notif_works() {
+		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[]}"#;
+		let dsr: JsonRpcNotification = serde_json::from_str(ser).unwrap();
+		assert_eq!(dsr.method, "say_hello");
+		assert_eq!(dsr.jsonrpc, TwoPointZero);
+	}
+
+	#[test]
+	fn deserialize_valid_call_without_params_works() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello", "id":1}"#;
 		let dsr: JsonRpcRequest = serde_json::from_str(ser).unwrap();
 		assert_eq!(dsr.method, "say_hello");
 		assert_eq!(dsr.jsonrpc, TwoPointZero);
 	}
 
+	// TODO(niklasad1): merge the types `JsonRpcParams` and `RpcParams` and remove `RawValue`.
 	#[test]
-	fn deserialize_request_bad_params_should_fail() {
+	#[ignore]
+	fn deserialize_call_bad_params_should_fail() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":"lol","id":1}"#;
 		assert!(serde_json::from_str::<JsonRpcRequest>(ser).is_err());
 	}
 
 	#[test]
-	fn deserialize_request_bad_id_should_fail() {
+	fn deserialize_call_bad_id_should_fail() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[],"id":{}}"#;
 		assert!(serde_json::from_str::<JsonRpcRequest>(ser).is_err());
+	}
+
+	#[test]
+	fn deserialize_invalid_request() {
+		let s = r#"{"id":120,"method":"my_method","params":["foo", "bar"],"extra_field":[]}"#;
+		let deserialized: JsonRpcInvalidRequest = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, JsonRpcInvalidRequest { id: Id::Number(120) });
+	}
+
+	#[test]
+	fn serialize_call() {
+		let exp = r#"{"jsonrpc":"2.0","method":"say_hello","id":"bar","params":[]}"#;
+		let req = JsonRpcCallSer::new(Id::Str("bar".into()), "say_hello", vec![].into());
+		let ser = serde_json::to_string(&req).unwrap();
+		assert_eq!(exp, ser);
+	}
+
+	#[test]
+	fn serialize_notif() {
+		let exp = r#"{"jsonrpc":"2.0","method":"say_hello","params":["hello"]}"#;
+		let req = JsonRpcNotificationSer::new("say_hello", vec!["hello".into()].into());
+		let ser = serde_json::to_string(&req).unwrap();
+		assert_eq!(exp, ser);
 	}
 }

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -1,6 +1,5 @@
-use crate::v2::params::{JsonRpcNotificationParamsAlloc, TwoPointZero};
+use crate::v2::params::{Id, JsonRpcNotificationParamsAlloc, TwoPointZero};
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue;
 
 /// JSON-RPC successful response object.
 #[derive(Serialize, Deserialize, Debug)]
@@ -11,7 +10,7 @@ pub struct JsonRpcResponse<'a, T> {
 	pub result: T,
 	/// Request ID
 	#[serde(borrow)]
-	pub id: Option<&'a RawValue>,
+	pub id: Id<'a>,
 }
 
 /// JSON-RPC subscription response.

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -1,4 +1,4 @@
-use crate::v2::params::{Id, JsonRpcNotificationParamsAlloc, JsonRpcNotificationParams, TwoPointZero};
+use crate::v2::params::{Id, JsonRpcNotificationParams, JsonRpcNotificationParamsAlloc, TwoPointZero};
 use serde::{Deserialize, Serialize};
 
 /// JSON-RPC successful response object.

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -1,8 +1,9 @@
-use crate::v2::params::{Id, JsonRpcNotificationParamsAlloc, TwoPointZero};
+use crate::v2::params::{Id, JsonRpcNotificationParamsAlloc, JsonRpcNotificationParams, TwoPointZero};
 use serde::{Deserialize, Serialize};
 
 /// JSON-RPC successful response object.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct JsonRpcResponse<'a, T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
@@ -14,16 +15,31 @@ pub struct JsonRpcResponse<'a, T> {
 }
 
 /// JSON-RPC subscription response.
-#[derive(Deserialize, Debug)]
-pub struct JsonRpcSubscriptionResponse<T> {
+#[derive(Serialize)]
+pub struct JsonRpcSubscriptionResponse<'a> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
+	/// Method
+	pub method: &'a str,
+	/// Params.
+	pub params: JsonRpcNotificationParams<'a>,
+}
+
+/// JSON-RPC subscription response.
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct JsonRpcSubscriptionResponseAlloc<'a, T> {
+	/// JSON-RPC version.
+	pub jsonrpc: TwoPointZero,
+	/// Method
+	pub method: &'a str,
 	/// Params.
 	pub params: JsonRpcNotificationParamsAlloc<T>,
 }
 
 /// JSON-RPC notification response.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct JsonRpcNotifResponse<'a, T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -2,13 +2,13 @@ use crate::server::rpc_module::MethodSink;
 use futures_channel::mpsc;
 use futures_util::stream::StreamExt;
 use jsonrpsee_types::v2::error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject};
-use jsonrpsee_types::v2::params::{JsonRpcRawId, TwoPointZero};
+use jsonrpsee_types::v2::params::{Id, TwoPointZero};
 use jsonrpsee_types::v2::response::JsonRpcResponse;
 use serde::Serialize;
 
 /// Helper for sending JSON-RPC responses to the client
-pub fn send_response(id: JsonRpcRawId, tx: &MethodSink, result: impl Serialize) {
-	let json = match serde_json::to_string(&JsonRpcResponse { jsonrpc: TwoPointZero, id, result }) {
+pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
+	let json = match serde_json::to_string(&JsonRpcResponse { jsonrpc: TwoPointZero, id: id.clone(), result }) {
 		Ok(json) => json,
 		Err(err) => {
 			log::error!("Error serializing response: {:?}", err);
@@ -23,7 +23,7 @@ pub fn send_response(id: JsonRpcRawId, tx: &MethodSink, result: impl Serialize) 
 }
 
 /// Helper for sending JSON-RPC errors to the client
-pub fn send_error(id: JsonRpcRawId, tx: &MethodSink, error: JsonRpcErrorObject) {
+pub fn send_error(id: Id, tx: &MethodSink, error: JsonRpcErrorObject) {
 	let json = match serde_json::to_string(&JsonRpcError { jsonrpc: TwoPointZero, error, id }) {
 		Ok(json) => json,
 		Err(err) => {

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -4,7 +4,7 @@ use jsonrpsee_types::error::{CallError, Error};
 use jsonrpsee_types::traits::RpcMethod;
 use jsonrpsee_types::v2::error::{JsonRpcErrorCode, JsonRpcErrorObject, CALL_EXECUTION_FAILED_CODE};
 use jsonrpsee_types::v2::params::{Id, JsonRpcNotificationParams, RpcParams, TwoPointZero};
-use jsonrpsee_types::v2::request::JsonRpcNotification;
+use jsonrpsee_types::v2::response::JsonRpcSubscriptionResponse;
 
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
@@ -236,7 +236,7 @@ impl SubscriptionSink {
 		let mut subs = self.subscribers.lock();
 
 		for ((conn_id, sub_id), sender) in subs.iter() {
-			let msg = serde_json::to_string(&JsonRpcNotification {
+			let msg = serde_json::to_string(&JsonRpcSubscriptionResponse {
 				jsonrpc: TwoPointZero,
 				method: self.method,
 				params: JsonRpcNotificationParams { subscription: *sub_id, result: &*result },

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -3,7 +3,7 @@ use futures_channel::mpsc;
 use jsonrpsee_types::error::{CallError, Error};
 use jsonrpsee_types::traits::RpcMethod;
 use jsonrpsee_types::v2::error::{JsonRpcErrorCode, JsonRpcErrorObject, CALL_EXECUTION_FAILED_CODE};
-use jsonrpsee_types::v2::params::{JsonRpcNotificationParams, JsonRpcRawId, RpcParams, TwoPointZero};
+use jsonrpsee_types::v2::params::{Id, JsonRpcNotificationParams, RpcParams, TwoPointZero};
 use jsonrpsee_types::v2::request::JsonRpcNotification;
 
 use parking_lot::Mutex;
@@ -16,7 +16,7 @@ use std::sync::Arc;
 /// implemented as a function pointer to a `Fn` function taking four arguments:
 /// the `id`, `params`, a channel the function uses to communicate the result (or error)
 /// back to `jsonrpsee`, and the connection ID (useful for the websocket transport).
-pub type Method = Box<dyn Send + Sync + Fn(JsonRpcRawId, RpcParams, &MethodSink, ConnectionId) -> anyhow::Result<()>>;
+pub type Method = Box<dyn Send + Sync + Fn(Id, RpcParams, &MethodSink, ConnectionId) -> anyhow::Result<()>>;
 /// A collection of registered [`Method`]s.
 pub type Methods = FxHashMap<&'static str, Method>;
 /// Connection ID, used for stateful protocol such as WebSockets.

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -26,7 +26,7 @@
 
 use crate::traits::{Client, SubscriptionClient};
 use crate::transport::{parse_url, Receiver as WsReceiver, Sender as WsSender, WsTransportClientBuilder};
-use crate::v2::error::JsonRpcErrorAlloc;
+use crate::v2::error::JsonRpcError;
 use crate::v2::params::{Id, JsonRpcParams};
 use crate::v2::request::{JsonRpcCallSer, JsonRpcNotificationSer};
 use crate::v2::response::{JsonRpcNotifResponse, JsonRpcResponse, JsonRpcSubscriptionResponse};
@@ -651,7 +651,7 @@ async fn background_task(
 					}
 				}
 				// Error response
-				else if let Ok(err) = serde_json::from_slice::<JsonRpcErrorAlloc>(&raw) {
+				else if let Ok(err) = serde_json::from_slice::<JsonRpcError>(&raw) {
 					log::debug!("[backend]: recv error response {:?}", err);
 					if let Err(e) = process_error_response(&mut manager, err) {
 						let _ = front_error.send(e);

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -29,7 +29,7 @@ use crate::transport::{parse_url, Receiver as WsReceiver, Sender as WsSender, Ws
 use crate::v2::error::JsonRpcError;
 use crate::v2::params::{Id, JsonRpcParams};
 use crate::v2::request::{JsonRpcCallSer, JsonRpcNotificationSer};
-use crate::v2::response::{JsonRpcNotifResponse, JsonRpcResponse, JsonRpcSubscriptionResponse};
+use crate::v2::response::{JsonRpcNotifResponse, JsonRpcResponse, JsonRpcSubscriptionResponseAlloc};
 use crate::TEN_MB_SIZE_BYTES;
 use crate::{
 	helpers::{
@@ -631,7 +631,7 @@ async fn background_task(
 					}
 				}
 				// Subscription response.
-				else if let Ok(notif) = serde_json::from_slice::<JsonRpcSubscriptionResponse<_>>(&raw) {
+				else if let Ok(notif) = serde_json::from_slice::<JsonRpcSubscriptionResponseAlloc<_>>(&raw) {
 					log::debug!("[backend]: recv subscription {:?}", notif);
 					if let Err(Some(unsub)) = process_subscription_response(&mut manager, notif) {
 						let _ = stop_subscription(&mut sender, &mut manager, unsub).await;

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -3,7 +3,7 @@ use crate::transport::Sender as WsSender;
 use futures::channel::mpsc;
 use jsonrpsee_types::v2::params::{Id, JsonRpcParams, SubscriptionId};
 use jsonrpsee_types::v2::request::JsonRpcCallSer;
-use jsonrpsee_types::v2::response::{JsonRpcNotifResponse, JsonRpcResponse, JsonRpcSubscriptionResponse};
+use jsonrpsee_types::v2::response::{JsonRpcNotifResponse, JsonRpcResponse, JsonRpcSubscriptionResponseAlloc};
 use jsonrpsee_types::{v2::error::JsonRpcError, Error, RequestMessage};
 use serde_json::Value as JsonValue;
 
@@ -46,7 +46,7 @@ pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<JsonRpcResp
 /// Returns `Err(Some(msg))` if the subscription was full.
 pub fn process_subscription_response(
 	manager: &mut RequestManager,
-	notif: JsonRpcSubscriptionResponse<JsonValue>,
+	notif: JsonRpcSubscriptionResponseAlloc<JsonValue>,
 ) -> Result<(), Option<RequestMessage>> {
 	let sub_id = notif.params.subscription;
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -190,9 +190,7 @@ fn assert_error_response(err: Error, exp: JsonRpcErrorObject) {
 	match &err {
 		Error::Request(e) => {
 			let this: JsonRpcError = serde_json::from_str(&e).unwrap();
-			// NOTE: `RawValue` doesn't implement PartialEq.
-			assert_eq!(this.error.code, exp.code);
-			assert_eq!(this.error.message, exp.message);
+			assert_eq!(this.error, exp);
 		}
 		e => panic!("Expected error: \"{}\", got: {:?}", err, e),
 	};

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::v2::{
-	error::{JsonRpcErrorCode, JsonRpcErrorObjectAlloc},
+	error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject},
 	params::JsonRpcParams,
 };
 use crate::{
@@ -186,9 +186,14 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 	client.request("say_hello", JsonRpcParams::NoParams).await
 }
 
-fn assert_error_response(error: Error, code: JsonRpcErrorObjectAlloc) {
-	match &error {
-		Error::Request(e) => assert_eq!(e.error, code),
-		e => panic!("Expected error: \"{}\", got: {:?}", error, e),
+fn assert_error_response(err: Error, exp: JsonRpcErrorObject) {
+	match &err {
+		Error::Request(e) => {
+			let this: JsonRpcError = serde_json::from_str(&e).unwrap();
+			// NOTE: `RawValue` doesn't implement PartialEq.
+			assert_eq!(this.error.code, exp.code);
+			assert_eq!(this.error.message, exp.message);
+		}
+		e => panic!("Expected error: \"{}\", got: {:?}", err, e),
 	};
 }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -141,12 +141,12 @@ async fn background_task(
 	let execute = move |tx: &MethodSink, req: JsonRpcRequest| {
 		if let Some(method) = methods.get(&*req.method) {
 			let params = RpcParams::new(req.params.map(|params| params.get()));
-			if let Err(err) = (method)(req.id.to_owned(), params, &tx, conn_id) {
+			if let Err(err) = (method)(req.id.clone(), params, &tx, conn_id) {
 				log::error!("execution of method call '{}' failed: {:?}, request id={:?}", req.method, err, req.id);
-				send_error(req.id.to_owned(), &tx, JsonRpcErrorCode::ServerError(-1).into());
+				send_error(req.id.clone(), &tx, JsonRpcErrorCode::ServerError(-1).into());
 			}
 		} else {
-			send_error(req.id.to_owned(), &tx, JsonRpcErrorCode::MethodNotFound.into());
+			send_error(req.id.clone(), &tx, JsonRpcErrorCode::MethodNotFound.into());
 		}
 	};
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -143,10 +143,10 @@ async fn background_task(
 			let params = RpcParams::new(req.params.map(|params| params.get()));
 			if let Err(err) = (method)(req.id.clone(), params, &tx, conn_id) {
 				log::error!("execution of method call '{}' failed: {:?}, request id={:?}", req.method, err, req.id);
-				send_error(req.id.clone(), &tx, JsonRpcErrorCode::ServerError(-1).into());
+				send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
 			}
 		} else {
-			send_error(req.id.clone(), &tx, JsonRpcErrorCode::MethodNotFound.into());
+			send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 		}
 	};
 


### PR DESCRIPTION
Similar should be done on `Params` and `JsonRpcNotifParams` to work properly but this PR is large enough as it is.

Further info see https://github.com/paritytech/jsonrpsee/pull/292#issuecomment-829874041
