### PR TITLE
Add timeouts to the futures in tests

### DIFF
--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -5,64 +5,69 @@ use crate::v2::{
 use crate::{traits::Client, Error, HttpClientBuilder, JsonValue};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::Id;
+use jsonrpsee_test_utils::TimeoutFutureExt;
 
 #[tokio::test]
 async fn method_call_works() {
-	let result = run_request_with_response(ok_response("hello".into(), Id::Num(0))).await.unwrap();
+	let result =
+		run_request_with_response(ok_response("hello".into(), Id::Num(0))).with_timeout().await.unwrap().unwrap();
 	assert_eq!(JsonValue::String("hello".into()), result);
 }
 
 #[tokio::test]
 async fn notification_works() {
-	let server_addr = http_server_with_hardcoded_response(String::new()).await;
+	let server_addr = http_server_with_hardcoded_response(String::new()).with_timeout().await.unwrap();
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
 	client
 		.notification("i_dont_care_about_the_response_because_the_server_should_not_respond", JsonRpcParams::NoParams)
+		.with_timeout()
 		.await
+		.unwrap()
 		.unwrap();
 }
 
 #[tokio::test]
 async fn response_with_wrong_id() {
-	let err = run_request_with_response(ok_response("hello".into(), Id::Num(99))).await.unwrap_err();
+	let err =
+		run_request_with_response(ok_response("hello".into(), Id::Num(99))).with_timeout().await.unwrap().unwrap_err();
 	assert!(matches!(err, Error::InvalidRequestId));
 }
 
 #[tokio::test]
 async fn response_method_not_found() {
-	let err = run_request_with_response(method_not_found(Id::Num(0))).await.unwrap_err();
+	let err = run_request_with_response(method_not_found(Id::Num(0))).with_timeout().await.unwrap().unwrap_err();
 	assert_jsonrpc_error_response(err, JsonRpcErrorCode::MethodNotFound.into());
 }
 
 #[tokio::test]
 async fn response_parse_error() {
-	let err = run_request_with_response(parse_error(Id::Num(0))).await.unwrap_err();
+	let err = run_request_with_response(parse_error(Id::Num(0))).with_timeout().await.unwrap().unwrap_err();
 	assert_jsonrpc_error_response(err, JsonRpcErrorCode::ParseError.into());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
-	let err = run_request_with_response(invalid_request(Id::Num(0_u64))).await.unwrap_err();
+	let err = run_request_with_response(invalid_request(Id::Num(0_u64))).with_timeout().await.unwrap().unwrap_err();
 	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InvalidRequest.into());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
-	let err = run_request_with_response(invalid_params(Id::Num(0_u64))).await.unwrap_err();
+	let err = run_request_with_response(invalid_params(Id::Num(0_u64))).with_timeout().await.unwrap().unwrap_err();
 	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InvalidParams.into());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
-	let err = run_request_with_response(internal_error(Id::Num(0_u64))).await.unwrap_err();
+	let err = run_request_with_response(internal_error(Id::Num(0_u64))).with_timeout().await.unwrap().unwrap_err();
 	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InternalError.into());
 }
 
 #[tokio::test]
 async fn subscription_response_to_request() {
 	let req = r#"{"jsonrpc":"2.0","method":"subscribe_hello","params":{"subscription":"3px4FrtxSYQ1zBKW154NoVnrDhrq764yQNCXEgZyM6Mu","result":"hello my friend"}}"#.to_string();
-	let err = run_request_with_response(req).await.unwrap_err();
+	let err = run_request_with_response(req).with_timeout().await.unwrap().unwrap_err();
 	assert!(matches!(err, Error::ParseError(_)));
 }
 
@@ -74,7 +79,8 @@ async fn batch_request_works() {
 		("get_swag", JsonRpcParams::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}, {"jsonrpc":"2.0","result":"here's your swag","id":2}]"#.to_string();
