### PR TITLE
Add a builder to the ws server

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -1,7 +1,7 @@
 use futures_channel::oneshot;
 use jsonrpsee::{
 	http_server::HttpServerBuilder,
-	ws_server::{RpcModule, WsServer},
+	ws_server::{RpcModule, WsServerBuilder},
 };
 
 /// Run jsonrpsee HTTP server for benchmarks.
@@ -23,7 +23,7 @@ pub async fn http_server() -> String {
 pub async fn ws_server() -> String {
 	let (server_started_tx, server_started_rx) = oneshot::channel();
 	tokio::spawn(async move {
-		let mut server = WsServer::new("127.0.0.1:0").await.unwrap();
+		let mut server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 		let mut module = RpcModule::new(());
 		module.register_method("say_hello", |_, _| Ok("lo")).unwrap();
 		server.register_module(module).unwrap();

--- a/examples/weather.rs
+++ b/examples/weather.rs
@@ -33,7 +33,7 @@
 use jsonrpsee::{
 	ws_client::{traits::SubscriptionClient, v2::params::JsonRpcParams, WsClientBuilder},
 	ws_server::RpcModule,
-	ws_server::WsServer,
+	ws_server::WsServerBuilder,
 };
 use restson::{Error as RestsonError, RestPath};
 use serde::{Deserialize, Serialize};
@@ -99,7 +99,7 @@ struct WeatherApiCx {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let mut server = WsServer::new("127.0.0.1:0").await?;
+	let mut server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 
 	let api_client = restson::RestClient::new("http://api.openweathermap.org").unwrap();
 	let last_weather = Weather::default();

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -44,7 +44,6 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	// let mut server = WsServer::new("127.0.0.1:0").await?;
 	let mut server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("lo"))?;

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -26,7 +26,7 @@
 
 use jsonrpsee::{
 	ws_client::{traits::Client, v2::params::JsonRpcParams, WsClientBuilder},
-	ws_server::{RpcModule, WsServer},
+	ws_server::{RpcModule, WsServerBuilder},
 };
 use std::net::SocketAddr;
 
@@ -44,7 +44,8 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let mut server = WsServer::new("127.0.0.1:0").await?;
+	// let mut server = WsServer::new("127.0.0.1:0").await?;
+	let mut server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("lo"))?;
 	server.register_module(module).unwrap();

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -26,7 +26,7 @@
 
 use jsonrpsee::{
 	ws_client::{traits::SubscriptionClient, v2::params::JsonRpcParams, WsClientBuilder},
-	ws_server::{RpcModule, WsServer},
+	ws_server::{RpcModule, WsServerBuilder},
 };
 use std::net::SocketAddr;
 
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	const LETTERS: &str = "abcdefghijklmnopqrstuvxyz";
-	let mut server = WsServer::new("127.0.0.1:0").await?;
+	let mut server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module
 		.register_subscription("sub_one_param", "unsub_one_param", |params, sink, _| {

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -26,7 +26,7 @@
 
 use jsonrpsee::{
 	ws_client::{traits::SubscriptionClient, v2::params::JsonRpcParams, Subscription, WsClientBuilder},
-	ws_server::{RpcModule, WsServer},
+	ws_server::{RpcModule, WsServerBuilder},
 };
 use std::net::SocketAddr;
 
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let mut server = WsServer::new("127.0.0.1:0").await?;
+	let mut server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_subscription("subscribe_hello", "unsubscribe_hello", |_, sink, _| {
 		std::thread::spawn(move || loop {

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -301,8 +301,10 @@ async fn can_register_modules() {
 
 	server.register_module(mod1).unwrap();
 	assert_eq!(server.method_names().len(), 2);
+
 	let err = server.register_module(mod2).unwrap_err();
-	let _expected_err = Error::MethodAlreadyRegistered(String::from("bla"));
-	assert!(matches!(err, _expected_err));
+
+	let expected_err = Error::MethodAlreadyRegistered(String::from("bla"));
+	assert_eq!(err.to_string(), expected_err.to_string());
 	assert_eq!(server.method_names().len(), 2);
 }

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -43,6 +43,10 @@ pub fn parse_error(id: Id) -> String {
 	)
 }
 
+pub fn oversized_request() -> String {
+	r#"{"jsonrpc":"2.0","error":{"code":-32701,"message":"Request too big"},"id":null}"#.into()
+}
+
 pub fn invalid_request(id: Id) -> String {
 	format!(
 		r#"{{"jsonrpc":"2.0","error":{{"code":-32600,"message":"Invalid request"}},"id":{}}}"#,

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -44,7 +44,7 @@ pub fn parse_error(id: Id) -> String {
 }
 
 pub fn oversized_request() -> String {
-	r#"{"jsonrpc":"2.0","error":{"code":-32701,"message":"Request too big"},"id":null}"#.into()
+	r#"{"jsonrpc":"2.0","error":{"code":-32701,"message":"Request is too big"},"id":null}"#.into()
 }
 
 pub fn invalid_request(id: Id) -> String {

--- a/test-utils/src/types.rs
+++ b/test-utils/src/types.rs
@@ -56,6 +56,12 @@ pub struct WebSocketTestClient {
 	rx: soketto::Receiver<BufReader<BufWriter<Compat<TcpStream>>>>,
 }
 
+impl std::fmt::Debug for WebSocketTestClient {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "WebSocketTestClient")
+	}
+}
+
 impl WebSocketTestClient {
 	pub async fn new(url: SocketAddr) -> Result<Self, Error> {
 		let socket = TcpStream::connect(url).await?;

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use futures_channel::oneshot;
-use jsonrpsee::{http_server::HttpServerBuilder, ws_server::WsServer, RpcModule};
+use jsonrpsee::{http_server::HttpServerBuilder, ws_server::WsServerBuilder, RpcModule};
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -35,7 +35,8 @@ pub async fn websocket_server_with_subscription() -> SocketAddr {
 	std::thread::spawn(move || {
 		let rt = tokio::runtime::Runtime::new().unwrap();
 
-		let mut server = rt.block_on(WsServer::new("127.0.0.1:0")).unwrap();
+		let mut server = rt.block_on(WsServerBuilder::default().build("127.0.0.1:0")).unwrap();
+
 		let mut module = RpcModule::new(());
 		module.register_method("say_hello", |_, _| Ok("hello")).unwrap();
 
@@ -87,8 +88,7 @@ pub async fn websocket_server() -> SocketAddr {
 
 	std::thread::spawn(move || {
 		let rt = tokio::runtime::Runtime::new().unwrap();
-
-		let mut server = rt.block_on(WsServer::new("127.0.0.1:0")).unwrap();
+		let mut server = rt.block_on(WsServerBuilder::default().build("127.0.0.1:0")).unwrap();
 		let mut module = RpcModule::new(());
 		module.register_method("say_hello", |_, _| Ok("hello")).unwrap();
 		server.register_module(module).unwrap();

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -70,7 +70,7 @@ pub const CALL_EXECUTION_FAILED_CODE: i32 = -32000;
 /// Parse error message
 pub const PARSE_ERROR_MSG: &str = "Parse error";
 /// Oversized request message
-pub const OVERSIZED_REQUEST_MSG: &str = "Request too big";
+pub const OVERSIZED_REQUEST_MSG: &str = "Request is too big";
 /// Internal error message.
 pub const INTERNAL_ERROR_MSG: &str = "Internal error";
 /// Invalid params error message.

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -54,6 +54,8 @@ impl<'a> PartialEq for JsonRpcErrorObject<'a> {
 
 /// Parse error code.
 pub const PARSE_ERROR_CODE: i32 = -32700;
+/// Oversized request error code.
+pub const OVERSIZED_REQUEST_CODE: i32 = -32701;
 /// Internal error code.
 pub const INTERNAL_ERROR_CODE: i32 = -32603;
 /// Invalid params error code.
@@ -67,6 +69,8 @@ pub const CALL_EXECUTION_FAILED_CODE: i32 = -32000;
 
 /// Parse error message
 pub const PARSE_ERROR_MSG: &str = "Parse error";
+/// Oversized request message
+pub const OVERSIZED_REQUEST_MSG: &str = "Request too big";
 /// Internal error message.
 pub const INTERNAL_ERROR_MSG: &str = "Internal error";
 /// Invalid params error message.
@@ -84,6 +88,8 @@ pub enum JsonRpcErrorCode {
 	/// Invalid JSON was received by the server.
 	/// An error occurred on the server while parsing the JSON text.
 	ParseError,
+	/// The request was too big.
+	OversizedRequest,
 	/// The JSON sent is not a valid Request object.
 	InvalidRequest,
 	/// The method does not exist / is not available.
@@ -99,25 +105,29 @@ pub enum JsonRpcErrorCode {
 impl JsonRpcErrorCode {
 	/// Returns integer code value
 	pub const fn code(&self) -> i32 {
+		use JsonRpcErrorCode::*;
 		match *self {
-			JsonRpcErrorCode::ParseError => PARSE_ERROR_CODE,
-			JsonRpcErrorCode::InvalidRequest => INVALID_REQUEST_CODE,
-			JsonRpcErrorCode::MethodNotFound => METHOD_NOT_FOUND_CODE,
-			JsonRpcErrorCode::InvalidParams => INVALID_PARAMS_CODE,
-			JsonRpcErrorCode::InternalError => INTERNAL_ERROR_CODE,
-			JsonRpcErrorCode::ServerError(code) => code,
+			ParseError => PARSE_ERROR_CODE,
+			OversizedRequest => OVERSIZED_REQUEST_CODE,
+			InvalidRequest => INVALID_REQUEST_CODE,
+			MethodNotFound => METHOD_NOT_FOUND_CODE,
+			InvalidParams => INVALID_PARAMS_CODE,
+			InternalError => INTERNAL_ERROR_CODE,
+			ServerError(code) => code,
 		}
 	}
 
 	/// Returns the message for the given error code.
 	pub const fn message(&self) -> &'static str {
+		use JsonRpcErrorCode::*;
 		match self {
-			JsonRpcErrorCode::ParseError => PARSE_ERROR_MSG,
-			JsonRpcErrorCode::InvalidRequest => INVALID_REQUEST_MSG,
-			JsonRpcErrorCode::MethodNotFound => METHOD_NOT_FOUND_MSG,
-			JsonRpcErrorCode::InvalidParams => INVALID_PARAMS_MSG,
-			JsonRpcErrorCode::InternalError => INTERNAL_ERROR_MSG,
-			JsonRpcErrorCode::ServerError(_) => SERVER_ERROR_MSG,
+			ParseError => PARSE_ERROR_MSG,
+			OversizedRequest => OVERSIZED_REQUEST_MSG,
+			InvalidRequest => INVALID_REQUEST_MSG,
+			MethodNotFound => METHOD_NOT_FOUND_MSG,
+			InvalidParams => INVALID_PARAMS_MSG,
+			InternalError => INTERNAL_ERROR_MSG,
+			ServerError(_) => SERVER_ERROR_MSG,
 		}
 	}
 }
@@ -130,13 +140,15 @@ impl fmt::Display for JsonRpcErrorCode {
 
 impl From<i32> for JsonRpcErrorCode {
 	fn from(code: i32) -> Self {
+		use JsonRpcErrorCode::*;
 		match code {
-			PARSE_ERROR_CODE => JsonRpcErrorCode::ParseError,
-			INVALID_REQUEST_CODE => JsonRpcErrorCode::InvalidRequest,
-			METHOD_NOT_FOUND_CODE => JsonRpcErrorCode::MethodNotFound,
-			INVALID_PARAMS_CODE => JsonRpcErrorCode::InvalidParams,
-			INTERNAL_ERROR_CODE => JsonRpcErrorCode::InternalError,
-			code => JsonRpcErrorCode::ServerError(code),
+			PARSE_ERROR_CODE => ParseError,
+			OVERSIZED_REQUEST_CODE => OversizedRequest,
+			INVALID_REQUEST_CODE => InvalidRequest,
+			METHOD_NOT_FOUND_CODE => MethodNotFound,
+			INVALID_PARAMS_CODE => InvalidParams,
+			INTERNAL_ERROR_CODE => InternalError,
+			code => ServerError(code),
 		}
 	}
 }

--- a/ws-server/src/lib.rs
+++ b/ws-server/src/lib.rs
@@ -39,4 +39,4 @@ mod tests;
 
 pub use jsonrpsee_types::error::Error;
 pub use jsonrpsee_utils::server::rpc_module::{RpcModule, SubscriptionSink};
-pub use server::Server as WsServer;
+pub use server::{Builder as WsServerBuilder, Server as WsServer};

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -27,6 +27,7 @@
 use futures_channel::mpsc;
 use futures_util::io::{BufReader, BufWriter};
 use futures_util::stream::StreamExt;
+use jsonrpsee_types::TEN_MB_SIZE_BYTES;
 use soketto::handshake::{server::Response, Server as SokettoServer};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::net::{TcpListener, ToSocketAddrs};
@@ -45,14 +46,16 @@ use jsonrpsee_utils::server::rpc_module::{ConnectionId, Methods, RpcModule};
 pub struct Server {
 	methods: Methods,
 	listener: TcpListener,
+	cfg: Builder,
 }
 
 impl Server {
+	// TODO: remove
 	/// Create a new WebSocket RPC server, bound to the `addr`.
 	pub async fn new(addr: impl ToSocketAddrs) -> Result<Self, Error> {
 		let listener = TcpListener::bind(addr).await?;
 
-		Ok(Server { listener, methods: Methods::default() })
+		Ok(Server { listener, methods: Methods::default(), cfg: Builder::default() })
 	}
 
 	/// Register all methods from a [`Methods`] of provided [`RpcModule`] on this server.
@@ -77,6 +80,7 @@ impl Server {
 	pub async fn start(self) {
 		let mut incoming = TcpListenerStream::new(self.listener);
 		let methods = Arc::new(self.methods);
+		let cfg = Arc::new(self.cfg);
 		let mut id = 0;
 
 		while let Some(socket) = incoming.next().await {
@@ -84,8 +88,9 @@ impl Server {
 				socket.set_nodelay(true).unwrap();
 
 				let methods = methods.clone();
+				let cfg = cfg.clone();
 
-				tokio::spawn(async move { background_task(socket, methods, id).await });
+				tokio::spawn(async move { background_task(socket, id, methods, cfg).await });
 
 				id += 1;
 			}
@@ -95,8 +100,9 @@ impl Server {
 
 async fn background_task(
 	socket: tokio::net::TcpStream,
-	methods: Arc<Methods>,
 	conn_id: ConnectionId,
+	methods: Arc<Methods>,
+	cfg: Arc<Builder>,
 ) -> Result<(), Error> {
 	// For each incoming background_task we perform a handshake.
 	let mut server = SokettoServer::new(BufReader::new(BufWriter::new(socket.compat())));
@@ -130,6 +136,12 @@ async fn background_task(
 		data.clear();
 
 		receiver.receive_data(&mut data).await?;
+
+		if data.len() > cfg.max_request_body_size as usize {
+			log::warn!("Request too big ({} bytes, max is {})", data.len(), cfg.max_request_body_size);
+			send_error(Id::Null, &tx, JsonRpcErrorCode::OversizedRequest.into());
+			continue
+		}
 
 		// For reasons outlined [here](https://github.com/serde-rs/json/issues/497), `RawValue` can't be used with
 		// untagged enums at the moment. This means we can't use an `SingleOrBatch` untagged enum here and have to try
@@ -166,5 +178,32 @@ async fn background_task(
 
 			send_error(id, &tx, code.into());
 		}
+	}
+}
+
+
+/// Builder to configure and create a JSON-RPC Websocket server
+#[derive(Debug)]
+pub struct Builder {
+	max_request_body_size: u32,
+}
+
+impl Builder {
+	/// Set the maximum size of a request body in bytes. Default is 10 MiB.
+	pub fn max_request_body_size(mut self, size: u32) -> Self {
+		self.max_request_body_size = size;
+		self
+	}
+
+	/// Finalize the configuration of the server. Consumes the [`Builder`].
+	pub async fn build(self, addr: impl ToSocketAddrs) -> Result<Server, Error> {
+		let listener = TcpListener::bind(addr).await?;
+		Ok(Server { listener, methods: Methods::default(), cfg: self })
+	}
+}
+
+impl Default for Builder {
+	fn default() -> Self {
+		Self { max_request_body_size: TEN_MB_SIZE_BYTES }
 	}
 }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -50,14 +50,6 @@ pub struct Server {
 }
 
 impl Server {
-	// TODO: remove
-	/// Create a new WebSocket RPC server, bound to the `addr`.
-	pub async fn new(addr: impl ToSocketAddrs) -> Result<Self, Error> {
-		let listener = TcpListener::bind(addr).await?;
-
-		Ok(Server { listener, methods: Methods::default(), cfg: Builder::default() })
-	}
-
 	/// Register all methods from a [`Methods`] of provided [`RpcModule`] on this server.
 	/// In case a method already is registered with the same name, no method is added and a [`Error::MethodAlreadyRegistered`]
 	/// is returned. Note that the [`RpcModule`] is consumed after this call.

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -132,7 +132,7 @@ async fn background_task(
 		if data.len() > cfg.max_request_body_size as usize {
 			log::warn!("Request is too big ({} bytes, max is {})", data.len(), cfg.max_request_body_size);
 			send_error(Id::Null, &tx, JsonRpcErrorCode::OversizedRequest.into());
-			continue
+			continue;
 		}
 
 		// For reasons outlined [here](https://github.com/serde-rs/json/issues/497), `RawValue` can't be used with
@@ -172,7 +172,6 @@ async fn background_task(
 		}
 	}
 }
-
 
 /// Builder to configure and create a JSON-RPC Websocket server
 #[derive(Debug)]

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -130,7 +130,7 @@ async fn background_task(
 		receiver.receive_data(&mut data).await?;
 
 		if data.len() > cfg.max_request_body_size as usize {
-			log::warn!("Request too big ({} bytes, max is {})", data.len(), cfg.max_request_body_size);
+			log::warn!("Request is too big ({} bytes, max is {})", data.len(), cfg.max_request_body_size);
 			send_error(Id::Null, &tx, JsonRpcErrorCode::OversizedRequest.into());
 			continue
 		}

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -124,9 +124,7 @@ async fn can_set_the_max_request_body_size() {
 	// Rejects all requests larger than 10 bytes
 	let mut server = WsServerBuilder::default().max_request_body_size(10).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| {
-		Ok(())
-	}).unwrap();
+	module.register_method("anything", |_p, _cx| Ok(())).unwrap();
 	server.register_module(module).unwrap();
 	let addr = server.local_addr().unwrap();
 	tokio::spawn(async { server.start().await });

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{RpcModule, WsServer, WsServerBuilder};
+use crate::{RpcModule, WsServerBuilder};
 use futures_util::FutureExt;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
@@ -26,7 +26,7 @@ impl std::error::Error for MyAppError {}
 /// Spawns a dummy `JSONRPC v2 WebSocket`
 /// It has two hardcoded methods: "say_hello" and "add"
 async fn server() -> SocketAddr {
-	let mut server = WsServer::new("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let mut server = WsServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut module = RpcModule::new(());
 	module
 		.register_method("say_hello", |_, _| {
@@ -70,7 +70,7 @@ async fn server() -> SocketAddr {
 
 /// Run server with user provided context.
 async fn server_with_context() -> SocketAddr {
-	let mut server = WsServer::new("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let mut server = WsServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 
 	let ctx = TestContext;
 	let mut rpc_module = RpcModule::new(ctx);
@@ -397,7 +397,8 @@ async fn can_register_modules() {
 	let cx2 = Vec::<u8>::new();
 	let mut mod2 = RpcModule::new(cx2);
 
-	let mut server = WsServer::new("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	// let mut server = WsServer::new("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let mut server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	assert_eq!(server.method_names().len(), 0);
 	mod1.register_method("bla", |_, cx| Ok(format!("Gave me {}", cx))).unwrap();
 	mod1.register_method("bla2", |_, cx| Ok(format!("Gave me {}", cx))).unwrap();

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -397,7 +397,6 @@ async fn can_register_modules() {
 	let cx2 = Vec::<u8>::new();
 	let mut mod2 = RpcModule::new(cx2);
 
-	// let mut server = WsServer::new("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	assert_eq!(server.method_names().len(), 0);
 	mod1.register_method("bla", |_, cx| Ok(format!("Gave me {}", cx))).unwrap();

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -162,7 +162,9 @@ async fn can_set_max_connections() {
 	// Third connection is rejected
 	assert!(conn3.is_err());
 	let err = conn3.unwrap_err();
-	assert_eq!(err.to_string(), "WebSocketHandshake failed: Err(Io(Os { code: 54, kind: ConnectionReset, message: \"Connection reset by peer\" }))");
+	assert!(err.to_string().contains("WebSocketHandshake failed"));
+	assert!(err.to_string().contains("Connection reset by peer"));
+	// Err(Io(Os { code: 54, kind: ConnectionReset, message: \"Connection reset by peer\" }))");
 
 	// Decrement connection count
 	drop(conn2);


### PR DESCRIPTION
Add minimal builder. Partially addresses https://github.com/paritytech/jsonrpsee/issues/361 but there are plenty of config options we could add (see e.g. what `parity-ws` [offers](https://github.com/paritytech/ws-rs/blob/master/src/lib.rs#L131)).

In particular this PR does not address the need to handle allowlists for hosts and origins (used in `substrate` e.g. [here](https://github.com/paritytech/substrate/blob/4652f9e00f0e3079b9ed40ff806829f17fd1ddcf/client/rpc-servers/src/lib.rs#L129)), which looks like it needs a change in soketto. When a client handshakes with a `soketto` server we get a [`ClientRequest`](https://github.com/paritytech/soketto/blob/38f5254ad230f2d16ea0d087be527abb21321500/src/handshake/server.rs#L219) which does not contain any header info at all. 

Supporting request filtering based on headers will require a change in `soketto`.