### PR TITLE
chore(deps): update futures 0.3.14

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dev-dependencies]
 criterion = "0.3"
-futures-channel = "0.3"
+futures-channel = "0.3.14"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 num_cpus = "1"
 serde_json = "1"

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/jsonrpsee-http-server"
 [dependencies]
 thiserror = "1"
 hyper = { version = "0.14", features = ["server", "http1", "http2", "tcp"] }
-futures-channel = "0.3"
-futures-util = { version = "0.3", default-features = false }
+futures-channel = "0.3.14"
+futures-util = { version = "0.3.14", default-features = false }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.6" }
 jsonrpsee-utils = { path = "../utils", version = "0.2.0-alpha.6", features = ["server", "hyper_14"] }
 globset = "0.4"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 [dependencies]
 async-std = "1.9"
 anyhow = "1"
-futures-channel = "0.3"
-futures-util = "0.3"
+futures-channel = "0.3.14"
+futures-util = "0.3.14"
 hyper = { version = "0.14", features = ["full"] }
 log = "0.4"
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 
 [dev-dependencies]
 env_logger = "0.8"
-futures-channel = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3.14", default-features = false }
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 tokio = { version = "1", features = ["full"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/jsonrpsee-types"
 [dependencies]
 async-trait = "0.1"
 beef = { version = "0.5", features = ["impl_serde"] }
-futures-channel = { version = "0.3", features = ["sink"] }
-futures-util = { version = "0.3", default-features = false, features = ["std", "sink", "channel"] }
+futures-channel = { version = "0.3.14", features = ["sink"] }
+futures-util = { version = "0.3.14", default-features = false, features = ["std", "sink", "channel"] }
 log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 
 [dependencies]
 thiserror = { version = "1", optional = true }
-futures-channel = { version = "0.3", default-features = false, optional = true }
-futures-util = { version = "0.3", default-features = false, optional = true }
+futures-channel = { version = "0.3.14", default-features = false, optional = true }
+futures-util = { version = "0.3.14", default-features = false, optional = true }
 hyper13 = { package = "hyper", version = "0.13", default-features = false, features = ["stream"], optional = true }
 hyper14 = { package = "hyper", version = "0.14", default-features = false, features = ["stream"], optional = true }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.6", optional = true }

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 async-std = "1.9"
 async-tls = "0.11"
 fnv = "1"
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.6" }
 log = "0.4"
 serde = "1"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 
 [dependencies]
 thiserror = "1"
-futures-channel = "0.3"
-futures-util = { version = "0.3", default-features = false, features = ["io"] }
+futures-channel = "0.3.14"
+futures-util = { version = "0.3.14", default-features = false, features = ["io"] }
 jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.6" }
 jsonrpsee-utils = { path = "../utils", version = "0.2.0-alpha.6", features = ["server"] }
 log = "0.4"


### PR DESCRIPTION
The reason is that `Receiver::next` won't panic polling after `Ok(None)` has been received.