-	let response = run_batch_request_with_response(batch_request, server_response).await.unwrap();
+	let response =
+		run_batch_request_with_response(batch_request, server_response).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
@@ -86,7 +92,8 @@ async fn batch_request_out_of_order_response() {
 		("get_swag", JsonRpcParams::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"here's your swag","id":2}, {"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}]"#.to_string();
-	let response = run_batch_request_with_response(batch_request, server_response).await.unwrap();
+	let response =
+		run_batch_request_with_response(batch_request, server_response).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
@@ -94,17 +101,17 @@ async fn run_batch_request_with_response<'a>(
 	batch: Vec<(&'a str, JsonRpcParams<'a>)>,
 	response: String,
 ) -> Result<Vec<String>, Error> {
-	let server_addr = http_server_with_hardcoded_response(response).await;
+	let server_addr = http_server_with_hardcoded_response(response).with_timeout().await.unwrap();
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
-	client.batch_request(batch).await
+	client.batch_request(batch).with_timeout().await.unwrap()
 }
 
 async fn run_request_with_response(response: String) -> Result<JsonValue, Error> {
-	let server_addr = http_server_with_hardcoded_response(response).await;
+	let server_addr = http_server_with_hardcoded_response(response).with_timeout().await.unwrap();
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
-	client.request("say_hello", JsonRpcParams::NoParams).await
+	client.request("say_hello", JsonRpcParams::NoParams).with_timeout().await.unwrap()
 }
 
 fn assert_jsonrpc_error_response(err: Error, exp: JsonRpcErrorObject) {

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use crate::{HttpServerBuilder, RpcContextModule};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, StatusCode, TestContext};
+use jsonrpsee_test_utils::TimeoutFutureExt;
 use jsonrpsee_types::error::CallError;
 use serde_json::Value as JsonValue;
 
@@ -56,19 +57,19 @@ pub async fn server_with_context() -> SocketAddr {
 	server.register_module(rpc_module).unwrap();
 	let addr = server.local_addr().unwrap();
 
-	tokio::spawn(async { server.start().await });
+	tokio::spawn(async { server.start().with_timeout().await.unwrap() });
 	addr
 }
 
 #[tokio::test]
 async fn single_method_call_works() {
 	let _ = env_logger::try_init();
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	for i in 0..10 {
 		let req = format!(r#"{{"jsonrpc":"2.0","method":"say_hello","id":{}}}"#, i);
-		let response = http_request(req.into(), uri.clone()).await.unwrap();
+		let response = http_request(req.into(), uri.clone()).with_timeout().await.unwrap().unwrap();
 		assert_eq!(response.status, StatusCode::OK);
 		assert_eq!(response.body, ok_response(JsonValue::String("lo".to_owned()), Id::Num(i)));
 	}
@@ -77,66 +78,66 @@ async fn single_method_call_works() {
 #[tokio::test]
 async fn invalid_single_method_call() {
 	let _ = env_logger::try_init();
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":1, "params": "bar"}"#;
-	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	let response = http_request(req.into(), uri.clone()).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, parse_error(Id::Null));
 }
 
 #[tokio::test]
 async fn single_method_call_with_params() {
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
 }
 
 #[tokio::test]
 async fn single_method_call_with_multiple_params_of_different_types() {
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"multiparam", "params":["Hello", "World", [0,1,2,3]],"id":1}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, ok_response(JsonValue::String("string1=5, string2=5, vec=4".into()), Id::Num(1)));
 }
 
 #[tokio::test]
 async fn single_method_call_with_faulty_params_returns_err() {
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":["Invalid"],"id":1}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_params(Id::Num(1)));
 }
 
 #[tokio::test]
 async fn single_method_call_with_faulty_context() {
-	let addr = server_with_context().await;
+	let addr = server_with_context().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_err", "params":[],"id":1}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_context("RPC context failed", Id::Num(1)));
 }
 
 #[tokio::test]
 async fn single_method_call_with_ok_context() {
-	let addr = server_with_context().await;
+	let addr = server_with_context().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_ok", "params":[],"id":1}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, ok_response("ok".into(), Id::Num(1)));
 }
@@ -145,7 +146,7 @@ async fn single_method_call_with_ok_context() {
 async fn valid_batched_method_calls() {
 	let _ = env_logger::try_init();
 
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"[
@@ -154,7 +155,7 @@ async fn valid_batched_method_calls() {
 		{"jsonrpc":"2.0","method":"say_hello","id":3},
 		{"jsonrpc":"2.0","method":"add", "params":[5, 6],"id":4}
 	]"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(
 		response.body,
@@ -166,11 +167,11 @@ async fn valid_batched_method_calls() {
 async fn batched_notifications() {
 	let _ = env_logger::try_init();
 
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"[{"jsonrpc": "2.0", "method": "notif", "params": [1,2,4]},{"jsonrpc": "2.0", "method": "notif", "params": [7]}]"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	// Note: on HTTP acknowledge the notification with an empty response.
 	assert_eq!(response.body, "");
@@ -180,25 +181,25 @@ async fn batched_notifications() {
 async fn invalid_batched_method_calls() {
 	let _ = env_logger::try_init();
 
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	// batch with no requests
 	let req = r#"[]"#;
-	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	let response = http_request(req.into(), uri.clone()).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_request(Id::Null));
 
 	// batch with invalid request
 	let req = r#"[123]"#;
-	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	let response = http_request(req.into(), uri.clone()).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	// Note: according to the spec the `id` should be `null` here, not 123.
 	assert_eq!(response.body, invalid_request(Id::Num(123)));
 
 	// batch with invalid request
 	let req = r#"[1, 2, 3]"#;
-	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	let response = http_request(req.into(), uri.clone()).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	// Note: according to the spec this should return an array of three `Invalid Request`s
 	assert_eq!(response.body, parse_error(Id::Null));
@@ -208,51 +209,51 @@ async fn invalid_batched_method_calls() {
 		{"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
 		{"jsonrpc": "2.0", "method"
 	  ]"#;
-	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	let response = http_request(req.into(), uri.clone()).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, parse_error(Id::Null));
 }
 
 #[tokio::test]
 async fn should_return_method_not_found() {
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"bar","id":"foo"}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, method_not_found(Id::Str("foo".into())));
 }
 
 #[tokio::test]
 async fn invalid_json_id_missing_value() {
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
 	assert_eq!(response.body, parse_error(Id::Null));
 }
 
 #[tokio::test]
 async fn invalid_request_object() {
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_request(Id::Num(1)));
 }
 
 #[tokio::test]
 async fn notif_works() {
-	let addr = server().await;
+	let addr = server().with_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
 	let req = r#"{"jsonrpc":"2.0","method":"bar"}"#;
-	let response = http_request(req.into(), uri).await.unwrap();
+	let response = http_request(req.into(), uri).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, "");
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -11,13 +11,23 @@ pub mod types;
 /// Helper extension trait which allows to limit execution time for the futures.
 /// It is helpful in tests to ensure that no future will ever get stuck forever.
 pub trait TimeoutFutureExt<T>: Future<Output = T> + Sized {
-	/// Adds a fixed timeout to the future.
-	fn with_timeout(self) -> Timeout<Self> {
-		// If some future wasn't done in 5 seconds, it's either a poorly written test
+	/// Returns a reasonable value that can be used as a future timeout with a certain
+	/// degree of confidence that timeout won't be triggered by the test specifics.
+	fn default_timeout() -> Duration {
+		// If some future wasn't done in 60 seconds, it's either a poorly written test
 		// or (most likely) a bug related to some future never actually being completed.
-		const TIMEOUT_SECONDS: u64 = 5;
+		const TIMEOUT_SECONDS: u64 = 60;
+		Duration::from_secs(TIMEOUT_SECONDS)
+	}
 
-		timeout(Duration::from_secs(TIMEOUT_SECONDS), self)
+	/// Adds a fixed timeout to the future.
+	fn with_default_timeout(self) -> Timeout<Self> {
+		self.with_timeout(Self::default_timeout())
+	}
+
+	/// Adds a custom timeout to the future.
+	fn with_timeout(self, timeout_value: Duration) -> Timeout<Self> {
+		timeout(timeout_value, self)
 	}
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -2,5 +2,23 @@
 
 #![recursion_limit = "256"]
 
+use std::{future::Future, time::Duration};
+use tokio::time::{timeout, Timeout};
+
 pub mod helpers;
 pub mod types;
+
+/// Helper extension trait which allows to limit execution time for the futures.
+/// It is helpful in tests to ensure that no future will ever get stuck forever.
+pub trait TimeoutFutureExt<T>: Future<Output = T> + Sized {
+	/// Adds a fixed timeout to the future.
+	fn with_timeout(self) -> Timeout<Self> {
+		// If some future wasn't done in 5 seconds, it's either a poorly written test
+		// or (most likely) a bug related to some future never actually being completed.
+		const TIMEOUT_SECONDS: u64 = 5;
+
+		timeout(Duration::from_secs(TIMEOUT_SECONDS), self)
+	}
+}
+
+impl<T, U> TimeoutFutureExt<T> for U where U: Future<Output = T> + Sized {}

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -15,8 +15,11 @@ use serde_json::Value as JsonValue;
 
 #[tokio::test]
 async fn method_call_works() {
-	let result =
-		run_request_with_response(ok_response("hello".into(), Id::Num(0))).with_timeout().await.unwrap().unwrap();
+	let result = run_request_with_response(ok_response("hello".into(), Id::Num(0)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(JsonValue::String("hello".into()), result);
 }
 
@@ -24,48 +27,55 @@ async fn method_call_works() {
 async fn notif_works() {
 	// this empty string shouldn't be read because the server shouldn't respond to notifications.
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), String::new())
-		.with_timeout()
+		.with_default_timeout()
 		.await
 		.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_timeout().await.unwrap().unwrap();
-	assert!(client.notification("notif", JsonRpcParams::NoParams).with_timeout().await.unwrap().is_ok());
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	assert!(client.notification("notif", JsonRpcParams::NoParams).with_default_timeout().await.unwrap().is_ok());
 }
 
 #[tokio::test]
 async fn response_with_wrong_id() {
-	let err =
-		run_request_with_response(ok_response("hello".into(), Id::Num(99))).with_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(ok_response("hello".into(), Id::Num(99)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert!(matches!(err, Error::RestartNeeded(_)));
 }
 
 #[tokio::test]
 async fn response_method_not_found() {
-	let err = run_request_with_response(method_not_found(Id::Num(0))).with_timeout().await.unwrap().unwrap_err();
+	let err =
+		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::MethodNotFound.into());
 }
 
 #[tokio::test]
 async fn parse_error_works() {
-	let err = run_request_with_response(parse_error(Id::Num(0))).with_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::ParseError.into());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
-	let err = run_request_with_response(invalid_request(Id::Num(0_u64))).with_timeout().await.unwrap().unwrap_err();
+	let err =
+		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InvalidRequest.into());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
-	let err = run_request_with_response(invalid_params(Id::Num(0_u64))).with_timeout().await.unwrap().unwrap_err();
+	let err =
+		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InvalidParams.into());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
-	let err = run_request_with_response(internal_error(Id::Num(0_u64))).with_timeout().await.unwrap().unwrap_err();
+	let err =
+		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InternalError.into());
 }
 
@@ -76,19 +86,19 @@ async fn subscription_works() {
 		server_subscription_id_response(Id::Num(0)),
 		server_subscription_response(JsonValue::String("hello my friend".to_owned())),
 	)
-	.with_timeout()
+	.with_default_timeout()
 	.await
 	.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	{
 		let mut sub: Subscription<String> = client
 			.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello")
-			.with_timeout()
+			.with_default_timeout()
 			.await
 			.unwrap()
 			.unwrap();
-		let response: String = sub.next().with_timeout().await.unwrap().unwrap();
+		let response: String = sub.next().with_default_timeout().await.unwrap().unwrap();
 		assert_eq!("hello my friend".to_owned(), response);
 	}
 }
@@ -99,16 +109,16 @@ async fn notification_handler_works() {
 		"127.0.0.1:0".parse().unwrap(),
 		server_notification("test", "server originated notification works".into()),
 	)
-	.with_timeout()
+	.with_default_timeout()
 	.await
 	.unwrap();
 
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	{
 		let mut nh: NotificationHandler<String> =
-			client.register_notification("test").with_timeout().await.unwrap().unwrap();
-		let response: String = nh.next().with_timeout().await.unwrap().unwrap();
+			client.register_notification("test").with_default_timeout().await.unwrap().unwrap();
+		let response: String = nh.next().with_default_timeout().await.unwrap().unwrap();
 		assert_eq!("server originated notification works".to_owned(), response);
 	}
 }
@@ -119,33 +129,38 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 		"127.0.0.1:0".parse().unwrap(),
 		server_notification("test", "server originated notification".into()),
 	)
