### PR TITLE
Switch from anyhow::Result to std Result

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -49,7 +49,7 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	let mut server = HttpServerBuilder::default().build("127.0.0.1:0".parse()?)?;
 	server.register_method("say_hello", |_| Ok("lo"))?;
-	let addr = server.local_addr();
+	let addr = server.local_addr()?;
 	tokio::spawn(async move { server.start().await });
-	addr
+	Ok(addr)
 }

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	let mut server = HttpServerBuilder::default().build("127.0.0.1:0".parse()?)?;
 	server.register_method("state_getPairs", |_| Ok(vec![1, 2, 3]))?;
-	let addr = server.local_addr();
+	let addr = server.local_addr()?;
 	tokio::spawn(async move { server.start().await });
-	addr
+	Ok(addr)
 }

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -47,7 +47,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let mut server = WsServer::new("127.0.0.1:0").await?;
 	server.register_method("say_hello", |_| Ok("lo"))?;
 
-	let addr = server.local_addr();
+	let addr = server.local_addr()?;
 	tokio::spawn(async move { server.start().await });
-	addr
+	Ok(addr)
 }

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -61,7 +61,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		std::thread::sleep(std::time::Duration::from_secs(1));
 	});
 
-	let addr = server.local_addr();
+	let addr = server.local_addr()?;
 	tokio::spawn(async move { server.start().await });
-	addr
+	Ok(addr)
 }

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-http-server"
 
 [dependencies]
