### PR TITLE
Async/subscription benches

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,7 +9,8 @@ publish = false
 
 [dev-dependencies]
 criterion = "0.3"
-futures-channel = "0.3.14"
+futures-channel = "0.3.15"
+futures-util = "0.3.15"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 num_cpus = "1"
 serde_json = "1"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,8 +13,43 @@ use tokio::runtime::Runtime as TokioRuntime;
 
 mod helpers;
 
-criterion_group!(benches, http_requests, batched_http_requests, websocket_requests, jsonrpsee_types_v2);
-criterion_main!(benches);
+criterion_group!(types_benches, jsonrpsee_types_v2);
+criterion_group!(
+	sync_benches,
+	SyncBencher::http_requests,
+	SyncBencher::batched_http_requests,
+	SyncBencher::websocket_requests
+);
+criterion_group!(
+	async_benches,
+	AsyncBencher::http_requests,
+	AsyncBencher::batched_http_requests,
+	AsyncBencher::websocket_requests
+);
+criterion_main!(types_benches, sync_benches, async_benches);
+
+#[derive(Debug, Clone, Copy)]
+enum RequestType {
+	Sync,
+	Async,
+}
+
+impl RequestType {
+	fn method_name(self) -> &'static str {
+		match self {
+			RequestType::Sync => crate::helpers::SYNC_METHOD_NAME,
+			RequestType::Async => crate::helpers::ASYNC_METHOD_NAME,
+		}
+	}
+
+	fn group_name(self, name: &str) -> String {
+		let request_type_name = match self {
+			RequestType::Sync => "sync",
+			RequestType::Async => "async",
+		};
+		format!("{}/{}", request_type_name, name)
+	}
+}
 
 fn v2_serialize(req: JsonRpcCallSer<'_>) -> String {
 	serde_json::to_string(&req).unwrap()
@@ -39,53 +74,74 @@ pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
 	});
 }
 
