### PR TITLE
[servers] Mmove transport specific errors to respective crates

### DIFF
--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{response, AccessControl, TEN_MB_SIZE_BYTES};
+use crate::{response, AccessControl, HttpError, TEN_MB_SIZE_BYTES};
 use futures_channel::mpsc;
 use futures_util::stream::StreamExt;
 use hyper::{
@@ -76,7 +76,7 @@ impl Builder {
 		self
 	}
 
-	pub fn build(self, addr: SocketAddr) -> Result<Server, Error> {
+	pub fn build(self, addr: SocketAddr) -> Result<Server, HttpError> {
 		let domain = Domain::for_address(addr);
 		let socket = Socket::new(domain, Type::STREAM, None)?;
 		socket.set_nodelay(true)?;
@@ -141,7 +141,7 @@ impl Server {
 	}
 
 	/// Start the server.
-	pub async fn start(self) -> Result<(), Error> {
+	pub async fn start(self) -> Result<(), HttpError> {
 		let methods = Arc::new(self.root.into_methods());
 		let max_request_body_size = self.max_request_body_size;
 		let access_control = self.access_control;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,5 +18,3 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
-soketto = "0.4"
-hyper = "0.14"

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -95,21 +95,3 @@ impl From<std::io::Error> for Error {
 		Error::Transport(Box::new(io_err))
 	}
 }
-
-impl From<soketto::handshake::Error> for Error {
-	fn from(handshake_err: soketto::handshake::Error) -> Error {
-		Error::Transport(Box::new(handshake_err))
-	}
-}
-
-impl From<soketto::connection::Error> for Error {
-	fn from(conn_err: soketto::connection::Error) -> Error {
-		Error::Transport(Box::new(conn_err))
-	}
-}
-
-impl From<hyper::Error> for Error {
-	fn from(hyper_err: hyper::Error) -> Error {
-		Error::Transport(Box::new(hyper_err))
-	}
-}

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -130,7 +130,6 @@ impl RpcModule {
 			self.methods.insert(
 				unsubscribe_method_name,
 				Box::new(move |id, params, tx, conn| {
-					// let sub_id = params.one().map_err(|e| anyhow::anyhow!("{:?}", e))?;
 					let sub_id = params.one()?;
 
 					subscribers.lock().remove(&(conn, sub_id));

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -42,6 +42,8 @@ use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest};
 use jsonrpsee_utils::server::helpers::{collect_batch_response, send_error};
 use jsonrpsee_utils::server::rpc_module::{ConnectionId, MethodSink, Methods, RpcModule, SubscriptionSink};
 
+use crate::WsError;
+
 pub struct Server {
 	root: RpcModule,
 	listener: TcpListener,
@@ -107,7 +109,7 @@ async fn background_task(
 	socket: tokio::net::TcpStream,
 	methods: Arc<Methods>,
 	conn_id: ConnectionId,
-) -> Result<(), Error> {
+) -> Result<(), WsError> {
 	// For each incoming background_task we perform a handshake.
 	let mut server = SokettoServer::new(BufReader::new(BufWriter::new(socket.compat())));
 


### PR DESCRIPTION
Move transport-specific error conversion to http/ws crates respectively.

This lets us avoid pulling in hyper and soketto as dependencies to the `jsonrpsee_types` crate.