-	.with_timeout()
+	.with_default_timeout()
 	.await
 	.unwrap();
 
 	let uri = to_ws_uri_string(server.local_addr());
-	let client =
-		WsClientBuilder::default().max_notifs_per_subscription(4).build(&uri).with_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.max_notifs_per_subscription(4)
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	let mut nh: NotificationHandler<String> =
-		client.register_notification("test").with_timeout().await.unwrap().unwrap();
+		client.register_notification("test").with_default_timeout().await.unwrap().unwrap();
 
 	// don't poll the notification stream for 2 seconds, should be full now.
 	std::thread::sleep(std::time::Duration::from_secs(2));
 
 	// Capacity is `num_sender` + `capacity`
 	for _ in 0..5 {
-		assert!(nh.next().with_timeout().await.unwrap().is_some());
+		assert!(nh.next().with_default_timeout().await.unwrap().is_some());
 	}
 
 	// NOTE: this is now unuseable and unregistered.
-	assert!(nh.next().with_timeout().await.unwrap().is_none());
+	assert!(nh.next().with_default_timeout().await.unwrap().is_none());
 
 	// The same subscription should be possible to register again.
 	let mut other_nh: NotificationHandler<String> =
-		client.register_notification("test").with_timeout().await.unwrap().unwrap();
+		client.register_notification("test").with_default_timeout().await.unwrap().unwrap();
 
 	// check that the new subscription works.