-anyhow = "1"
+thiserror = "1"
 hyper = { version = "0.14", features = ["server", "http1", "http2", "tcp"] }
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -25,7 +25,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{response, AccessControl, TEN_MB_SIZE_BYTES};
-use anyhow::anyhow;
 use futures_channel::mpsc;
 use futures_util::stream::StreamExt;
 use hyper::{
@@ -77,7 +76,7 @@ impl Builder {
 		self
 	}
 
-	pub fn build(self, addr: SocketAddr) -> anyhow::Result<Server> {
+	pub fn build(self, addr: SocketAddr) -> Result<Server, Error> {
 		let domain = Domain::for_address(addr);
 		let socket = Socket::new(domain, Type::STREAM, None)?;
 		socket.set_nodelay(true)?;
@@ -137,12 +136,12 @@ impl Server {
 	}
 
 	/// Returns socket address to which the server is bound.
-	pub fn local_addr(&self) -> anyhow::Result<SocketAddr> {
-		self.local_addr.ok_or_else(|| anyhow!("Local address not found"))
+	pub fn local_addr(&self) -> Result<SocketAddr, Error> {
+		self.local_addr.ok_or_else(|| Error::Custom("Local address not found".into()))
 	}
 
 	/// Start the server.
-	pub async fn start(self) -> anyhow::Result<()> {
+	pub async fn start(self) -> Result<(), Error> {
 		let methods = Arc::new(self.root.into_methods());
 		let max_request_body_size = self.max_request_body_size;
 		let access_control = self.access_control;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,7 +18,5 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
-# TODO: a bit sad to have to pull in soketto to handle errors
 soketto = "0.4"
-# TODO: a bit sad to have to pull in soketto to handle errors
 hyper = "0.14"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,3 +18,7 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
+# TODO: a bit sad to have to pull in soketto to handle errors
+soketto = "0.4"
+# TODO: a bit sad to have to pull in soketto to handle errors
+hyper = "0.14"

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -31,7 +31,7 @@ pub enum CallError {
 pub enum Error {
 	/// Error that occurs when a call failed.
 	#[error("Server call failed: {0}")]
-	Call(CallError),
+	Call(#[from] CallError),
 	/// Networking error or error on the low-level protocol layer.
 	#[error("Networking or low-level protocol error: {0}")]
 	Transport(#[source] Box<dyn std::error::Error + Send + Sync>),
@@ -49,7 +49,7 @@ pub enum Error {
 	RestartNeeded(String),
 	/// Failed to parse the data.
 	#[error("Parse error: {0}")]
-	ParseError(#[source] serde_json::Error),
+	ParseError(#[from] serde_json::Error),
 	/// Invalid subscription ID.
 	#[error("Invalid subscription ID")]
 	InvalidSubscriptionId,
@@ -88,18 +88,6 @@ pub enum GenericTransportError<T: std::error::Error + Send + Sync> {
 	/// Concrete transport error.
 	#[error("Transport error: {0}")]
 	Inner(T),
-}
-
-impl From<CallError> for Error {
-	fn from(call_err: CallError) -> Error {
-		Error::Call(call_err)
-	}
-}
-
-impl From<serde_json::Error> for Error {
-	fn from(json_err: serde_json::Error) -> Error {
-		Error::ParseError(json_err)
-	}
 }
 
 impl From<std::io::Error> for Error {

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -90,7 +90,6 @@ pub enum GenericTransportError<T: std::error::Error + Send + Sync> {
 	Inner(T),
 }
 
-
 impl From<CallError> for Error {
 	fn from(call_err: CallError) -> Error {
 		Error::Call(call_err)

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+
 /// Convenience type for displaying errors.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Mismatch<T> {
@@ -87,4 +88,41 @@ pub enum GenericTransportError<T: std::error::Error + Send + Sync> {
 	/// Concrete transport error.
 	#[error("Transport error: {0}")]
 	Inner(T),
+}
+
+
+impl From<CallError> for Error {
+	fn from(call_err: CallError) -> Error {
+		Error::Call(call_err)
+	}
+}
+
+impl From<serde_json::Error> for Error {
+	fn from(json_err: serde_json::Error) -> Error {
+		Error::ParseError(json_err)
+	}
+}
+
+impl From<std::io::Error> for Error {
+	fn from(io_err: std::io::Error) -> Error {
+		Error::Transport(Box::new(io_err))
+	}
+}
+
+impl From<soketto::handshake::Error> for Error {
+	fn from(handshake_err: soketto::handshake::Error) -> Error {
+		Error::Transport(Box::new(handshake_err))
+	}
+}
+
+impl From<soketto::connection::Error> for Error {
+	fn from(conn_err: soketto::connection::Error) -> Error {
+		Error::Transport(Box::new(conn_err))
+	}
+}
+
+impl From<hyper::Error> for Error {
+	fn from(hyper_err: hyper::Error) -> Error {
+		Error::Transport(Box::new(hyper_err))
+	}
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-anyhow = { version = "1", optional = true }
+thiserror = { version = "1", optional = true }
 futures-channel = { version = "0.3", default-features = false, optional = true }
 futures-util = { version = "0.3", default-features = false, optional = true }
 hyper13 = { package = "hyper", version = "0.13", default-features = false, features = ["stream"], optional = true }
@@ -25,7 +25,7 @@ default = []
 hyper_13 = ["hyper13", "futures-util", "jsonrpsee-types"]
 hyper_14 = ["hyper14", "futures-util", "jsonrpsee-types"]
 server = [
-	"anyhow",
+	"thiserror",
 	"futures-channel",
 	"futures-util",
 	"jsonrpsee-types",

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-server"
 
 [dependencies]
-anyhow = "1.0.34"
+thiserror = "1"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.6" }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -49,7 +49,7 @@ pub struct Server {
 
 impl Server {
 	/// Create a new WebSocket RPC server, bound to the `addr`.
-	pub async fn new(addr: impl ToSocketAddrs) -> anyhow::Result<Self> {
+	pub async fn new(addr: impl ToSocketAddrs) -> Result<Self, Error> {
 		let listener = TcpListener::bind(addr).await?;
 
 		Ok(Server { listener, root: RpcModule::new() })
@@ -79,7 +79,7 @@ impl Server {
 	}
 
 	/// Returns socket address to which the server is bound.
-	pub fn local_addr(&self) -> anyhow::Result<SocketAddr> {
+	pub fn local_addr(&self) -> Result<SocketAddr, Error> {
 		self.listener.local_addr().map_err(Into::into)
 	}
 
@@ -107,7 +107,7 @@ async fn background_task(
 	socket: tokio::net::TcpStream,
 	methods: Arc<Methods>,
 	conn_id: ConnectionId,
-) -> anyhow::Result<()> {
+) -> Result<(), Error> {
 	// For each incoming background_task we perform a handshake.
 	let mut server = SokettoServer::new(BufReader::new(BufWriter::new(socket.compat())));
 


### PR DESCRIPTION
Don't return `anyhow::Result`﻿and instead just use `thiserror` and standard `Result<T, Error>` where `Error` is the `jsonrpsee_types::error::Error` type.

The downside is that with this PR `jsonrpsee_types` depends on both `soketto` and `hyper`. I think making `jsonrpsee_types` as dependency-free as possible was a big part of an external crate in the first place. OTOH all users will depend on at least one of them.
