### PR TITLE
Basic support for async methods

### DIFF
--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -33,12 +33,13 @@ use hyper::{
 	Error as HyperError,
 };
 use jsonrpsee_types::error::{CallError, Error, GenericTransportError};
+use jsonrpsee_types::traits::AsyncRpcMethod;
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
 use jsonrpsee_types::v2::params::{Id, RpcParams};
-use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest};
-use jsonrpsee_utils::hyper_helpers::read_response_to_body;
+use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest, OwnedJsonRpcRequest};
 use jsonrpsee_utils::server::helpers::{collect_batch_response, send_error};
 use jsonrpsee_utils::server::rpc_module::{MethodSink, RpcModule};
+use jsonrpsee_utils::{hyper_helpers::read_response_to_body, server::rpc_module::MethodType};
 
 use serde::Serialize;
 use socket2::{Domain, Socket, Type};
@@ -130,6 +131,15 @@ impl Server {
 		self.root.register_method(method_name, callback)
 	}
 
+	/// Register a new RPC method, which responds with a given callback.
+	pub fn register_async_method<R, F>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
+	where
+		R: Serialize + Send + Sync + 'static,
+		F: AsyncRpcMethod<R, CallError> + Copy + Send + Sync + 'static,
+	{
+		self.root.register_async_method(method_name, callback)
+	}
+
 	/// Register all methods from a module on this server.
 	pub fn register_module(&mut self, module: RpcModule) -> Result<(), Error> {
 		self.root.merge(module)
@@ -142,7 +152,7 @@ impl Server {
 
 	/// Start the server.
 	pub async fn start(self) -> Result<(), Error> {
-		let methods = Arc::new(self.root.into_methods());
+		let methods = Arc::new(self.root);
 		let max_request_body_size = self.max_request_body_size;
 		let access_control = self.access_control;
 
@@ -158,11 +168,42 @@ impl Server {
 					// Look up the "method" (i.e. function pointer) from the registered methods and run it passing in
 					// the params from the request. The result of the computation is sent back over the `tx` channel and
 					// the result(s) are collected into a `String` and sent back over the wire.
-					let execute = move |tx: &MethodSink, req: JsonRpcRequest| {
-						if let Some(method) = methods.get(&*req.method) {
+					//
+					// Note: This handler expects method existence to be checked prior to the call and will panic if
+					// method does not exist.
+					let sync_methods = methods.clone();
+					let execute_sync = move |tx: &MethodSink, req: JsonRpcRequest| {
+						let method = sync_methods.method(&*req.method).unwrap();
+						let params = RpcParams::new(req.params.map(|params| params.get()));
+						// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
+						if let Err(err) = (method)(req.id.clone(), params, &tx, 0) {
+							log::error!(
+								"execution of method call '{}' failed: {:?}, request id={:?}",
+								req.method,
+								err,
+								req.id
+							);
+							send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
+						}
+					};
+
+					// Similar to `execute_sync`, but uses an asyncrhonous context.
+					// Unfortunately, we have to use owned versions of objects due to heavy lifetime
+					// usage in borrowed ones.
+					// Probably there is a chance to avoid using the heap here through some `Pin` magic,
+					// but several simple attempts to do so were failed.
+					//
+					// Note: This handler expects method existence to be checked prior to the call and will panic if
+					// method does not exist.
+					let async_methods = methods.clone();
+					let execute_async = move |tx: MethodSink, req: OwnedJsonRpcRequest| {
+						let async_methods = async_methods.clone();
+						async move {
+							let req = req.borrowed();
+							let method = async_methods.async_method(&*req.method).unwrap();
 							let params = RpcParams::new(req.params.map(|params| params.get()));
 							// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
-							if let Err(err) = (method)(req.id.clone(), params, &tx, 0) {
+							if let Err(err) = (method)(req.id.clone().into(), params.into(), tx.clone(), 0).await {
 								log::error!(
 									"execution of method call '{}' failed: {:?}, request id={:?}",
 									req.method,
@@ -171,8 +212,6 @@ impl Server {
 								);
 								send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
 							}
-						} else {
-							send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 						}
 					};
 
@@ -210,14 +249,26 @@ impl Server {
 						// to [`serde_json::from_slice`] which is pretty annoying.
 						// Our [issue](https://github.com/paritytech/jsonrpsee/issues/296).
 						if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&body) {
-							execute(&tx, req);
+							match methods.method_type(&*req.method) {
+								Some(MethodType::Sync) => execute_sync(&tx, req),
+								Some(MethodType::Async) => execute_async(tx.clone(), req.into()).await,
+								None => {
+									send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
+								}
+							}
 						} else if let Ok(_req) = serde_json::from_slice::<JsonRpcNotification>(&body) {
 							return Ok::<_, HyperError>(response::ok_response("".into()));
 						} else if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&body) {
 							if !batch.is_empty() {
 								single = false;
 								for req in batch {
-									execute(&tx, req);
+									match methods.method_type(&*req.method) {
+										Some(MethodType::Sync) => execute_sync(&tx, req),
+										Some(MethodType::Async) => execute_async(tx.clone(), req.into()).await,
+										None => {
+											send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
+										}
+									}
 								}
 							} else {
 								send_error(Id::Null, &tx, JsonRpcErrorCode::InvalidRequest.into());

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -3,6 +3,8 @@
 use std::net::SocketAddr;
 
 use crate::{HttpServerBuilder, RpcContextModule};
+use futures_util::FutureExt;
+use jsonrpsee_http_client::v2::params::RpcParams;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, StatusCode, TestContext};
 use jsonrpsee_test_utils::TimeoutFutureExt;
@@ -13,6 +15,7 @@ async fn server() -> SocketAddr {
 	let mut server = HttpServerBuilder::default().build("127.0.0.1:0".parse().unwrap()).unwrap();
 	let addr = server.local_addr().unwrap();
 	server.register_method("say_hello", |_| Ok("lo")).unwrap();
+	server.register_async_method("say_hello_async", |_: RpcParams| async move { Ok("lo") }.boxed()).unwrap();
 	server
 		.register_method("add", |params| {
 			let params: Vec<u64> = params.parse()?;
@@ -53,6 +56,16 @@ pub async fn server_with_context() -> SocketAddr {
 		})
 		.unwrap();
 
+	rpc_ctx
+		.register_async_method("should_ok_async", |_p, ctx| {
+			async move {
+				let _ = ctx.ok().map_err(|e| CallError::Failed(e.into()))?;
+				Ok("ok")
+			}
+			.boxed()
+		})
+		.unwrap();
+
 	let rpc_module = rpc_ctx.into_module();
 	server.register_module(rpc_module).unwrap();
 	let addr = server.local_addr().unwrap();
@@ -70,6 +83,20 @@ async fn single_method_call_works() {
 	for i in 0..10 {
 		let req = format!(r#"{{"jsonrpc":"2.0","method":"say_hello","id":{}}}"#, i);
 		let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
+		assert_eq!(response.status, StatusCode::OK);
+		assert_eq!(response.body, ok_response(JsonValue::String("lo".to_owned()), Id::Num(i)));
+	}
+}
+
+#[tokio::test]
+async fn async_method_call_works() {
+	let _ = env_logger::try_init();
+	let addr = server().await;
+	let uri = to_http_uri(addr);
+
+	for i in 0..10 {
+		let req = format!(r#"{{"jsonrpc":"2.0","method":"say_hello_async","id":{}}}"#, i);
+		let response = http_request(req.into(), uri.clone()).await.unwrap();
 		assert_eq!(response.status, StatusCode::OK);
 		assert_eq!(response.body, ok_response(JsonValue::String("lo".to_owned()), Id::Num(i)));
 	}
@@ -138,6 +165,17 @@ async fn single_method_call_with_ok_context() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_ok", "params":[],"id":1}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, ok_response("ok".into(), Id::Num(1)));
+}
+
+#[tokio::test]
+async fn async_method_call_with_ok_context() {
+	let addr = server_with_context().await;
+	let uri = to_http_uri(addr);
+
+	let req = r#"{"jsonrpc":"2.0","method":"should_ok_async", "params":[],"id":1}"#;
+	let response = http_request(req.into(), uri).await.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, ok_response("ok".into(), Id::Num(1)));
 }

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -1,6 +1,7 @@
 use crate::v2::params::{JsonRpcParams, RpcParams};
 use crate::{Error, NotificationHandler, Subscription};
 use async_trait::async_trait;
+use futures_util::future::BoxFuture;
 use serde::de::DeserializeOwned;
 
 /// [JSON-RPC](https://www.jsonrpc.org/specification) client interface that can make requests and notifications.
@@ -55,3 +56,17 @@ pub trait SubscriptionClient: Client {
 pub trait RpcMethod<R, E>: Fn(RpcParams) -> Result<R, E> + Send + Sync + 'static {}
 
 impl<R, T, E> RpcMethod<R, E> for T where T: Fn(RpcParams) -> Result<R, E> + Send + Sync + 'static {}
+
+/// JSON-RPC server interface for managing method calls.
+pub trait AsyncRpcMethod<R, E>: Fn(RpcParams) -> BoxFuture<'static, Result<R, E>>
+where
+	Result<R, E>: Send + Sync,
+{
+}
+
+impl<R, T, E> AsyncRpcMethod<R, E> for T
+where
+	T: Fn(RpcParams) -> BoxFuture<'static, Result<R, E>>,
+	Result<R, E>: Send + Sync,
+{
+}

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -131,46 +131,6 @@ pub enum JsonRpcParams<'a> {
 	Map(BTreeMap<&'a str, JsonValue>),
 }
 
-/// Owned version of [`JsonRpcParams`].
-#[derive(Serialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum OwnedJsonRpcParams {
-	/// No params.
-	NoParams,
-	/// Positional params (heap allocated)
-	Array(Vec<JsonValue>),
-	/// Params by name.
-	Map(BTreeMap<String, JsonValue>),
-}
-
-impl OwnedJsonRpcParams {
-	/// Converts `OwnedJsonRpcParams` into borrowed [`JsonRpcParams`].
-	pub fn borrowed(&self) -> JsonRpcParams<'_> {
-		match self {
-			OwnedJsonRpcParams::NoParams => JsonRpcParams::NoParams,
-			OwnedJsonRpcParams::Array(arr) => JsonRpcParams::ArrayRef(arr.as_ref()),
-			OwnedJsonRpcParams::Map(map) => {
-				let map = map.iter().map(|(k, v)| (k.as_ref(), v.clone())).collect();
-				JsonRpcParams::Map(map)
-			}
-		}
-	}
-}
-
-impl<'a> From<JsonRpcParams<'a>> for OwnedJsonRpcParams {
-	fn from(borrowed: JsonRpcParams<'a>) -> Self {
-		match borrowed {
-			JsonRpcParams::NoParams => Self::NoParams,
-			JsonRpcParams::Array(arr) => Self::Array(arr),
-			JsonRpcParams::ArrayRef(slice) => Self::Array(slice.to_vec()),
-			JsonRpcParams::Map(map) => {
-				let map = map.iter().map(|(k, v)| (k.to_string(), v.clone())).collect();
-				Self::Map(map)
-			}
-		}
-	}
-}
-
 impl<'a> From<BTreeMap<&'a str, JsonValue>> for JsonRpcParams<'a> {
 	fn from(map: BTreeMap<&'a str, JsonValue>) -> Self {
 		Self::Map(map)

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -43,7 +43,12 @@ impl OwnedJsonRpcRequest {
 			jsonrpc: self.jsonrpc,
 			id: self.id.borrowed(),
 			method: Cow::borrowed(self.method.as_ref()),
-			params: self.params.as_ref().map(|s| serde_json::from_str(&s).unwrap()),
+			params: self.params.as_ref().map(|s| {
+				// Note: while this object *may* be created not from the `JsonRpcRequest` object,
+				// using an invalid field to construct it would be a logical invariant break.
+				serde_json::from_str(&s)
+					.expect("OwnedJsonRpcRequest is only created from JsonRpcRequest, so this conversion must be safe")
+			}),
 		}
 	}
 }

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -3,6 +3,8 @@ use beef::Cow;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
+use super::params::OwnedId;
+
 /// [JSON-RPC request object](https://www.jsonrpc.org/specification#request-object)
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -18,6 +20,43 @@ pub struct JsonRpcRequest<'a> {
 	/// Parameter values of the request.
 	#[serde(borrow)]
 	pub params: Option<&'a RawValue>,
+}
+
+/// Owned version of [`JsonRpcRequest`].
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct OwnedJsonRpcRequest {
+	/// JSON-RPC version.
+	pub jsonrpc: TwoPointZero,
+	/// Request ID
+	pub id: OwnedId,
+	/// Name of the method to be invoked.
+	pub method: String,
+	/// Parameter values of the request.
+	pub params: Option<String>,
+}
+
+impl OwnedJsonRpcRequest {
+	/// Converts `OwnedJsonRpcRequest` into borrowed `JsonRpcRequest`.
+	pub fn borrowed(&self) -> JsonRpcRequest<'_> {
+		JsonRpcRequest {
+			jsonrpc: self.jsonrpc,
+			id: self.id.borrowed(),
+			method: Cow::borrowed(self.method.as_ref()),
+			params: self.params.as_ref().map(|s| serde_json::from_str(&s).unwrap()),
+		}
+	}
+}
+
+impl<'a> From<JsonRpcRequest<'a>> for OwnedJsonRpcRequest {
+	fn from(borrowed: JsonRpcRequest<'a>) -> Self {
+		Self {
+			jsonrpc: borrowed.jsonrpc,
+			id: borrowed.id.into(),
+			method: borrowed.method.as_ref().to_owned(),
+			params: borrowed.params.map(|p| p.get().to_owned()),
+		}
+	}
 }
 
 /// Invalid request with known request ID.

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -195,6 +195,8 @@ impl RpcModule {
 
 		self.verify_method_name(subscribe_method_name)?;
 		self.verify_method_name(unsubscribe_method_name)?;
+		self.method_types.insert(subscribe_method_name, MethodType::Sync);
+		self.method_types.insert(unsubscribe_method_name, MethodType::Sync);
 
 		{
 			let subscribers = self.subscribers.clone();

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -44,7 +44,7 @@ pub enum MethodType {
 	Async,
 }
 
-/// Collection of syncrhonous and asynchronous methods.
+/// Collection of synchronous and asynchronous methods.
 #[derive(Default)]
 pub struct MethodsHolder {
 	method_types: FxHashMap<&'static str, MethodType>,

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -167,16 +167,6 @@ async fn background_task(
 			log::error!("execution of method call '{}' failed: {:?}, request id={:?}", req.method, err, req.id);
 			send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
 		}
-
-		// if let Some(method) = sync_methods.method(&*req.method) {
-		// 	let params = RpcParams::new(req.params.map(|params| params.get()));
-		// 	if let Err(err) = (method)(req.id.clone(), params, &tx, conn_id) {
-		// 		log::error!("execution of method call '{}' failed: {:?}, request id={:?}", req.method, err, req.id);
-		// 		send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
-		// 	}
-		// } else {
-		// 	send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
-		// }
 	};
 
 	// Similar to `execute_sync`, but uses an asyncrhonous context.

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -1,10 +1,14 @@
 #![cfg(test)]
 
 use crate::{RpcContextModule, WsServer};
+use futures_util::FutureExt;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
 use jsonrpsee_test_utils::TimeoutFutureExt;
-use jsonrpsee_types::error::{CallError, Error};
+use jsonrpsee_types::{
+	error::{CallError, Error},
+	v2::params::RpcParams,
+};
 use serde_json::Value as JsonValue;
 use std::fmt;
 use std::net::SocketAddr;
@@ -28,6 +32,17 @@ pub async fn server() -> SocketAddr {
 		.register_method("say_hello", |_| {
 			log::debug!("server respond to hello");
 			Ok("hello")
+		})
+		.unwrap();
+	server
+		.register_async_method("say_hello_async", |_: RpcParams| {
+			async move {
+				log::debug!("server respond to hello");
+				// Call some async function inside.
+				futures_util::future::ready(()).await;
+				Ok("hello")
+			}
+			.boxed()
 		})
 		.unwrap();
 	server
@@ -74,6 +89,18 @@ pub async fn server_with_context() -> SocketAddr {
 		})
 		.unwrap();
 
+	rpc_ctx
+		.register_async_method("should_ok_async", |_p, ctx| {
+			async move {
+				let _ = ctx.ok().map_err(|e| CallError::Failed(e.into()))?;
+				// Call some async function inside.
+				futures_util::future::ready(()).await;
+				Ok("ok")
+			}
+			.boxed()
+		})
+		.unwrap();
+
 	let rpc_module = rpc_ctx.into_module();
 	server.register_module(rpc_module).unwrap();
 	let addr = server.local_addr().unwrap();
@@ -90,6 +117,19 @@ async fn single_method_calls_works() {
 	for i in 0..10 {
 		let req = format!(r#"{{"jsonrpc":"2.0","method":"say_hello","id":{}}}"#, i);
 		let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
+
+		assert_eq!(response, ok_response(JsonValue::String("hello".to_owned()), Id::Num(i)));
+	}
+}
+
+#[tokio::test]
+async fn async_method_calls_works() {
+	let addr = server().await;
+	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+
+	for i in 0..10 {
+		let req = format!(r#"{{"jsonrpc":"2.0","method":"say_hello_async","id":{}}}"#, i);
+		let response = client.send_request_text(req).await.unwrap();
 
 		assert_eq!(response, ok_response(JsonValue::String("hello".to_owned()), Id::Num(i)));
 	}
@@ -181,6 +221,16 @@ async fn single_method_call_with_ok_context() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_ok", "params":[],"id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response, ok_response("ok".into(), Id::Num(1)));
+}
+
+#[tokio::test]
+async fn async_method_call_with_ok_context() {
+	let addr = server_with_context().await;
+	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+
+	let req = r#"{"jsonrpc":"2.0","method":"should_ok_async", "params":[],"id":1}"#;
+	let response = client.send_request_text(req).await.unwrap();
 	assert_eq!(response, ok_response("ok".into(), Id::Num(1)));
 }
 


### PR DESCRIPTION
Related to #291

This PR introduces support for `register_async_method` and it, *uhm*, even seems to be working.

I'm not quite fond of introduced `Owned*` types, but not sure that my `Pin` kung fu is strong enough to deal with all these lifetimes.