-pub fn http_requests(crit: &mut Criterion) {
-	let rt = TokioRuntime::new().unwrap();
-	let url = rt.block_on(helpers::http_server());
-	let client = Arc::new(HttpClientBuilder::default().build(&url).unwrap());
-	run_round_trip(&rt, crit, client.clone(), "http_round_trip");
-	run_concurrent_round_trip(&rt, crit, client, "http_concurrent_round_trip");
+trait RequestBencher {
+	const REQUEST_TYPE: RequestType;
+
+	fn http_requests(crit: &mut Criterion) {
+		let rt = TokioRuntime::new().unwrap();
+		let url = rt.block_on(helpers::http_server());
+		let client = Arc::new(HttpClientBuilder::default().build(&url).unwrap());
+		run_round_trip(&rt, crit, client.clone(), "http_round_trip", Self::REQUEST_TYPE);
+		run_concurrent_round_trip(&rt, crit, client, "http_concurrent_round_trip", Self::REQUEST_TYPE);
+	}
+
+	fn batched_http_requests(crit: &mut Criterion) {
+		let rt = TokioRuntime::new().unwrap();
+		let url = rt.block_on(helpers::http_server());
+		let client = Arc::new(HttpClientBuilder::default().build(&url).unwrap());
+		run_round_trip_with_batch(&rt, crit, client, "http batch requests", Self::REQUEST_TYPE);
+	}
+
+	fn websocket_requests(crit: &mut Criterion) {
+		let rt = TokioRuntime::new().unwrap();
+		let url = rt.block_on(helpers::ws_server());
+		let client =
+			Arc::new(rt.block_on(WsClientBuilder::default().max_concurrent_requests(1024 * 1024).build(&url)).unwrap());
+		run_round_trip(&rt, crit, client.clone(), "ws_round_trip", Self::REQUEST_TYPE);
+		run_concurrent_round_trip(&rt, crit, client, "ws_concurrent_round_trip", Self::REQUEST_TYPE);
+	}
+
+	fn batched_ws_requests(crit: &mut Criterion) {
+		let rt = TokioRuntime::new().unwrap();
+		let url = rt.block_on(helpers::ws_server());
+		let client =
+			Arc::new(rt.block_on(WsClientBuilder::default().max_concurrent_requests(1024 * 1024).build(&url)).unwrap());
+		run_round_trip_with_batch(&rt, crit, client, "ws batch requests", Self::REQUEST_TYPE);
+	}
 }
 
-pub fn batched_http_requests(crit: &mut Criterion) {
-	let rt = TokioRuntime::new().unwrap();
-	let url = rt.block_on(helpers::http_server());
-	let client = Arc::new(HttpClientBuilder::default().build(&url).unwrap());
-	run_round_trip_with_batch(&rt, crit, client, "http batch requests");
+pub struct SyncBencher;
+
+impl RequestBencher for SyncBencher {
+	const REQUEST_TYPE: RequestType = RequestType::Sync;
+}
+pub struct AsyncBencher;
+
+impl RequestBencher for AsyncBencher {
+	const REQUEST_TYPE: RequestType = RequestType::Async;
 }
 
-pub fn websocket_requests(crit: &mut Criterion) {
-	let rt = TokioRuntime::new().unwrap();
-	let url = rt.block_on(helpers::ws_server());
-	let client =
-		Arc::new(rt.block_on(WsClientBuilder::default().max_concurrent_requests(1024 * 1024).build(&url)).unwrap());
-	run_round_trip(&rt, crit, client.clone(), "ws_round_trip");
-	run_concurrent_round_trip(&rt, crit, client, "ws_concurrent_round_trip");
-}
-
-pub fn batched_ws_requests(crit: &mut Criterion) {
-	let rt = TokioRuntime::new().unwrap();
-	let url = rt.block_on(helpers::ws_server());
-	let client =
-		Arc::new(rt.block_on(WsClientBuilder::default().max_concurrent_requests(1024 * 1024).build(&url)).unwrap());
-	run_round_trip_with_batch(&rt, crit, client, "ws batch requests");
-}
-
-fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str) {
-	crit.bench_function(name, |b| {
+fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str, request: RequestType) {
+	crit.bench_function(&request.group_name(name), |b| {
 		b.iter(|| {
 			rt.block_on(async {
-				black_box(client.request::<String>("say_hello", JsonRpcParams::NoParams).await.unwrap());
+				black_box(client.request::<String>(request.method_name(), JsonRpcParams::NoParams).await.unwrap());
 			})
 		})
 	});
 }
 
 /// Benchmark http batch requests over batch sizes of 2, 5, 10, 50 and 100 RPCs in each batch.
-fn run_round_trip_with_batch(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str) {
-	let mut group = crit.benchmark_group(name);
+fn run_round_trip_with_batch(
+	rt: &TokioRuntime,
+	crit: &mut Criterion,
+	client: Arc<impl Client>,
+	name: &str,
+	request: RequestType,
+) {
+	let mut group = crit.benchmark_group(request.group_name(name));
 	for batch_size in [2, 5, 10, 50, 100usize].iter() {
-		let batch = vec![("say_hello", JsonRpcParams::NoParams); *batch_size];
+		let batch = vec![(request.method_name(), JsonRpcParams::NoParams); *batch_size];
 		group.throughput(Throughput::Elements(*batch_size as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(batch_size), batch_size, |b, _| {
 			b.iter(|| rt.block_on(async { client.batch_request::<String>(batch.clone()).await.unwrap() }))
@@ -99,8 +155,9 @@ fn run_concurrent_round_trip<C: 'static + Client + Send + Sync>(
 	crit: &mut Criterion,
 	client: Arc<C>,
 	name: &str,
+	request: RequestType,
 ) {
-	let mut group = crit.benchmark_group(name);
+	let mut group = crit.benchmark_group(request.group_name(name));
 	for num_concurrent_tasks in helpers::concurrent_tasks() {
 		group.bench_function(format!("{}", num_concurrent_tasks), |b| {
 			b.iter(|| {
@@ -108,8 +165,9 @@ fn run_concurrent_round_trip<C: 'static + Client + Send + Sync>(
 				for _ in 0..num_concurrent_tasks {
 					let client_rc = client.clone();
 					let task = rt.spawn(async move {
-						let _ =
-							black_box(client_rc.request::<String>("say_hello", JsonRpcParams::NoParams).await.unwrap());
+						let _ = black_box(
+							client_rc.request::<String>(request.method_name(), JsonRpcParams::NoParams).await.unwrap(),
+						);
 					});
 					tasks.push(task);
 				}


### PR DESCRIPTION
This PR implements some basic benches for async methods and subscriptions.

<details>
  <summary>Benches results on my machine (Macbook pro 2020 m1/8gb)</summary>
    
    jsonrpsee_types_v2_array_ref                                                                            
                            time:   [136.86 ns 136.94 ns 137.02 ns]
                            change: [-0.4086% -0.1071% +0.1582%] (p = 0.48 > 0.05)
                            No change in performance detected.
    Found 4 outliers among 100 measurements (4.00%)
    1 (1.00%) low severe
    2 (2.00%) high mild
    1 (1.00%) high severe

    jsonrpsee_types_v2_vec  time:   [195.37 ns 196.11 ns 196.84 ns]                                   
                            change: [+0.4514% +1.0805% +1.6948%] (p = 0.00 < 0.05)
                            Change within noise threshold.
    Found 5 outliers among 100 measurements (5.00%)
    5 (5.00%) low mild

    sync/http_round_trip    time:   [90.861 us 91.206 us 91.547 us]                                 
                            change: [-20.655% -19.404% -18.098%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 6 outliers among 100 measurements (6.00%)
    2 (2.00%) low mild
    2 (2.00%) high mild
    2 (2.00%) high severe

    sync/http_concurrent_round_trip/2                                                                            
                            time:   [131.93 us 132.54 us 133.17 us]
                            change: [-19.932% -18.803% -17.515%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 13 outliers among 100 measurements (13.00%)
    1 (1.00%) low mild
    6 (6.00%) high mild
    6 (6.00%) high severe
    sync/http_concurrent_round_trip/4                                                                            
                            time:   [154.31 us 155.21 us 156.32 us]
                            change: [-9.8596% -8.1128% -6.5251%] (p = 0.00 < 0.05)
                            Performance has improved.
    sync/http_concurrent_round_trip/8                                                                            
                            time:   [193.63 us 194.09 us 194.56 us]
                            change: [-8.7617% -7.5428% -6.2819%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 3 outliers among 100 measurements (3.00%)
    3 (3.00%) high severe
    sync/http_concurrent_round_trip/16                                                                            
                            time:   [278.36 us 283.64 us 292.98 us]
                            change: [-4.3959% -2.7864% -0.8561%] (p = 0.00 < 0.05)
                            Change within noise threshold.
    Found 9 outliers among 100 measurements (9.00%)
    1 (1.00%) low severe
    2 (2.00%) high mild
    6 (6.00%) high severe
    sync/http_concurrent_round_trip/32                                                                            
                            time:   [429.71 us 432.54 us 436.70 us]
                            change: [-1.5870% -0.1872% +1.3616%] (p = 0.80 > 0.05)
                            No change in performance detected.
    Found 10 outliers among 100 measurements (10.00%)
    2 (2.00%) low mild
    2 (2.00%) high mild
    6 (6.00%) high severe

    sync/http batch requests/2                                                                            
                            time:   [93.545 us 94.298 us 95.209 us]
                            thrpt:  [21.006 Kelem/s 21.209 Kelem/s 21.380 Kelem/s]
                    change:
                            time:   [-20.416% -19.389% -18.366%] (p = 0.00 < 0.05)
                            thrpt:  [+22.498% +24.053% +25.653%]
                            Performance has improved.
    Found 8 outliers among 100 measurements (8.00%)
    2 (2.00%) high mild
    6 (6.00%) high severe
    sync/http batch requests/5                                                                            
                            time:   [98.013 us 98.522 us 99.056 us]
                            thrpt:  [50.476 Kelem/s 50.750 Kelem/s 51.014 Kelem/s]
                    change:
                            time:   [-18.776% -18.055% -17.309%] (p = 0.00 < 0.05)
                            thrpt:  [+20.933% +22.033% +23.116%]
                            Performance has improved.
    Found 3 outliers among 100 measurements (3.00%)
    1 (1.00%) high mild
    2 (2.00%) high severe
    sync/http batch requests/10                                                                            
                            time:   [106.80 us 107.40 us 107.97 us]
                            thrpt:  [92.616 Kelem/s 93.114 Kelem/s 93.635 Kelem/s]
                    change:
                            time:   [-16.815% -15.906% -14.983%] (p = 0.00 < 0.05)
                            thrpt:  [+17.623% +18.914% +20.214%]
                            Performance has improved.
    Found 5 outliers among 100 measurements (5.00%)
    2 (2.00%) high mild
    3 (3.00%) high severe
    sync/http batch requests/50                                                                            
                            time:   [174.68 us 175.30 us 175.96 us]
                            thrpt:  [284.15 Kelem/s 285.22 Kelem/s 286.24 Kelem/s]
                    change:
                            time:   [-1.5951% -0.6425% +0.3317%] (p = 0.20 > 0.05)
                            thrpt:  [-0.3306% +0.6466% +1.6210%]
                            No change in performance detected.
    Found 4 outliers among 100 measurements (4.00%)
    4 (4.00%) high mild
    sync/http batch requests/100                                                                            
                            time:   [273.30 us 274.19 us 275.10 us]
                            thrpt:  [363.51 Kelem/s 364.71 Kelem/s 365.90 Kelem/s]
                    change:
                            time:   [+7.5490% +8.3824% +9.2222%] (p = 0.00 < 0.05)
                            thrpt:  [-8.4435% -7.7341% -7.0191%]
                            Performance has regressed.
    Found 5 outliers among 100 measurements (5.00%)
    1 (1.00%) low mild
    1 (1.00%) high mild
    3 (3.00%) high severe

    sync/ws_round_trip      time:   [86.736 us 87.293 us 87.867 us]                               
                            change: [-18.136% -17.115% -15.944%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 6 outliers among 100 measurements (6.00%)
    1 (1.00%) low mild
    3 (3.00%) high mild
    2 (2.00%) high severe

    sync/ws_concurrent_round_trip/2                                                                            
                            time:   [101.33 us 101.76 us 102.25 us]
                            change: [-20.728% -19.813% -18.675%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 8 outliers among 100 measurements (8.00%)
    1 (1.00%) low severe
    1 (1.00%) low mild
    4 (4.00%) high mild
    2 (2.00%) high severe
    sync/ws_concurrent_round_trip/4                                                                            
                            time:   [113.42 us 114.23 us 115.25 us]
                            change: [-19.532% -18.700% -17.802%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 5 outliers among 100 measurements (5.00%)
    1 (1.00%) low severe
    1 (1.00%) low mild
    3 (3.00%) high severe
    sync/ws_concurrent_round_trip/8                                                                            
                            time:   [128.96 us 129.87 us 130.70 us]
                            change: [-17.782% -16.830% -15.806%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 9 outliers among 100 measurements (9.00%)
    1 (1.00%) low severe
    5 (5.00%) high mild
    3 (3.00%) high severe
    sync/ws_concurrent_round_trip/16                                                                            
                            time:   [163.23 us 163.78 us 164.37 us]
                            change: [-8.9197% -8.1539% -7.4094%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 8 outliers among 100 measurements (8.00%)
    1 (1.00%) low severe
    1 (1.00%) low mild
    4 (4.00%) high mild
    2 (2.00%) high severe
    sync/ws_concurrent_round_trip/32                                                                            
                            time:   [229.02 us 229.82 us 230.61 us]
                            change: [-5.5192% -4.7596% -3.9306%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 3 outliers among 100 measurements (3.00%)
    1 (1.00%) low severe
    2 (2.00%) high severe

    async/http_round_trip   time:   [90.950 us 92.079 us 93.495 us]                                  
                            change: [-20.751% -19.390% -17.690%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 14 outliers among 100 measurements (14.00%)
    4 (4.00%) low mild
    4 (4.00%) high mild
    6 (6.00%) high severe

    async/http_concurrent_round_trip/2                                                                            
                            time:   [131.02 us 131.91 us 132.93 us]
                            change: [-21.533% -20.620% -19.652%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 11 outliers among 100 measurements (11.00%)
    1 (1.00%) low mild
    7 (7.00%) high mild
    3 (3.00%) high severe
    async/http_concurrent_round_trip/4                                                                            
                            time:   [152.07 us 153.13 us 154.30 us]
                            change: [-16.028% -15.161% -14.315%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 9 outliers among 100 measurements (9.00%)
    1 (1.00%) low mild
    3 (3.00%) high mild
    5 (5.00%) high severe
    async/http_concurrent_round_trip/8                                                                            
                            time:   [193.08 us 195.43 us 199.31 us]
                            change: [-11.520% -9.9780% -8.5042%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 9 outliers among 100 measurements (9.00%)
    2 (2.00%) low mild
    7 (7.00%) high severe
    async/http_concurrent_round_trip/16                                                                            
                            time:   [275.12 us 275.70 us 276.31 us]
                            change: [-5.6653% -4.5815% -3.4251%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 7 outliers among 100 measurements (7.00%)
    3 (3.00%) high mild
    4 (4.00%) high severe
    async/http_concurrent_round_trip/32                                                                            
                            time:   [429.88 us 430.45 us 431.05 us]
                            change: [-4.7226% -3.4359% -2.1057%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 12 outliers among 100 measurements (12.00%)
    1 (1.00%) low severe
    1 (1.00%) low mild
    5 (5.00%) high mild
    5 (5.00%) high severe

    async/http batch requests/2                                                                            
                            time:   [92.909 us 93.450 us 94.020 us]
                            thrpt:  [21.272 Kelem/s 21.402 Kelem/s 21.526 Kelem/s]
                    change:
                            time:   [-20.348% -19.069% -17.565%] (p = 0.00 < 0.05)
                            thrpt:  [+21.308% +23.561% +25.546%]
                            Performance has improved.
    Found 8 outliers among 100 measurements (8.00%)
    2 (2.00%) low mild
    4 (4.00%) high mild
    2 (2.00%) high severe
    async/http batch requests/5                                                                            
                            time:   [97.867 us 98.567 us 99.535 us]
                            thrpt:  [50.234 Kelem/s 50.727 Kelem/s 51.090 Kelem/s]
                    change:
                            time:   [-19.334% -18.553% -17.706%] (p = 0.00 < 0.05)
                            thrpt:  [+21.516% +22.779% +23.969%]
                            Performance has improved.
    Found 10 outliers among 100 measurements (10.00%)
    1 (1.00%) low severe
    7 (7.00%) high mild
    2 (2.00%) high severe
    async/http batch requests/10                                                                            
                            time:   [106.96 us 107.92 us 109.20 us]
                            thrpt:  [91.579 Kelem/s 92.662 Kelem/s 93.492 Kelem/s]
                    change:
                            time:   [-12.412% -10.164% -7.8280%] (p = 0.00 < 0.05)
                            thrpt:  [+8.4928% +11.314% +14.171%]
                            Performance has improved.
    Found 5 outliers among 100 measurements (5.00%)
    3 (3.00%) high mild
    2 (2.00%) high severe
    async/http batch requests/50                                                                            
                            time:   [177.76 us 178.48 us 179.34 us]
                            thrpt:  [278.79 Kelem/s 280.14 Kelem/s 281.27 Kelem/s]
                    change:
                            time:   [-1.1054% +0.1042% +1.3024%] (p = 0.87 > 0.05)
                            thrpt:  [-1.2856% -0.1041% +1.1178%]
                            No change in performance detected.
    Found 13 outliers among 100 measurements (13.00%)
    1 (1.00%) low severe
    4 (4.00%) low mild
    4 (4.00%) high mild
    4 (4.00%) high severe
    async/http batch requests/100                                                                            
                            time:   [281.07 us 281.97 us 282.87 us]
                            thrpt:  [353.52 Kelem/s 354.64 Kelem/s 355.79 Kelem/s]
                    change:
                            time:   [+6.0183% +6.7535% +7.5430%] (p = 0.00 < 0.05)
                            thrpt:  [-7.0139% -6.3263% -5.6766%]
                            Performance has regressed.
    Found 11 outliers among 100 measurements (11.00%)
    5 (5.00%) low mild
    5 (5.00%) high mild
    1 (1.00%) high severe

    async/ws_round_trip     time:   [87.437 us 88.289 us 89.279 us]                                
                            change: [-18.146% -17.272% -16.271%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 11 outliers among 100 measurements (11.00%)
    1 (1.00%) low severe
    4 (4.00%) high mild
    6 (6.00%) high severe

    async/ws_concurrent_round_trip/2                                                                            
                            time:   [101.12 us 101.51 us 101.91 us]
                            change: [-22.532% -21.498% -20.645%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 12 outliers among 100 measurements (12.00%)
    3 (3.00%) low severe
    1 (1.00%) low mild
    6 (6.00%) high mild
    2 (2.00%) high severe
    async/ws_concurrent_round_trip/4                                                                            
                            time:   [113.08 us 113.56 us 114.07 us]
                            change: [-18.648% -17.668% -16.526%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 6 outliers among 100 measurements (6.00%)
    1 (1.00%) low mild
    3 (3.00%) high mild
    2 (2.00%) high severe
    async/ws_concurrent_round_trip/8                                                                            
                            time:   [130.58 us 131.22 us 131.99 us]
                            change: [-18.569% -17.875% -17.141%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 5 outliers among 100 measurements (5.00%)
    1 (1.00%) high mild
    4 (4.00%) high severe
    async/ws_concurrent_round_trip/16                                                                            
                            time:   [165.56 us 166.18 us 166.88 us]
                            change: [-8.6374% -7.5013% -5.9319%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 14 outliers among 100 measurements (14.00%)
    3 (3.00%) low severe
    5 (5.00%) high mild
    6 (6.00%) high severe
    async/ws_concurrent_round_trip/32                                                                            
                            time:   [234.30 us 235.81 us 237.80 us]
                            change: [-5.0602% -4.2564% -3.3089%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 8 outliers among 100 measurements (8.00%)
    1 (1.00%) low mild
    4 (4.00%) high mild
    3 (3.00%) high severe

    subscriptions/subscribe time:   [89.484 us 90.426 us 91.406 us]                                    
                            change: [-0.3713% +1.2644% +2.8882%] (p = 0.13 > 0.05)
                            No change in performance detected.
    Found 4 outliers among 100 measurements (4.00%)
    1 (1.00%) low mild
    2 (2.00%) high mild
    1 (1.00%) high severe
    subscriptions/subscribe_response                                                                            
                            time:   [2.9190 us 2.9761 us 3.0350 us]
                            change: [-0.5973% +5.5974% +10.953%] (p = 0.05 < 0.05)
                            Change within noise threshold.
    Found 2 outliers among 100 measurements (2.00%)
    2 (2.00%) high severe
    subscriptions/unsub     time:   [1.0417 us 1.0562 us 1.0715 us]                                
                            change: [+4.9001% +7.3872% +10.319%] (p = 0.00 < 0.05)
                            Performance has regressed.
    Found 6 outliers among 100 measurements (6.00%)
    1 (1.00%) low mild
    4 (4.00%) high mild
    1 (1.00%) high severe

</details>
