### PR TITLE
Use a single map for methods

### DIFF
--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -30,7 +30,7 @@ mod server;
 
 pub use access_control::{AccessControl, AccessControlBuilder, AllowHosts, Host};
 pub use jsonrpsee_types::{Error, TEN_MB_SIZE_BYTES};
-pub use jsonrpsee_utils::server::rpc_module::{RpcModule, SyncMethods};
+pub use jsonrpsee_utils::server::rpc_module::RpcModule;
 pub use server::{Builder as HttpServerBuilder, Server as HttpServer};
 
 #[cfg(test)]

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -40,7 +40,7 @@ use jsonrpsee_utils::hyper_helpers::read_response_to_body;
 use jsonrpsee_utils::server::rpc_module::{MethodSink, RpcModule};
 use jsonrpsee_utils::server::{
 	helpers::{collect_batch_response, send_error},
-	rpc_module::{MethodCallback, Methods, SyncMethod},
+	rpc_module::{MethodCallback, Methods, SyncMethod, AsyncMethod},
 };
 
 use socket2::{Domain, Socket, Type};
@@ -184,16 +184,10 @@ impl Server {
 					//
 					// Note: This handler expects method existence to be checked prior to the call and will panic if
 					// method does not exist.
-					let async_methods = methods.clone();
 					let execute_async =
-						move |tx: MethodSink, req: OwnedJsonRpcRequest| {
-							let async_methods = async_methods.clone();
+						move |tx: MethodSink, req: OwnedJsonRpcRequest, callback: AsyncMethod| {
 							async move {
 								let req = req.borrowed();
-								let callback = match async_methods.method(&*req.method) {
-									Some(MethodCallback::Async(callback)) => callback,
-									_ => panic!("async method '{}' is not registered on the server or is not async – this is a bug", req.method),
-								};
 								let params = RpcParams::new(req.params.map(|params| params.get()));
 								// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
 								if let Err(err) = (callback)(req.id.clone().into(), params.into(), tx.clone(), 0).await
@@ -245,7 +239,7 @@ impl Server {
 						if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&body) {
 							match methods.method(&*req.method) {
 								Some(MethodCallback::Sync(callback)) => execute_sync(&tx, req, callback),
-								Some(MethodCallback::Async(_)) => execute_async(tx.clone(), req.into()).await,
+								Some(MethodCallback::Async(callback)) => execute_async(tx.clone(), req.into(), callback.clone()).await,
 								None => {
 									send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 								}
@@ -258,7 +252,7 @@ impl Server {
 								for req in batch {
 									match methods.method(&*req.method) {
 										Some(MethodCallback::Sync(callback)) => execute_sync(&tx, req, callback),
-										Some(MethodCallback::Async(_)) => execute_async(tx.clone(), req.into()).await,
+										Some(MethodCallback::Async(callback)) => execute_async(tx.clone(), req.into(), callback.clone()).await,
 										None => {
 											send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 										}

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -40,7 +40,7 @@ use jsonrpsee_utils::hyper_helpers::read_response_to_body;
 use jsonrpsee_utils::server::rpc_module::{MethodSink, RpcModule};
 use jsonrpsee_utils::server::{
 	helpers::{collect_batch_response, send_error},
-	rpc_module::{Methods, SyncMethod, MethodCallback},
+	rpc_module::{MethodCallback, Methods, SyncMethod},
 };
 
 use socket2::{Domain, Socket, Type};
@@ -185,27 +185,29 @@ impl Server {
 					// Note: This handler expects method existence to be checked prior to the call and will panic if
 					// method does not exist.
 					let async_methods = methods.clone();
-					let execute_async = move |tx: MethodSink, req: OwnedJsonRpcRequest| {
-						let async_methods = async_methods.clone();
-						async move {
-							let req = req.borrowed();
-							let callback = match async_methods.method(&*req.method) {
+					let execute_async =
+						move |tx: MethodSink, req: OwnedJsonRpcRequest| {
+							let async_methods = async_methods.clone();
+							async move {
+								let req = req.borrowed();
+								let callback = match async_methods.method(&*req.method) {
 								Some(MethodCallback::Async(callback)) => callback,
 								_ => panic!("async method '{}' is not registered on the server or is not async – this is a bug", req.method),
 							};
-							let params = RpcParams::new(req.params.map(|params| params.get()));
-							// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
-							if let Err(err) = (callback)(req.id.clone().into(), params.into(), tx.clone(), 0).await {
-								log::error!(
-									"execution of method call '{}' failed: {:?}, request id={:?}",
-									req.method,
-									err,
-									req.id
-								);
-								send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
+								let params = RpcParams::new(req.params.map(|params| params.get()));
+								// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
+								if let Err(err) = (callback)(req.id.clone().into(), params.into(), tx.clone(), 0).await
+								{
+									log::error!(
+										"execution of method call '{}' failed: {:?}, request id={:?}",
+										req.method,
+										err,
+										req.id
+									);
+									send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
+								}
 							}
-						}
-					};
+						};
 
 					// Run some validation on the http request, then read the body and try to deserialize it into one of
 					// two cases: a single RPC request or a batch of RPC requests.

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -34,13 +34,13 @@ use hyper::{
 };
 use jsonrpsee_types::error::{Error, GenericTransportError};
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
-use jsonrpsee_types::v2::params::{Id, RpcParams};
-use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest, OwnedJsonRpcRequest};
+use jsonrpsee_types::v2::params::Id;
+use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcNotification, JsonRpcRequest};
 use jsonrpsee_utils::hyper_helpers::read_response_to_body;
-use jsonrpsee_utils::server::rpc_module::{MethodSink, RpcModule};
+use jsonrpsee_utils::server::rpc_module::RpcModule;
 use jsonrpsee_utils::server::{
 	helpers::{collect_batch_response, send_error},
-	rpc_module::{AsyncMethod, MethodCallback, Methods, SyncMethod},
+	rpc_module::Methods,
 };
 
 use socket2::{Domain, Socket, Type};
@@ -156,51 +156,6 @@ impl Server {
 					let methods = methods.clone();
 					let access_control = access_control.clone();
 
-					// Look up the "method" (i.e. function pointer) from the registered methods and run it passing in
-					// the params from the request. The result of the computation is sent back over the `tx` channel and
-					// the result(s) are collected into a `String` and sent back over the wire.
-					//
-					// Note: This handler expects method existence to be checked prior to the call and will panic if
-					// method does not exist.
-					let execute_sync = move |tx: &MethodSink, req: JsonRpcRequest, callback: &SyncMethod| {
-						let params = RpcParams::new(req.params.map(|params| params.get()));
-						// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
-						if let Err(err) = (callback)(req.id.clone(), params, &tx, 0) {
-							log::error!(
-								"execution of method call '{}' failed: {:?}, request id={:?}",
-								req.method,
-								err,
-								req.id
-							);
-							send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
-						}
-					};
-
-					// Similar to `execute_sync`, but uses an asyncrhonous context.
-					// Unfortunately, we have to use owned versions of objects due to heavy lifetime
-					// usage in borrowed ones.
-					// Probably there is a chance to avoid using the heap here through some `Pin` magic,
-					// but several simple attempts to do so were failed.
-					//
-					// Note: This handler expects method existence to be checked prior to the call and will panic if
-					// method does not exist.
-					let execute_async = move |tx: MethodSink, req: OwnedJsonRpcRequest, callback: AsyncMethod| {
-						async move {
-							let req = req.borrowed();
-							let params = RpcParams::new(req.params.map(|params| params.get()));
-							// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
-							if let Err(err) = (callback)(req.id.clone().into(), params.into(), tx.clone(), 0).await {
-								log::error!(
-									"execution of method call '{}' failed: {:?}, request id={:?}",
-									req.method,
-									err,
-									req.id
-								);
-								send_error(req.id, &tx, JsonRpcErrorCode::ServerError(-1).into());
-							}
-						}
-					};
-
 					// Run some validation on the http request, then read the body and try to deserialize it into one of
 					// two cases: a single RPC request or a batch of RPC requests.
 					async move {
@@ -236,10 +191,7 @@ impl Server {
 						// Our [issue](https://github.com/paritytech/jsonrpsee/issues/296).
 						if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&body) {
 							match methods.method(&*req.method) {
-								Some(MethodCallback::Sync(callback)) => execute_sync(&tx, req, callback),
-								Some(MethodCallback::Async(callback)) => {
-									execute_async(tx.clone(), req.into(), callback.clone()).await
-								}
+								Some(callback) => callback.execute(&tx, req, 0).await,
 								None => {
 									send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 								}
@@ -251,10 +203,7 @@ impl Server {
 								single = false;
 								for req in batch {
 									match methods.method(&*req.method) {
-										Some(MethodCallback::Sync(callback)) => execute_sync(&tx, req, callback),
-										Some(MethodCallback::Async(callback)) => {
-											execute_async(tx.clone(), req.into(), callback.clone()).await
-										}
+										Some(callback) => callback.execute(&tx, req, 0).await,
 										None => {
 											send_error(req.id, &tx, JsonRpcErrorCode::MethodNotFound.into());
 										}

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -190,6 +190,7 @@ impl Server {
 						// to [`serde_json::from_slice`] which is pretty annoying.
 						// Our [issue](https://github.com/paritytech/jsonrpsee/issues/296).
 						if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&body) {
+							// NOTE: we don't need to track connection id on HTTP, so using hardcoded 0 here.
 							methods.execute(&tx, req, 0).await;
 						} else if let Ok(_req) = serde_json::from_slice::<JsonRpcNotification>(&body) {
 							return Ok::<_, HyperError>(response::ok_response("".into()));

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -191,9 +191,9 @@ impl Server {
 							async move {
 								let req = req.borrowed();
 								let callback = match async_methods.method(&*req.method) {
-								Some(MethodCallback::Async(callback)) => callback,
-								_ => panic!("async method '{}' is not registered on the server or is not async – this is a bug", req.method),
-							};
+									Some(MethodCallback::Async(callback)) => callback,
+									_ => panic!("async method '{}' is not registered on the server or is not async – this is a bug", req.method),
+								};
 								let params = RpcParams::new(req.params.map(|params| params.get()));
 								// NOTE(niklasad1): connection ID is unused thus hardcoded to `0`.
 								if let Err(err) = (callback)(req.id.clone().into(), params.into(), tx.clone(), 0).await

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -1,4 +1,4 @@
-use crate::v2::params::{Id, JsonRpcParams, OwnedId, TwoPointZero};
+use crate::v2::params::{Id, JsonRpcParams, TwoPointZero};
 use beef::Cow;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
@@ -18,48 +18,6 @@ pub struct JsonRpcRequest<'a> {
 	/// Parameter values of the request.
 	#[serde(borrow)]
 	pub params: Option<&'a RawValue>,
-}
-
-/// Owned version of [`JsonRpcRequest`].
-#[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct OwnedJsonRpcRequest {
-	/// JSON-RPC version.
-	pub jsonrpc: TwoPointZero,
-	/// Request ID
-	pub id: OwnedId,
-	/// Name of the method to be invoked.
-	pub method: String,
-	/// Parameter values of the request.
-	pub params: Option<String>,
-}
-
-impl OwnedJsonRpcRequest {
-	/// Converts `OwnedJsonRpcRequest` into borrowed `JsonRpcRequest`.
-	pub fn borrowed(&self) -> JsonRpcRequest<'_> {
-		JsonRpcRequest {
-			jsonrpc: self.jsonrpc,
-			id: self.id.borrowed(),
-			method: Cow::borrowed(self.method.as_ref()),
-			params: self.params.as_ref().map(|s| {
-				// Note: while this object *may* be created from something that is not a `JsonRpcRequest` object, using
-				// an invalid field to construct it would be a logical invariant break.
-				serde_json::from_str(&s)
-					.expect("OwnedJsonRpcRequest is only created from JsonRpcRequest, so this conversion must be safe")
-			}),
-		}
-	}
-}
-
-impl<'a> From<JsonRpcRequest<'a>> for OwnedJsonRpcRequest {
-	fn from(borrowed: JsonRpcRequest<'a>) -> Self {
-		Self {
-			jsonrpc: borrowed.jsonrpc,
-			id: borrowed.id.into(),
-			method: borrowed.method.as_ref().to_owned(),
-			params: borrowed.params.map(|p| p.get().to_owned()),
-		}
-	}
 }
 
 /// Invalid request with known request ID.

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -115,7 +115,7 @@ impl Methods {
 
 	/// Returns a `Vec` with all the method names registered on this server.
 	pub fn method_names(&self) -> Vec<&'static str> {
-		self.callbacks.keys().map(|name| *name).collect()
+		self.callbacks.keys().copied().collect()
 	}
 }
 

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// back to `jsonrpsee`, and the connection ID (useful for the websocket transport).
 pub type SyncMethod = Box<dyn Send + Sync + Fn(Id, RpcParams, &MethodSink, ConnectionId) -> Result<(), Error>>;
 /// Similar to [`SyncMethod`], but represents an asynchronous handler.
-pub type AsyncMethod = Box<
+pub type AsyncMethod = Arc<
 	dyn Send + Sync + Fn(OwnedId, OwnedRpcParams, MethodSink, ConnectionId) -> BoxFuture<'static, Result<(), Error>>,
 >;
 /// A collection of registered [`SyncMethod`]s.
@@ -148,7 +148,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 
 		self.methods.callbacks.insert(
 			method_name,
-			MethodCallback::Async(Box::new(move |id, params, tx, _| {
+			MethodCallback::Async(Arc::new(move |id, params, tx, _| {
 				let ctx = ctx.clone();
 				let future = async move {
 					let params = params.borrowed();

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -60,7 +60,7 @@ impl MethodCallback {
 		};
 
 		if let Err(err) = result {
-			log::error!("execution of sync method call '{}' failed: {:?}, request id={:?}", req.method, err, id);
+			log::error!("execution of method call '{}' failed: {:?}, request id={:?}", req.method, err, id);
 			send_error(id, &tx, JsonRpcErrorCode::ServerError(-1).into());
 		}
 	}

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -44,15 +44,13 @@ impl MethodCallback {
 	/// Execute the callback, sending the resulting JSON (success or error) to the specified sink.
 	pub async fn execute(&self, tx: &MethodSink, req: JsonRpcRequest<'_>, conn_id: ConnectionId) {
 		let id = req.id.clone();
+		let params = RpcParams::new(req.params.map(|params| params.get()));
 
 		let result = match self {
-			MethodCallback::Sync(callback) => {
-				let params = RpcParams::new(req.params.map(|params| params.get()));
-				(callback)(req.id.clone(), params, tx, conn_id)
-			}
+			MethodCallback::Sync(callback) => (callback)(req.id.clone(), params, tx, conn_id),
 			MethodCallback::Async(callback) => {
 				let tx = tx.clone();
-				let params = OwnedRpcParams::from(RpcParams::new(req.params.map(|params| params.get())));
+				let params = OwnedRpcParams::from(params);
 				let id = OwnedId::from(req.id);
 
 				(callback)(id, params, tx, conn_id).await

--- a/ws-server/src/lib.rs
+++ b/ws-server/src/lib.rs
@@ -32,5 +32,5 @@ mod server;
 mod tests;
 
 pub use jsonrpsee_types::error::Error;
-pub use jsonrpsee_utils::server::rpc_module::{RpcModule, SubscriptionSink, SyncMethods};
+pub use jsonrpsee_utils::server::rpc_module::{RpcModule, SubscriptionSink};
 pub use server::Server as WsServer;

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -33,12 +33,12 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio_stream::wrappers::TcpListenerStream;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
+use jsonrpsee_types::error::Error;
 use jsonrpsee_types::v2::error::JsonRpcErrorCode;
 use jsonrpsee_types::v2::params::Id;
 use jsonrpsee_types::v2::request::{JsonRpcInvalidRequest, JsonRpcRequest};
-use jsonrpsee_types::error::Error;
-use jsonrpsee_utils::server::rpc_module::{ConnectionId, Methods, RpcModule};
 use jsonrpsee_utils::server::helpers::{collect_batch_response, send_error};
+use jsonrpsee_utils::server::rpc_module::{ConnectionId, Methods, RpcModule};
 
 pub struct Server {
 	methods: Methods,

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -154,7 +154,10 @@ async fn background_task(
 			let req = req.borrowed();
 			let callback = match async_methods.method(&*req.method) {
 				Some(MethodCallback::Async(callback)) => callback,
-				_ => panic!("async method '{}' is not registered on the server or is not async – this is a bug", req.method),
+				_ => panic!(
+					"async method '{}' is not registered on the server or is not async – this is a bug",
+					req.method
+				),
 			};
 			let params = RpcParams::new(req.params.map(|params| params.get()));
 			if let Err(err) = (callback)(req.id.clone().into(), params.into(), tx.clone(), conn_id).await {


### PR DESCRIPTION
Instead of having one map with an enum for type, and then a map each for sync and async, we can just use a single map with newtype variants.

This removes one map lookup and atomic clone of the map for sync methods ~(in principle we should be able to get rid of the map lookup for async methods too, but it might require a bit more of a unique container than std `HashMap`)~.

Update: Changed `AsyncMethod` to use `Arc` instead of `Box`, so now we can avoid the extra map lookup on each async call too (still need to clone an `Arc`, but this time it's the method itself instead of the whole map.

Also changed `method_names` to return `Vec<&'static str>`.