### PR TITLE
chore(deps): relax async-std to 1

### DIFF
--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = "1.9"
+async-std = "1"
 anyhow = "1"
 futures-channel = "0.3"
 futures-util = "0.3"

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
 async-trait = "0.1"
-async-std = "1.9"
+async-std = "1"
 async-tls = "0.11"
 fnv = "1"
 futures = { version = "0.3", default-features = false, features = ["std"] }


### PR DESCRIPTION
Make it more flexible for users to select which version of `async-std` to use.