-	assert!(other_nh.next().with_timeout().await.unwrap().is_some());
+	assert!(other_nh.next().with_default_timeout().await.unwrap().is_some());
 	assert!(client.is_connected());
 }
 
@@ -158,7 +173,7 @@ async fn batch_request_works() {
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}, {"jsonrpc":"2.0","result":"here's your swag","id":2}]"#.to_string();
 	let response =
-		run_batch_request_with_response(batch_request, server_response).with_timeout().await.unwrap().unwrap();
+		run_batch_request_with_response(batch_request, server_response).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
@@ -171,7 +186,7 @@ async fn batch_request_out_of_order_response() {
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"here's your swag","id":2}, {"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}]"#.to_string();
 	let response =
-		run_batch_request_with_response(batch_request, server_response).with_timeout().await.unwrap().unwrap();
+		run_batch_request_with_response(batch_request, server_response).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
@@ -181,13 +196,13 @@ async fn is_connected_works() {
 		"127.0.0.1:0".parse().unwrap(),
 		ok_response(JsonValue::String("foo".into()), Id::Num(99_u64)),
 	)
-	.with_timeout()
+	.with_default_timeout()
 	.await
 	.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	assert!(client.is_connected());
-	client.request::<String>("say_hello", JsonRpcParams::NoParams).with_timeout().await.unwrap().unwrap_err();
+	client.request::<String>("say_hello", JsonRpcParams::NoParams).with_default_timeout().await.unwrap().unwrap_err();
 	// give the background thread some time to terminate.
 	std::thread::sleep(std::time::Duration::from_millis(100));
 	assert!(!client.is_connected())
@@ -198,22 +213,22 @@ async fn run_batch_request_with_response<'a>(
 	response: String,
 ) -> Result<Vec<String>, Error> {
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), response)
-		.with_timeout()
+		.with_default_timeout()
 		.await
 		.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_timeout().await.unwrap().unwrap();
