### PR TITLE
Stick code to a single runtime

### DIFF
--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = "1"
 anyhow = "1"
 futures-channel = "0.3.14"
 futures-util = "0.3.14"

--- a/test-utils/src/types.rs
+++ b/test-utils/src/types.rs
@@ -109,7 +109,7 @@ pub struct WebSocketTestServer {
 impl WebSocketTestServer {
 	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded response` for every connection.
 	pub async fn with_hardcoded_response(sockaddr: SocketAddr, response: String) -> Self {
-		let listener = async_std::net::TcpListener::bind(sockaddr).await.unwrap();
+		let listener = tokio::net::TcpListener::bind(sockaddr).await.unwrap();
 		let local_addr = listener.local_addr().unwrap();
 		let (tx, rx) = mpsc::channel::<()>(4);
 		tokio::spawn(server_backend(listener, rx, ServerMode::Response(response)));
@@ -124,7 +124,7 @@ impl WebSocketTestServer {
 
 		std::thread::spawn(move || {
 			let rt = tokio::runtime::Runtime::new().unwrap();
-			let listener = rt.block_on(async_std::net::TcpListener::bind(sockaddr)).unwrap();
+			let listener = rt.block_on(tokio::net::TcpListener::bind(sockaddr)).unwrap();
 			let local_addr = listener.local_addr().unwrap();
 
 			addr_tx.send(local_addr).unwrap();
@@ -144,7 +144,7 @@ impl WebSocketTestServer {
 		subscription_id: String,
 		subscription_response: String,
 	) -> Self {
-		let listener = async_std::net::TcpListener::bind(sockaddr).await.unwrap();
+		let listener = tokio::net::TcpListener::bind(sockaddr).await.unwrap();
 		let local_addr = listener.local_addr().unwrap();
 		let (tx, rx) = mpsc::channel::<()>(4);
 		tokio::spawn(server_backend(listener, rx, ServerMode::Subscription { subscription_id, subscription_response }));
@@ -161,7 +161,7 @@ impl WebSocketTestServer {
 	}
 }
 
-async fn server_backend(listener: async_std::net::TcpListener, mut exit: Receiver<()>, mode: ServerMode) {
+async fn server_backend(listener: tokio::net::TcpListener, mut exit: Receiver<()>, mode: ServerMode) {
 	let mut connections = Vec::new();
 
 	loop {
@@ -190,8 +190,8 @@ async fn server_backend(listener: async_std::net::TcpListener, mut exit: Receive
 	}
 }
 
-async fn connection_task(socket: async_std::net::TcpStream, mode: ServerMode, mut exit: Receiver<()>) {
-	let mut server = Server::new(socket);
+async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut exit: Receiver<()>) {
+	let mut server = Server::new(socket.compat());
 
 	let websocket_key = match server.receive_request().await {
 		Ok(req) => req.into_key(),

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -161,7 +161,7 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 		client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
 
 	// don't poll the subscription stream for 2 seconds, should be full now.
-	std::thread::sleep(Duration::from_secs(2));
+	tokio::time::sleep(Duration::from_secs(2)).await;
 
 	// Capacity is `num_sender` + `capacity`
 	for _ in 0..5 {

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -30,4 +30,4 @@ rustls-native-certs = "0.5.0"
 [dev-dependencies]
 env_logger = "0.8"
 jsonrpsee-test-utils = { path = "../test-utils" }
-tokio = { version = "1", features = ["full"] }
+async-std = { version = "1", features = ["attributes"] }

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -11,8 +11,9 @@ documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
 async-trait = "0.1"
-async-std = "1"
-async-tls = "0.11"
+tokio = { version = "1", features = ["net", "time"] }
+tokio-rustls = "0.22"
+tokio-util = { version = "0.6", features = ["compat"] }
 fnv = "1"
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee-types = { path = "../types", version = "=0.2.0-alpha.7" }
@@ -23,11 +24,9 @@ soketto = "0.5"
 pin-project = "1"
 thiserror = "1"
 url = "2"
-webpki = { version = "0.22", features = ["std"] }
 rustls = "0.19.1"
 rustls-native-certs = "0.5.0"
 
 [dev-dependencies]
 env_logger = "0.8"
 jsonrpsee-test-utils = { path = "../test-utils" }
-async-std = { version = "1", features = ["attributes"] }

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -11,14 +11,14 @@ documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
 # Tokio v1 deps
-tokio1 = { package="tokio", version = "1", features = ["net", "time"], optional=true }
-tokio1-rustls = { package="tokio-rustls", version = "0.22", optional=true }
-tokio1-util = { package="tokio-util", version = "0.6", features = ["compat"], optional=true }
+tokioV1 = { package="tokio", version = "1", features = ["net", "time"], optional=true }
+tokioV1-rustls = { package="tokio-rustls", version = "0.22", optional=true }
+tokioV1-util = { package="tokio-util", version = "0.6", features = ["compat"], optional=true }
 
 # Tokio v0.2 deps
-tokio02 = { package="tokio", version = "0.2", features = ["net", "time"], optional=true }
-tokio02-rustls = { package="tokio-rustls", version = "0.15", optional=true }
-tokio02-util = { package="tokio-util", version = "0.3", features = ["compat"], optional=true }
+tokioV02 = { package="tokio", version = "0.2", features = ["net", "time"], optional=true }
+tokioV02-rustls = { package="tokio-rustls", version = "0.15", optional=true }
+tokioV02-util = { package="tokio-util", version = "0.3", features = ["compat"], optional=true }
 
 async-trait = "0.1"
 fnv = "1"
@@ -39,6 +39,6 @@ env_logger = "0.8"
 jsonrpsee-test-utils = { path = "../test-utils" }
 
 [features]
-default = ["tokioV1"]
-tokioV1 = ["tokio1", "tokio1-rustls", "tokio1-util"]
-tokioV02 = ["tokio02", "tokio02-rustls", "tokio02-util"]
+default = ["tokio1"]
+tokio1 = ["tokioV1", "tokioV1-rustls", "tokioV1-util"]
+tokio02 = ["tokioV02", "tokioV02-rustls", "tokioV02-util"]

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -10,10 +10,17 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
+# Tokio v1 deps
+tokio1 = { package="tokio", version = "1", features = ["net", "time"], optional=true }
+tokio1-rustls = { package="tokio-rustls", version = "0.22", optional=true }
+tokio1-util = { package="tokio-util", version = "0.6", features = ["compat"], optional=true }
+
+# Tokio v0.2 deps
+tokio02 = { package="tokio", version = "0.2", features = ["net", "time"], optional=true }
+tokio02-rustls = { package="tokio-rustls", version = "0.15", optional=true }
+tokio02-util = { package="tokio-util", version = "0.3", features = ["compat"], optional=true }
+
 async-trait = "0.1"
-tokio = { version = "1", features = ["net", "time"] }
-tokio-rustls = "0.22"
-tokio-util = { version = "0.6", features = ["compat"] }
 fnv = "1"
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee-types = { path = "../types", version = "=0.2.0-alpha.7" }
@@ -30,3 +37,8 @@ rustls-native-certs = "0.5.0"
 [dev-dependencies]
 env_logger = "0.8"
 jsonrpsee-test-utils = { path = "../test-utils" }
+
+[features]
+default = ["tokioV1"]
+tokioV1 = ["tokio1", "tokio1-rustls", "tokio1-util"]
+tokioV02 = ["tokio02", "tokio02-rustls", "tokio02-util"]

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -24,6 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::tokio::Mutex;
 use crate::traits::{Client, SubscriptionClient};
 use crate::transport::{Receiver as WsReceiver, Sender as WsSender, Target, WsTransportClientBuilder};
 use crate::v2::error::JsonRpcError;
@@ -49,7 +50,6 @@ use futures::{
 	prelude::*,
 	sink::SinkExt,
 };
-use tokio::sync::Mutex;
 
 use serde::de::DeserializeOwned;
 use std::{
@@ -251,6 +251,10 @@ impl<'a> WsClientBuilder<'a> {
 	/// `ws://host` - port 80 is used
 	///
 	/// `wss://host` - port 443 is used
+	///
+	/// ## Panics
+	///
+	/// Panics if being called outside of `tokio` runtime context.
 	pub async fn build(self, url: &'a str) -> Result<WsClient, Error> {
 		let certificate_store = self.certificate_store;
 		let max_capacity_per_subscription = self.max_notifs_per_subscription;
@@ -269,7 +273,7 @@ impl<'a> WsClientBuilder<'a> {
 
 		let (sender, receiver) = builder.build().await.map_err(|e| Error::Transport(Box::new(e)))?;
 
-		tokio::spawn(async move {
+		crate::tokio::spawn(async move {
 			background_task(sender, receiver, from_front, err_tx, max_capacity_per_subscription).await;
 		});
 		Ok(WsClient {
@@ -340,7 +344,7 @@ impl Client for WsClient {
 		}
 
 		let send_back_rx_out = if let Some(duration) = self.request_timeout {
-			let timeout = tokio::time::sleep(duration);
+			let timeout = crate::tokio::sleep(duration);
 			futures::pin_mut!(send_back_rx, timeout);
 			match future::select(send_back_rx, timeout).await {
 				future::Either::Left((send_back_rx_out, _)) => send_back_rx_out,

--- a/ws-client/src/lib.rs
+++ b/ws-client/src/lib.rs
@@ -3,6 +3,11 @@
 //! # jsonrpsee-ws-client
 //!
 //! `jsonrpsee-ws-client` is a [JSON RPC](https://www.jsonrpc.org/specification) WebSocket client library that's is built for `async/await`.
+//!
+//! ## Runtime support
+//!
+//! This library uses `tokio` as the runtime and does not support other kinds of runtimes.
+//! Tokio versions v1 and v0.2 are supported behind `tokioV1` and `tokioV02` feature flags correspondingly.
 
 /// WebSocket Client.
 pub mod client;
@@ -14,6 +19,9 @@ pub mod manager;
 pub mod stream;
 /// WebSocket transport.
 pub mod transport;
+
+/// Compatibility layer to support both `tokio` 0.2 and 1.x versions.
+mod tokio;
 
 #[cfg(test)]
 mod tests;

--- a/ws-client/src/stream.rs
+++ b/ws-client/src/stream.rs
@@ -26,13 +26,13 @@
 
 //! Convenience wrapper for a stream (AsyncRead + AsyncWrite) which can either be plain TCP or TLS.
 
+use crate::tokio::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use futures::{
 	io::{IoSlice, IoSliceMut},
 	prelude::*,
 };
 use pin_project::pin_project;
 use std::{io::Error as IoError, pin::Pin, task::Context, task::Poll};
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 /// Stream to represent either a unencrypted or encrypted socket stream.
 #[pin_project(project = EitherStreamProj)]

--- a/ws-client/src/stream.rs
+++ b/ws-client/src/stream.rs
@@ -32,6 +32,7 @@ use futures::{
 };
 use pin_project::pin_project;
 use std::{io::Error as IoError, pin::Pin, task::Context, task::Poll};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 /// Stream to represent either a unencrypted or encrypted socket stream.
 #[pin_project(project = EitherStreamProj)]
@@ -45,13 +46,21 @@ pub enum EitherStream<S, T> {
 
 impl<S, T> AsyncRead for EitherStream<S, T>
 where
-	S: AsyncRead,
-	T: AsyncRead,
+	S: TokioAsyncReadCompatExt,
+	T: TokioAsyncReadCompatExt,
 {
 	fn poll_read(self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8]) -> Poll<Result<usize, IoError>> {
 		match self.project() {
-			EitherStreamProj::Plain(s) => AsyncRead::poll_read(s, cx, buf),
-			EitherStreamProj::Tls(t) => AsyncRead::poll_read(t, cx, buf),
+			EitherStreamProj::Plain(s) => {
+				let compat = s.compat();
+				futures::pin_mut!(compat);
+				AsyncRead::poll_read(compat, cx, buf)
+			}
+			EitherStreamProj::Tls(t) => {
+				let compat = t.compat();
+				futures::pin_mut!(compat);
+				AsyncRead::poll_read(compat, cx, buf)
+			}
 		}
 	}
 
@@ -61,42 +70,82 @@ where
 		bufs: &mut [IoSliceMut],
 	) -> Poll<Result<usize, IoError>> {
 		match self.project() {
-			EitherStreamProj::Plain(s) => AsyncRead::poll_read_vectored(s, cx, bufs),
-			EitherStreamProj::Tls(t) => AsyncRead::poll_read_vectored(t, cx, bufs),
+			EitherStreamProj::Plain(s) => {
+				let compat = s.compat();
+				futures::pin_mut!(compat);
+				AsyncRead::poll_read_vectored(compat, cx, bufs)
+			}
+			EitherStreamProj::Tls(t) => {
+				let compat = t.compat();
+				futures::pin_mut!(compat);
+				AsyncRead::poll_read_vectored(compat, cx, bufs)
+			}
 		}
 	}
 }
 
 impl<S, T> AsyncWrite for EitherStream<S, T>
 where
-	S: AsyncWrite,
-	T: AsyncWrite,
+	S: TokioAsyncWriteCompatExt,
+	T: TokioAsyncWriteCompatExt,
 {
 	fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize, IoError>> {
 		match self.project() {
-			EitherStreamProj::Plain(s) => AsyncWrite::poll_write(s, cx, buf),
-			EitherStreamProj::Tls(t) => AsyncWrite::poll_write(t, cx, buf),
+			EitherStreamProj::Plain(s) => {
+				let compat = s.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_write(compat, cx, buf)
+			}
+			EitherStreamProj::Tls(t) => {
+				let compat = t.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_write(compat, cx, buf)
+			}
 		}
 	}
 
 	fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context, bufs: &[IoSlice]) -> Poll<Result<usize, IoError>> {
 		match self.project() {
-			EitherStreamProj::Plain(s) => AsyncWrite::poll_write_vectored(s, cx, bufs),
-			EitherStreamProj::Tls(t) => AsyncWrite::poll_write_vectored(t, cx, bufs),
+			EitherStreamProj::Plain(s) => {
+				let compat = s.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_write_vectored(compat, cx, bufs)
+			}
+			EitherStreamProj::Tls(t) => {
+				let compat = t.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_write_vectored(compat, cx, bufs)
+			}
 		}
 	}
 
 	fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), IoError>> {
 		match self.project() {
-			EitherStreamProj::Plain(s) => AsyncWrite::poll_flush(s, cx),
-			EitherStreamProj::Tls(t) => AsyncWrite::poll_flush(t, cx),
+			EitherStreamProj::Plain(s) => {
+				let compat = s.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_flush(compat, cx)
+			}
+			EitherStreamProj::Tls(t) => {
+				let compat = t.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_flush(compat, cx)
+			}
 		}
 	}
 
 	fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), IoError>> {
 		match self.project() {
-			EitherStreamProj::Plain(s) => AsyncWrite::poll_close(s, cx),
-			EitherStreamProj::Tls(t) => AsyncWrite::poll_close(t, cx),
+			EitherStreamProj::Plain(s) => {
+				let compat = s.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_close(compat, cx)
+			}
+			EitherStreamProj::Tls(t) => {
+				let compat = t.compat_write();
+				futures::pin_mut!(compat);
+				AsyncWrite::poll_close(compat, cx)
+			}
 		}
 	}
 }

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -13,6 +13,8 @@ use jsonrpsee_test_utils::types::{Id, WebSocketTestServer};
 use jsonrpsee_test_utils::TimeoutFutureExt;
 use serde_json::Value as JsonValue;
 
+use crate::tokio;
+
 #[tokio::test]
 async fn method_call_works() {
 	let result = run_request_with_response(ok_response("hello".into(), Id::Num(0)))

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -13,7 +13,7 @@ use jsonrpsee_test_utils::types::{Id, WebSocketTestServer};
 use jsonrpsee_test_utils::TimeoutFutureExt;
 use serde_json::Value as JsonValue;
 
-#[tokio::test]
+#[async_std::test]
 async fn method_call_works() {
 	let result = run_request_with_response(ok_response("hello".into(), Id::Num(0)))
 		.with_default_timeout()
@@ -23,7 +23,7 @@ async fn method_call_works() {
 	assert_eq!(JsonValue::String("hello".into()), result);
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn notif_works() {
 	// this empty string shouldn't be read because the server shouldn't respond to notifications.
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), String::new())
@@ -35,7 +35,7 @@ async fn notif_works() {
 	assert!(client.notification("notif", JsonRpcParams::NoParams).with_default_timeout().await.unwrap().is_ok());
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn response_with_wrong_id() {
 	let err = run_request_with_response(ok_response("hello".into(), Id::Num(99)))
 		.with_default_timeout()
@@ -45,41 +45,41 @@ async fn response_with_wrong_id() {
 	assert!(matches!(err, Error::RestartNeeded(_)));
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::MethodNotFound.into());
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn parse_error_works() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::ParseError.into());
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InvalidRequest.into());
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InvalidParams.into());
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InternalError.into());
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn subscription_works() {
 	let server = WebSocketTestServer::with_hardcoded_subscription(
 		"127.0.0.1:0".parse().unwrap(),
@@ -103,7 +103,7 @@ async fn subscription_works() {
 	}
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn notification_handler_works() {
 	let server = WebSocketTestServer::with_hardcoded_notification(
 		"127.0.0.1:0".parse().unwrap(),
@@ -123,7 +123,7 @@ async fn notification_handler_works() {
 	}
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn notification_without_polling_doesnt_make_client_unuseable() {
 	let server = WebSocketTestServer::with_hardcoded_notification(
 		"127.0.0.1:0".parse().unwrap(),
@@ -164,7 +164,7 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 	assert!(client.is_connected());
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn batch_request_works() {
 	let batch_request = vec![
 		("say_hello", JsonRpcParams::NoParams),
@@ -177,7 +177,7 @@ async fn batch_request_works() {
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn batch_request_out_of_order_response() {
 	let batch_request = vec![
 		("say_hello", JsonRpcParams::NoParams),
@@ -190,7 +190,7 @@ async fn batch_request_out_of_order_response() {
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
-#[tokio::test]
+#[async_std::test]
 async fn is_connected_works() {
 	let server = WebSocketTestServer::with_hardcoded_response(
 		"127.0.0.1:0".parse().unwrap(),

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -13,7 +13,7 @@ use jsonrpsee_test_utils::types::{Id, WebSocketTestServer};
 use jsonrpsee_test_utils::TimeoutFutureExt;
 use serde_json::Value as JsonValue;
 
-#[async_std::test]
+#[tokio::test]
 async fn method_call_works() {
 	let result = run_request_with_response(ok_response("hello".into(), Id::Num(0)))
 		.with_default_timeout()
@@ -23,7 +23,7 @@ async fn method_call_works() {
 	assert_eq!(JsonValue::String("hello".into()), result);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn notif_works() {
 	// this empty string shouldn't be read because the server shouldn't respond to notifications.
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), String::new())
@@ -35,7 +35,7 @@ async fn notif_works() {
 	assert!(client.notification("notif", JsonRpcParams::NoParams).with_default_timeout().await.unwrap().is_ok());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn response_with_wrong_id() {
 	let err = run_request_with_response(ok_response("hello".into(), Id::Num(99)))
 		.with_default_timeout()
@@ -45,41 +45,41 @@ async fn response_with_wrong_id() {
 	assert!(matches!(err, Error::RestartNeeded(_)));
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::MethodNotFound.into());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn parse_error_works() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::ParseError.into());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InvalidRequest.into());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InvalidParams.into());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
 	assert_error_response(err, JsonRpcErrorCode::InternalError.into());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn subscription_works() {
 	let server = WebSocketTestServer::with_hardcoded_subscription(
 		"127.0.0.1:0".parse().unwrap(),
@@ -103,7 +103,7 @@ async fn subscription_works() {
 	}
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn notification_handler_works() {
 	let server = WebSocketTestServer::with_hardcoded_notification(
 		"127.0.0.1:0".parse().unwrap(),
@@ -123,7 +123,7 @@ async fn notification_handler_works() {
 	}
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn notification_without_polling_doesnt_make_client_unuseable() {
 	let server = WebSocketTestServer::with_hardcoded_notification(
 		"127.0.0.1:0".parse().unwrap(),
@@ -164,7 +164,7 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 	assert!(client.is_connected());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn batch_request_works() {
 	let batch_request = vec![
 		("say_hello", JsonRpcParams::NoParams),
@@ -177,7 +177,7 @@ async fn batch_request_works() {
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn batch_request_out_of_order_response() {
 	let batch_request = vec![
 		("say_hello", JsonRpcParams::NoParams),
@@ -190,7 +190,7 @@ async fn batch_request_out_of_order_response() {
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn is_connected_works() {
 	let server = WebSocketTestServer::with_hardcoded_response(
 		"127.0.0.1:0".parse().unwrap(),

--- a/ws-client/src/tokio.rs
+++ b/ws-client/src/tokio.rs
@@ -1,0 +1,45 @@
+//! Compatibility layer for supporting both tokio v0.2 and v1.
+
+pub(crate) use tokio_impl::*;
+
+#[cfg(feature = "tokioV1")]
+mod tokio_impl {
+	// Required for `tokio::test` to work correctly.
+	#[cfg(test)]
+	pub(crate) use tokio1::{runtime, test};
+
+	pub(crate) use tokio1::{net::TcpStream, spawn, sync::Mutex};
+	pub(crate) use tokio1_rustls::{
+		client::TlsStream,
+		webpki::{DNSNameRef, InvalidDNSNameError},
+		TlsConnector,
+	};
+	pub(crate) use tokio1_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+	pub(crate) use tokio1::time::sleep;
+}
+
+#[cfg(feature = "tokioV02")]
+mod tokio_impl {
+	// Required for `tokio::test` to work correctly.
+	#[cfg(test)]
+	pub(crate) use tokio02::{runtime, test};
+
+	pub(crate) use tokio02::{net::TcpStream, spawn, sync::Mutex};
+	pub(crate) use tokio02_rustls::{
+		client::TlsStream,
+		webpki::{DNSNameRef, InvalidDNSNameError},
+		TlsConnector,
+	};
+	pub(crate) use tokio02_util::compat::{
+		Tokio02AsyncReadCompatExt as TokioAsyncReadCompatExt, Tokio02AsyncWriteCompatExt as TokioAsyncWriteCompatExt,
+	};
+
+	// In 0.2 `tokio::time::sleep` had different name.
+	pub(crate) use tokio02::time::delay_for as sleep;
+}
+
+#[cfg(not(any(feature = "tokioV1", feature = "tokioV02")))]
+mod tokio_impl {
+	compile_error!("Either `tokiov1` or `tokiov02` feature must be enabled");
+}

--- a/ws-client/src/tokio.rs
+++ b/ws-client/src/tokio.rs
@@ -2,7 +2,7 @@
 
 // Check that either v1 or v0.2 feature is enabled.
 #[cfg(not(any(feature = "tokio1", feature = "tokio02")))]
-compile_error!("Either `tokiov1` or `tokiov02` feature must be enabled");
+compile_error!("Either `tokio1` or `tokio02` feature must be enabled");
 
 // Also check that only *one* of them is enabled.
 #[cfg(all(feature = "tokio1", feature = "tokio02"))]


### PR DESCRIPTION
First, I noticed that in some places, both `tokio` and `async-std` mixed together in tests.

It's generally not a good idea to mix globally accessible runtimes, because it may result in weird things happening.
It may have been the cause for weirdly behaving tests and not working timeouts (e.g. `tokio::timeout` may not work if it will be executed by `async-std` runtime).

Then I noticed that majority of code is using `tokio`, but `ws-client` is based on `async-std`. In my opinion it's weird, because if someone will want to use both `http-client` and `ws-client`, they will have to use two runtimes.

As a result, I removed `async-std` from everywhere, leaving only `tokio`.

Hopefully, it will help with both tests behavior and consistency.