### PR TITLE
[client]: add timeouts to all request kinds + default timeout

### DIFF
--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/jsonrpsee-http-client"
 
 [dependencies]
 async-trait = "0.1"
+futures = { version = "0.3.14", default-features = false, features = ["std"] }
 hyper13-rustls = { package = "hyper-rustls", version = "0.21", optional = true }
 hyper14-rustls = { package = "hyper-rustls", version = "0.22", optional = true }
 hyper14 = { package = "hyper", version = "0.14", features = ["client", "http1", "http2", "tcp"], optional = true }
@@ -20,14 +21,16 @@ jsonrpsee-utils = { path = "../utils", version = "=0.2.0-alpha.7", optional = tr
 log = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
+tokio-timer = { version = "0.2", optional = true }
+tokio = { version = "1", features = ["time"], optional = true }
 thiserror = "1.0"
 url = "2.2"
 fnv = "1"
 
 [features]
 default = ["tokio1"]
-tokio1 = ["hyper14", "hyper14-rustls", "jsonrpsee-utils/hyper_14"]
-tokio02 = ["hyper13", "hyper13-rustls", "jsonrpsee-utils/hyper_13"]
+tokio1 = ["hyper14", "hyper14-rustls", "jsonrpsee-utils/hyper_14", "tokio" ]
+tokio02 = ["hyper13", "hyper13-rustls", "jsonrpsee-utils/hyper_13", "tokio-timer" ]
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -21,8 +21,8 @@ jsonrpsee-utils = { path = "../utils", version = "=0.2.0-alpha.7", optional = tr
 log = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-tokio-timer = { version = "0.2", optional = true }
 tokio = { version = "1", features = ["time"], optional = true }
+_tokio02 = { package = "tokio", version = "0.2", features = ["time"], optional = true }
 thiserror = "1.0"
 url = "2.2"
 fnv = "1"
@@ -30,8 +30,8 @@ fnv = "1"
 [features]
 default = ["tokio1"]
 tokio1 = ["hyper14", "hyper14-rustls", "jsonrpsee-utils/hyper_14", "tokio" ]
-tokio02 = ["hyper13", "hyper13-rustls", "jsonrpsee-utils/hyper_13", "tokio-timer" ]
+tokio02 = ["hyper13", "hyper13-rustls", "jsonrpsee-utils/hyper_13", "_tokio02" ]
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }
-tokio = { version = "1.0", features = ["net", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "macros"] }

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -21,17 +21,17 @@ jsonrpsee-utils = { path = "../utils", version = "=0.2.0-alpha.7", optional = tr
 log = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", features = ["time"], optional = true }
-_tokio02 = { package = "tokio", version = "0.2", features = ["time"], optional = true }
+tokioV1 = { package = "tokio", version = "1", features = ["time"], optional = true }
+tokioV02 = { package = "tokio", version = "0.2", features = ["time"], optional = true }
 thiserror = "1.0"
 url = "2.2"
 fnv = "1"
 
 [features]
 default = ["tokio1"]
-tokio1 = ["hyper14", "hyper14-rustls", "jsonrpsee-utils/hyper_14", "tokio" ]
-tokio02 = ["hyper13", "hyper13-rustls", "jsonrpsee-utils/hyper_13", "_tokio02" ]
+tokio1 = ["hyper14", "hyper14-rustls", "jsonrpsee-utils/hyper_14", "tokioV1" ]
+tokio02 = ["hyper13", "hyper13-rustls", "jsonrpsee-utils/hyper_13", "tokioV02" ]
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }
-tokio = { version = "1", features = ["net", "rt-multi-thread", "macros"] }
+tokioV1 = { package = "tokio", version = "1", features = ["net", "rt-multi-thread", "macros"] }

--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -9,13 +9,17 @@ use crate::v2::{
 use crate::{Error, TEN_MB_SIZE_BYTES};
 use async_trait::async_trait;
 use fnv::FnvHashMap;
+use futures::Future;
 use serde::de::DeserializeOwned;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::time::error::Elapsed;
 
 /// Http Client Builder.
 #[derive(Debug)]
 pub struct HttpClientBuilder {
 	max_request_body_size: u32,
+	request_timeout: Option<Duration>,
 }
 
 impl HttpClientBuilder {
@@ -25,17 +29,25 @@ impl HttpClientBuilder {
 		self
 	}
 
+	/// Set request timeout (default is 60 seconds).
+	///
+	/// None - implies that no timeout is used.
+	pub fn request_timeout(mut self, timeout: Option<Duration>) -> Self {
+		self.request_timeout = timeout;
+		self
+	}
+
 	/// Build the HTTP client with target to connect to.
 	pub fn build(self, target: impl AsRef<str>) -> Result<HttpClient, Error> {
 		let transport =
 			HttpTransportClient::new(target, self.max_request_body_size).map_err(|e| Error::Transport(Box::new(e)))?;
-		Ok(HttpClient { transport, request_id: AtomicU64::new(0) })
+		Ok(HttpClient { transport, request_id: AtomicU64::new(0), request_timeout: self.request_timeout })
 	}
 }
 
 impl Default for HttpClientBuilder {
 	fn default() -> Self {
-		Self { max_request_body_size: TEN_MB_SIZE_BYTES }
+		Self { max_request_body_size: TEN_MB_SIZE_BYTES, request_timeout: Some(Duration::from_secs(60)) }
 	}
 }
 
@@ -46,16 +58,20 @@ pub struct HttpClient {
 	transport: HttpTransportClient,
 	/// Request ID that wraps around when overflowing.
 	request_id: AtomicU64,
+	/// Request timeout
+	request_timeout: Option<Duration>,
 }
 
 #[async_trait]
 impl Client for HttpClient {
 	async fn notification<'a>(&self, method: &'a str, params: JsonRpcParams<'a>) -> Result<(), Error> {
 		let notif = JsonRpcNotificationSer::new(method, params);
-		self.transport
-			.send(serde_json::to_string(&notif).map_err(Error::ParseError)?)
-			.await
-			.map_err(|e| Error::Transport(Box::new(e)))
+		let fut = self.transport.send(serde_json::to_string(&notif).map_err(Error::ParseError)?);
+		match call_with_maybe_timeout(fut, self.request_timeout).await {
+			Ok(Ok(ok)) => Ok(ok),
+			Err(_) => Err(Error::RequestTimeout),
+			Ok(Err(e)) => Err(Error::Transport(Box::new(e))),
+		}
 	}
 
 	/// Perform a request towards the server.
@@ -67,11 +83,12 @@ impl Client for HttpClient {
 		let id = self.request_id.fetch_add(1, Ordering::SeqCst);
 		let request = JsonRpcCallSer::new(Id::Number(id), method, params);
 
-		let body = self
-			.transport
-			.send_and_read_body(serde_json::to_string(&request).map_err(Error::ParseError)?)
-			.await
-			.map_err(|e| Error::Transport(Box::new(e)))?;
+		let fut = self.transport.send_and_read_body(serde_json::to_string(&request).map_err(Error::ParseError)?);
+		let body = match call_with_maybe_timeout(fut, self.request_timeout).await {
+			Ok(Ok(body)) => body,
+			Err(_e) => return Err(Error::RequestTimeout),
+			Ok(Err(e)) => return Err(Error::Transport(Box::new(e))),
+		};
 
 		let response: JsonRpcResponse<_> = match serde_json::from_slice(&body) {
 			Ok(response) => response,
@@ -106,11 +123,13 @@ impl Client for HttpClient {
 			request_set.insert(id, pos);
 		}
 
-		let body = self
-			.transport
-			.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?)
-			.await
-			.map_err(|e| Error::Transport(Box::new(e)))?;
+		let fut = self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
+
+		let body = match call_with_maybe_timeout(fut, self.request_timeout).await {
+			Ok(Ok(body)) => body,
+			Err(_e) => return Err(Error::RequestTimeout),
+			Ok(Err(e)) => return Err(Error::Transport(Box::new(e))),
+		};
 
 		let rps: Vec<JsonRpcResponse<_>> = match serde_json::from_slice(&body) {
 			Ok(response) => response,
@@ -131,5 +150,16 @@ impl Client for HttpClient {
 			responses[pos] = rp.result
 		}
 		Ok(responses)
+	}
+}
+
+async fn call_with_maybe_timeout<F>(fut: F, timeout: Option<Duration>) -> Result<F::Output, Elapsed>
+where
+	F: Future,
+{
+	if let Some(dur) = timeout {
+		tokio::time::timeout(dur, fut).await
+	} else {
+		Ok(fut.await)
 	}
 }

--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -152,25 +152,12 @@ impl Client for HttpClient {
 	}
 }
 
-#[cfg(feature = "tokio1")]
-async fn call_with_maybe_timeout<F>(fut: F, timeout: Option<Duration>) -> Result<F::Output, tokio::time::error::Elapsed>
+async fn call_with_maybe_timeout<F>(fut: F, timeout: Option<Duration>) -> Result<F::Output, crate::tokio::Elapsed>
 where
 	F: Future,
 {
 	if let Some(dur) = timeout {
-		tokio::time::timeout(dur, fut).await
-	} else {
-		Ok(fut.await)
-	}
-}
-
-#[cfg(feature = "tokio02")]
-async fn call_with_maybe_timeout<F>(fut: F, timeout: Option<Duration>) -> Result<F::Output, _tokio02::time::Elapsed>
-where
-	F: Future,
-{
-	if let Some(dur) = timeout {
-		_tokio02::time::timeout(dur, fut).await
+		crate::tokio::timeout(dur, fut).await
 	} else {
 		Ok(fut.await)
 	}

--- a/http-client/src/lib.rs
+++ b/http-client/src/lib.rs
@@ -39,6 +39,21 @@ extern crate hyper13_rustls as hyper_rustls;
 mod client;
 mod transport;
 
+#[cfg(all(feature = "tokio1", not(feature = "tokio02")))]
+mod tokio {
+	// Required for `tokio::test` to work correctly.
+	pub(crate) use tokioV1::time::error::Elapsed;
+	pub(crate) use tokioV1::time::timeout;
+	#[cfg(test)]
+	pub(crate) use tokioV1::{runtime, test};
+}
+
+#[cfg(all(feature = "tokio02", not(feature = "tokio1")))]
+mod tokio {
+	pub(crate) use tokioV02::time::timeout;
+	pub(crate) use tokioV02::time::Elapsed;
+}
+
 #[cfg(test)]
 mod tests;
 

--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -2,7 +2,7 @@ use crate::v2::{
 	error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject},
 	params::JsonRpcParams,
 };
-use crate::{traits::Client, Error, HttpClientBuilder, JsonValue};
+use crate::{tokio, traits::Client, Error, HttpClientBuilder, JsonValue};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::Id;
 use jsonrpsee_test_utils::TimeoutFutureExt;

--- a/http-client/src/transport.rs
+++ b/http-client/src/transport.rs
@@ -115,6 +115,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::{Error, HttpTransportClient};
+	use crate::tokio;
 
 	#[test]
 	fn invalid_http_url_rejected() {

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -11,14 +11,14 @@ documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
 # Tokio v1 deps
-tokioV1 = { package="tokio", version = "1", features = ["net", "time"], optional=true }
-tokioV1-rustls = { package="tokio-rustls", version = "0.22", optional=true }
-tokioV1-util = { package="tokio-util", version = "0.6", features = ["compat"], optional=true }
+tokioV1 = { package = "tokio", version = "1", features = ["net", "time"], optional = true }
+tokioV1-rustls = { package ="tokio-rustls", version = "0.22", optional = true }
+tokioV1-util = { package= "tokio-util", version = "0.6", features = ["compat"], optional = true }
 
 # Tokio v0.2 deps
-tokioV02 = { package="tokio", version = "0.2", features = ["net", "time"], optional=true }
-tokioV02-rustls = { package="tokio-rustls", version = "0.15", optional=true }
-tokioV02-util = { package="tokio-util", version = "0.3", features = ["compat"], optional=true }
+tokioV02 = { package = "tokio", version = "0.2", features = ["net", "time"], optional=true }
+tokioV02-rustls = { package = "tokio-rustls", version = "0.15", optional = true }
+tokioV02-util = { package = "tokio-util", version = "0.3", features = ["compat"], optional = true }
 
 async-trait = "0.1"
 fnv = "1"

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -209,7 +209,7 @@ impl<'a> WsClientBuilder<'a> {
 
 	/// Set request timeout (default is 60 seconds).
 	///
-	/// None - implies that no timeout is used.
+	/// None - no timeout is used.
 	pub fn request_timeout(mut self, timeout: Option<Duration>) -> Self {
 		self.request_timeout = timeout;
 		self


### PR DESCRIPTION
Add default timeout on the all the clients requests to 60 seconds.

The PR itself is !DRY of  in a few places.