-	client.batch_request(batch).with_timeout().await.unwrap()
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	client.batch_request(batch).with_default_timeout().await.unwrap()
 }
 
 async fn run_request_with_response(response: String) -> Result<JsonValue, Error> {
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), response)
-		.with_timeout()
+		.with_default_timeout()
 		.await
 		.unwrap();
 	let uri = format!("ws://{}", server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_timeout().await.unwrap().unwrap();
-	client.request("say_hello", JsonRpcParams::NoParams).with_timeout().await.unwrap()
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	client.request("say_hello", JsonRpcParams::NoParams).with_default_timeout().await.unwrap()
 }
 
 fn assert_error_response(err: Error, exp: JsonRpcErrorObject) {

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -3,6 +3,7 @@
 use crate::{RpcContextModule, WsServer};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
+use jsonrpsee_test_utils::TimeoutFutureExt;
 use jsonrpsee_types::error::{CallError, Error};
 use serde_json::Value as JsonValue;
 use std::fmt;
@@ -21,7 +22,7 @@ impl std::error::Error for MyAppError {}
 /// Spawns a dummy `JSONRPC v2 WebSocket`
 /// It has two hardcoded methods: "say_hello" and "add"
 pub async fn server() -> SocketAddr {
-	let mut server = WsServer::new("127.0.0.1:0").await.unwrap();
+	let mut server = WsServer::new("127.0.0.1:0").with_timeout().await.unwrap().unwrap();
 
 	server
 		.register_method("say_hello", |_| {
@@ -54,7 +55,7 @@ pub async fn server() -> SocketAddr {
 
 /// Run server with user provided context.
 pub async fn server_with_context() -> SocketAddr {
-	let mut server = WsServer::new("127.0.0.1:0").await.unwrap();
+	let mut server = WsServer::new("127.0.0.1:0").with_timeout().await.unwrap().unwrap();
 
 	let ctx = TestContext;
 	let mut rpc_ctx = RpcContextModule::new(ctx);
@@ -84,11 +85,11 @@ pub async fn server_with_context() -> SocketAddr {
 #[tokio::test]
 async fn single_method_calls_works() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	for i in 0..10 {
 		let req = format!(r#"{{"jsonrpc":"2.0","method":"say_hello","id":{}}}"#, i);
-		let response = client.send_request_text(req).await.unwrap();
+		let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 
 		assert_eq!(response, ok_response(JsonValue::String("hello".to_owned()), Id::Num(i)));
 	}
@@ -97,10 +98,10 @@ async fn single_method_calls_works() {
 #[tokio::test]
 async fn slow_method_calls_works() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"sleep_for","params":[1000],"id":123}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 
 	assert_eq!(response, ok_response(JsonValue::String("Yawn!".to_owned()), Id::Num(123)));
 }
@@ -108,15 +109,14 @@ async fn slow_method_calls_works() {
 #[tokio::test]
 async fn batch_method_call_works() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
-	let mut batch = Vec::new();
-	batch.push(r#"{"jsonrpc":"2.0","method":"sleep_for","params":[1000],"id":123}"#.to_string());
+	let mut batch = vec![r#"{"jsonrpc":"2.0","method":"sleep_for","params":[1000],"id":123}"#.to_string()];
 	for i in 1..4 {
 		batch.push(format!(r#"{{"jsonrpc":"2.0","method":"say_hello","id":{}}}"#, i));
 	}
 	let batch = format!("[{}]", batch.join(","));
-	let response = client.send_request_text(batch).await.unwrap();
+	let response = client.send_request_text(batch).with_timeout().await.unwrap().unwrap();
 	assert_eq!(
 		response,
 		r#"[{"jsonrpc":"2.0","result":"Yawn!","id":123},{"jsonrpc":"2.0","result":"hello","id":1},{"jsonrpc":"2.0","result":"hello","id":2},{"jsonrpc":"2.0","result":"hello","id":3}]"#
@@ -126,15 +126,16 @@ async fn batch_method_call_works() {
 #[tokio::test]
 async fn batch_method_call_where_some_calls_fail() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
-	let mut batch = Vec::new();
-	batch.push(r#"{"jsonrpc":"2.0","method":"say_hello","id":1}"#);
-	batch.push(r#"{"jsonrpc":"2.0","method":"call_fail","id":2}"#);
-	batch.push(r#"{"jsonrpc":"2.0","method":"add","params":[34, 45],"id":3}"#);
+	let batch = vec![
+		r#"{"jsonrpc":"2.0","method":"say_hello","id":1}"#,
+		r#"{"jsonrpc":"2.0","method":"call_fail","id":2}"#,
+		r#"{"jsonrpc":"2.0","method":"add","params":[34, 45],"id":3}"#,
+	];
 	let batch = format!("[{}]", batch.join(","));
 
-	let response = client.send_request_text(batch).await.unwrap();
+	let response = client.send_request_text(batch).with_timeout().await.unwrap().unwrap();
 
 	assert_eq!(
 		response,
@@ -145,10 +146,10 @@ async fn batch_method_call_where_some_calls_fail() {
 #[tokio::test]
 async fn single_method_call_with_params_works() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
 }
 
@@ -156,60 +157,60 @@ async fn single_method_call_with_params_works() {
 async fn single_method_call_with_faulty_params_returns_err() {
 	let _ = env_logger::try_init();
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":["Invalid"],"id":1}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_params(Id::Num(1)));
 }
 
 #[tokio::test]
 async fn single_method_call_with_faulty_context() {
 	let addr = server_with_context().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_err", "params":[],"id":1}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_context("RPC context failed", Id::Num(1)));
 }
 
 #[tokio::test]
 async fn single_method_call_with_ok_context() {
 	let addr = server_with_context().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_ok", "params":[],"id":1}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, ok_response("ok".into(), Id::Num(1)));
 }
 
 #[tokio::test]
 async fn single_method_send_binary() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-	let response = client.send_request_binary(req.as_bytes()).await.unwrap();
+	let response = client.send_request_binary(req.as_bytes()).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
 }
 
 #[tokio::test]
 async fn should_return_method_not_found() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"bar","id":"foo"}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, method_not_found(Id::Str("foo".into())));
 }
 
 #[tokio::test]
 async fn invalid_json_id_missing_value() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
 	assert_eq!(response, parse_error(Id::Null));
 }
@@ -217,16 +218,16 @@ async fn invalid_json_id_missing_value() {
 #[tokio::test]
 async fn invalid_request_object() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_request(Id::Num(1)));
 }
 
 #[tokio::test]
 async fn register_methods_works() {
-	let mut server = WsServer::new("127.0.0.1:0").await.unwrap();
+	let mut server = WsServer::new("127.0.0.1:0").with_timeout().await.unwrap().unwrap();
 	assert!(server.register_method("say_hello", |_| Ok("lo")).is_ok());
 	assert!(server.register_method("say_hello", |_| Ok("lo")).is_err());
 	assert!(server.register_subscription("subscribe_hello", "unsubscribe_hello").is_ok());
@@ -239,7 +240,7 @@ async fn register_methods_works() {
 
 #[tokio::test]
 async fn register_same_subscribe_unsubscribe_is_err() {
-	let mut server = WsServer::new("127.0.0.1:0").await.unwrap();
+	let mut server = WsServer::new("127.0.0.1:0").with_timeout().await.unwrap().unwrap();
 	assert!(matches!(
 		server.register_subscription("subscribe_hello", "subscribe_hello"),
 		Err(Error::SubscriptionNameConflict(_))
@@ -249,46 +250,46 @@ async fn register_same_subscribe_unsubscribe_is_err() {
 #[tokio::test]
 async fn parse_error_request_should_not_close_connection() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let invalid_request = r#"{"jsonrpc":"2.0","method":"bar","params":[1,"id":99}"#;
-	let response1 = client.send_request_text(invalid_request).await.unwrap();
+	let response1 = client.send_request_text(invalid_request).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response1, parse_error(Id::Null));
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":33}"#;
-	let response2 = client.send_request_text(request).await.unwrap();
+	let response2 = client.send_request_text(request).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response2, ok_response(JsonValue::String("hello".to_owned()), Id::Num(33)));
 }
 
 #[tokio::test]
 async fn invalid_request_should_not_close_connection() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_request(Id::Num(1)));
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":33}"#;
-	let response = client.send_request_text(request).await.unwrap();
+	let response = client.send_request_text(request).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, ok_response(JsonValue::String("hello".to_owned()), Id::Num(33)));
 }
 
 #[tokio::test]
 async fn valid_request_that_fails_to_execute_should_not_close_connection() {
 	let addr = server().await;
-	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_timeout().await.unwrap().unwrap();
 
 	// Good request, executes fine
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":33}"#;
-	let response = client.send_request_text(request).await.unwrap();
+	let response = client.send_request_text(request).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, ok_response(JsonValue::String("hello".to_owned()), Id::Num(33)));
 
 	// Good request, but causes error.
 	let req = r#"{"jsonrpc":"2.0","method":"call_fail","params":[],"id":123}"#;
-	let response = client.send_request_text(req).await.unwrap();
+	let response = client.send_request_text(req).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"MyAppError"},"id":123}"#);
 
 	// Connection is still good.
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":333}"#;
-	let response = client.send_request_text(request).await.unwrap();
+	let response = client.send_request_text(request).with_timeout().await.unwrap().unwrap();
 	assert_eq!(response, ok_response(JsonValue::String("hello".to_owned()), Id::Num(333)));
 }


### PR DESCRIPTION
I was a bit worried by the fact that CI jobs sometimes get stuck on their own.
I think it *may* be a signal of some hard-to-get but yet dangerous issue (or some kind of misconfiguration).

This PR adds ~~5~~60-second timeout to the futures spawned in tests, so it will be easier to get enough information and probably find the common pattern in these failures. Also, with it jobs will fail fast, without having to wait for the timeout.