### PR TITLE
Fix clippy lints

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,7 +16,7 @@ mod helpers;
 criterion_group!(benches, http_requests, batched_http_requests, websocket_requests, jsonrpsee_types_v2);
 criterion_main!(benches);
 
-fn v2_serialize<'a>(req: JsonRpcCallSer<'a>) -> String {
+fn v2_serialize(req: JsonRpcCallSer<'_>) -> String {
 	serde_json::to_string(&req).unwrap()
 }
 
@@ -44,14 +44,14 @@ pub fn http_requests(crit: &mut Criterion) {
 	let url = rt.block_on(helpers::http_server());
 	let client = Arc::new(HttpClientBuilder::default().build(&url).unwrap());
 	run_round_trip(&rt, crit, client.clone(), "http_round_trip");
-	run_concurrent_round_trip(&rt, crit, client.clone(), "http_concurrent_round_trip");
+	run_concurrent_round_trip(&rt, crit, client, "http_concurrent_round_trip");
 }
 
 pub fn batched_http_requests(crit: &mut Criterion) {
 	let rt = TokioRuntime::new().unwrap();
 	let url = rt.block_on(helpers::http_server());
 	let client = Arc::new(HttpClientBuilder::default().build(&url).unwrap());
-	run_round_trip_with_batch(&rt, crit, client.clone(), "http batch requests");
+	run_round_trip_with_batch(&rt, crit, client, "http batch requests");
 }
 
 pub fn websocket_requests(crit: &mut Criterion) {
@@ -60,7 +60,7 @@ pub fn websocket_requests(crit: &mut Criterion) {
 	let client =
 		Arc::new(rt.block_on(WsClientBuilder::default().max_concurrent_requests(1024 * 1024).build(&url)).unwrap());
 	run_round_trip(&rt, crit, client.clone(), "ws_round_trip");
-	run_concurrent_round_trip(&rt, crit, client.clone(), "ws_concurrent_round_trip");
+	run_concurrent_round_trip(&rt, crit, client, "ws_concurrent_round_trip");
 }
 
 pub fn batched_ws_requests(crit: &mut Criterion) {
@@ -68,7 +68,7 @@ pub fn batched_ws_requests(crit: &mut Criterion) {
 	let url = rt.block_on(helpers::ws_server());
 	let client =
 		Arc::new(rt.block_on(WsClientBuilder::default().max_concurrent_requests(1024 * 1024).build(&url)).unwrap());
-	run_round_trip_with_batch(&rt, crit, client.clone(), "ws batch requests");
+	run_round_trip_with_batch(&rt, crit, client, "ws batch requests");
 }
 
 fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str) {

--- a/examples/weather.rs
+++ b/examples/weather.rs
@@ -68,8 +68,8 @@ struct Wind {
 impl RestPath<&(String, String)> for Weather {
 	fn get_path(params: &(String, String)) -> Result<String, RestsonError> {
 		// Set up your own API key at https://openweathermap.org/current
-		const API_KEY: &'static str = "f6ba475df300d5f91135550da0f4a867";
-		Ok(String::from(format!("data/2.5/weather?q={}&units={}&appid={}", params.0, params.1, API_KEY,)))
+		const API_KEY: &str = "f6ba475df300d5f91135550da0f4a867";
+		Ok(format!("data/2.5/weather?q={}&units={}&appid={}", params.0, params.1, API_KEY,))
 	}
 }
 

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	const LETTERS: &'static str = "abcdefghijklmnopqrstuvxyz";
+	const LETTERS: &str = "abcdefghijklmnopqrstuvxyz";
 	let mut server = WsServer::new("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module

--- a/http-server/src/access_control/cors.rs
+++ b/http-server/src/access_control/cors.rs
@@ -435,7 +435,7 @@ mod tests {
 	#[test]
 	fn should_return_none_for_not_matching_origin() {
 		// given
-		let origin = Some("http://parity.io".into());
+		let origin = Some("http://parity.io");
 		let host = None;
 
 		// when
@@ -452,7 +452,7 @@ mod tests {
 	#[test]
 	fn should_return_specific_origin_if_we_allow_any() {
 		// given
-		let origin = Some("http://parity.io".into());
+		let origin = Some("http://parity.io");
 		let host = None;
 
 		// when
@@ -478,7 +478,7 @@ mod tests {
 	#[test]
 	fn should_return_null_if_origin_is_null() {
 		// given
-		let origin = Some("null".into());
+		let origin = Some("null");
 		let host = None;
 
 		// when
@@ -491,7 +491,7 @@ mod tests {
 	#[test]
 	fn should_return_specific_origin_if_there_is_a_match() {
 		// given
-		let origin = Some("http://parity.io".into());
+		let origin = Some("http://parity.io");
 		let host = None;
 
 		// when
@@ -511,9 +511,9 @@ mod tests {
 	#[test]
 	fn should_support_wildcards() {
 		// given
-		let origin1 = Some("http://parity.io".into());
-		let origin2 = Some("http://parity.iot".into());
-		let origin3 = Some("chrome-extension://test".into());
+		let origin1 = Some("http://parity.io");
+		let origin2 = Some("http://parity.iot");
+		let origin3 = Some("chrome-extension://test");
 		let host = None;
 		let allowed = Some(vec![
 			AccessControlAllowOrigin::Value("http://*.io".into()),
@@ -539,7 +539,7 @@ mod tests {
 		let requested = vec!["x-not-allowed"];
 
 		// when
-		let res = get_cors_allow_headers(headers.iter(), requested.iter(), &cors_allow_headers.into(), |x| x);
+		let res = get_cors_allow_headers(headers.iter(), requested.iter(), &cors_allow_headers, |x| x);
 
 		// then
 		assert_eq!(res, AllowCors::Invalid);
@@ -549,13 +549,12 @@ mod tests {
 	fn should_return_valid_if_header_allowed() {
 		// given
 		let allowed = vec!["x-allowed".to_owned()];
-		let cors_allow_headers = AccessControlAllowHeaders::Only(allowed.clone());
+		let cors_allow_headers = AccessControlAllowHeaders::Only(allowed);
 		let headers = vec!["Access-Control-Request-Headers"];
 		let requested = vec!["x-allowed"];
 
 		// when
-		let res =
-			get_cors_allow_headers(headers.iter(), requested.iter(), &cors_allow_headers.into(), |x| (*x).to_owned());
+		let res = get_cors_allow_headers(headers.iter(), requested.iter(), &cors_allow_headers, |x| (*x).to_owned());
 
 		// then
 		let allowed = vec!["x-allowed".to_owned()];
@@ -566,7 +565,7 @@ mod tests {
 	fn should_return_no_allowed_headers_if_none_in_request() {
 		// given
 		let allowed = vec!["x-allowed".to_owned()];
-		let cors_allow_headers = AccessControlAllowHeaders::Only(allowed.clone());
+		let cors_allow_headers = AccessControlAllowHeaders::Only(allowed);
 		let headers: Vec<String> = vec![];
 
 		// when
@@ -583,7 +582,7 @@ mod tests {
 		let headers: Vec<String> = vec![];
 
 		// when
-		let res = get_cors_allow_headers(headers.iter(), iter::empty(), &cors_allow_headers.into(), |x| x);
+		let res = get_cors_allow_headers(headers.iter(), iter::empty(), &cors_allow_headers, |x| x);
 
 		// then
 		assert_eq!(res, AllowCors::NotRequired);

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -25,6 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 #![cfg(test)]
+#![allow(clippy::blacklisted_name)]
 
 mod helpers;
 

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -169,7 +169,7 @@ mod tests {
 		let ser = r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}"#;
 		let exp = JsonRpcError {
 			jsonrpc: TwoPointZero,
-			error: JsonRpcErrorObject { code: JsonRpcErrorCode::ParseError, message: "Parse error".into(), data: None },
+			error: JsonRpcErrorObject { code: JsonRpcErrorCode::ParseError, message: "Parse error", data: None },
 			id: Id::Null,
 		};
 		let err: JsonRpcError = serde_json::from_str(ser).unwrap();
@@ -184,7 +184,7 @@ mod tests {
 			jsonrpc: TwoPointZero,
 			error: JsonRpcErrorObject {
 				code: JsonRpcErrorCode::ParseError,
-				message: "Parse error".into(),
+				message: "Parse error",
 				data: Some(&*data),
 			},
 			id: Id::Null,


### PR DESCRIPTION
While it's nothing critical, it's kinda annoying to see these warnings all the time (I use `cargo clippy` instead of `cargo check`).