### PR TITLE
fix(jsonrpsee internal deps): use exact version for pre-release

### DIFF
--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -15,8 +15,8 @@ hyper13-rustls = { package = "hyper-rustls", version = "0.21", optional = true }
 hyper14-rustls = { package = "hyper-rustls", version = "0.22", optional = true }
 hyper14 = { package = "hyper", version = "0.14", features = ["client", "http1", "http2", "tcp"], optional = true }
 hyper13 = { package = "hyper", version = "0.13", optional = true }
-jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.7" }
-jsonrpsee-utils = { path = "../utils", version = "0.2.0-alpha.7", optional = true }
+jsonrpsee-types = { path = "../types", version = "=0.2.0-alpha.7" }
+jsonrpsee-utils = { path = "../utils", version = "=0.2.0-alpha.7", optional = true }
 log = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -14,8 +14,8 @@ thiserror = "1"
 hyper = { version = "0.14", features = ["server", "http1", "http2", "tcp"] }
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false }
-jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.7" }
-jsonrpsee-utils = { path = "../utils", version = "0.2.0-alpha.7", features = ["server", "hyper_14"] }
+jsonrpsee-types = { path = "../types", version = "=0.2.0-alpha.7" }
+jsonrpsee-utils = { path = "../utils", version = "=0.2.0-alpha.7", features = ["server", "hyper_14"] }
 globset = "0.4"
 lazy_static = "1.4"
 log = "0.4"

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -10,12 +10,12 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee"
 
 [dependencies]
-http-client = { path = "../http-client", version = "0.2.0-alpha.7", package = "jsonrpsee-http-client", optional = true }
-http-server = { path = "../http-server", version = "0.2.0-alpha.7", package = "jsonrpsee-http-server", optional = true }
-ws-client = { path = "../ws-client", version = "0.2.0-alpha.7", package = "jsonrpsee-ws-client", optional = true }
-ws-server = { path = "../ws-server", version = "0.2.0-alpha.7", package = "jsonrpsee-ws-server", optional = true }
-proc-macros = { path = "../proc-macros", version = "0.2.0-alpha.7", package = "jsonrpsee-proc-macros", optional = true }
-types = { path = "../types", version = "0.2.0-alpha.7", package = "jsonrpsee-types", optional = true }
+http-client = { path = "../http-client", version = "=0.2.0-alpha.7", package = "jsonrpsee-http-client", optional = true }
+http-server = { path = "../http-server", version = "=0.2.0-alpha.7", package = "jsonrpsee-http-server", optional = true }
+ws-client = { path = "../ws-client", version = "=0.2.0-alpha.7", package = "jsonrpsee-ws-client", optional = true }
+ws-server = { path = "../ws-server", version = "=0.2.0-alpha.7", package = "jsonrpsee-ws-server", optional = true }
+proc-macros = { path = "../proc-macros", version = "=0.2.0-alpha.7", package = "jsonrpsee-proc-macros", optional = true }
+types = { path = "../types", version = "=0.2.0-alpha.7", package = "jsonrpsee-types", optional = true }
 
 [features]
 client = ["http-client", "ws-client"]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,7 +12,7 @@ futures-channel = { version = "0.3.14", default-features = false, optional = tru
 futures-util = { version = "0.3.14", default-features = false, optional = true }
 hyper13 = { package = "hyper", version = "0.13", default-features = false, features = ["stream"], optional = true }
 hyper14 = { package = "hyper", version = "0.14", default-features = false, features = ["stream"], optional = true }
-jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.7", optional = true }
+jsonrpsee-types = { path = "../types", version = "=0.2.0-alpha.7", optional = true }
 log = { version = "0.4", optional = true }
 rustc-hash = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -15,7 +15,7 @@ async-std = "1"
 async-tls = "0.11"
 fnv = "1"
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
-jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.7" }
+jsonrpsee-types = { path = "../types", version = "=0.2.0-alpha.7" }
 log = "0.4"
 serde = "1"
 serde_json = "1"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 thiserror = "1"
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io"] }
-jsonrpsee-types = { path = "../types", version = "0.2.0-alpha.7" }
-jsonrpsee-utils = { path = "../utils", version = "0.2.0-alpha.7", features = ["server"] }
+jsonrpsee-types = { path = "../types", version = "=0.2.0-alpha.7" }
+jsonrpsee-utils = { path = "../utils", version = "=0.2.0-alpha.7", features = ["server"] }
 log = "0.4"
 rustc-hash = "1.1.0"
 serde = { version = "1", default-features = false, features = ["derive"] }


### PR DESCRIPTION
This PR requires the internal dependencies to require the exact version
because `cargo` will otherwise fetch the latest version, closing #352

This could also be achievied by `cargo update -p package --precise x.y.z`.

Should be reverted once we release 0.2