### PR TITLE
Cross-origin protection

### DIFF
--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -15,6 +15,6 @@ hyper = { version = "0.14", features = ["full"] }
 log = "0.4"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
-soketto = "0.5"
+soketto = "0.6"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.6", features = ["compat"] }

--- a/test-utils/src/types.rs
+++ b/test-utils/src/types.rs
@@ -199,12 +199,12 @@ async fn server_backend(listener: tokio::net::TcpListener, mut exit: Receiver<()
 async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut exit: Receiver<()>) {
 	let mut server = Server::new(socket.compat());
 
-	let websocket_key = match server.receive_request().await {
-		Ok(req) => req.into_key(),
+	let key = match server.receive_request().await {
+		Ok(req) => req.key(),
 		Err(_) => return,
 	};
 
-	let accept = server.send_response(&Response::Accept { key: &websocket_key, protocol: None }).await;
+	let accept = server.send_response(&Response::Accept { key, protocol: None }).await;
 
 	if accept.is_err() {
 		return;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,6 +18,5 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
-# soketto = "0.5"
-soketto = { path = "../../soketto" }
+soketto = "0.6"
 hyper = "0.14"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,5 +18,6 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
-soketto = "0.5"
+# soketto = "0.5"
+soketto = { path = "../../soketto" }
 hyper = "0.14"

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -78,6 +78,9 @@ pub enum Error {
 	/// Configured max number of request slots exceeded.
 	#[error("Configured max number of request slots exceeded")]
 	MaxSlotsExceeded,
+	/// List passed into `set_allowed_origins` was empty
+	#[error("Must set at least one allowed origin")]
+	EmptyAllowedOrigins,
 	/// Custom error.
 	#[error("Custom error: {0}")]
 	Custom(String),

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -27,7 +27,7 @@ jsonrpsee-types = { path = "../types", version = "0.2.0" }
 log = "0.4"
 serde = "1"
 serde_json = "1"
-soketto = "0.5"
+soketto = "0.6"
 pin-project = "1"
 thiserror = "1"
 url = "2"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -19,7 +19,8 @@ log = "0.4"
 rustc-hash = "1.1.0"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
-soketto = "0.5"
+# soketto = "0.5"
+soketto = { path = "../../soketto" }
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.1", features = ["net"] }
 tokio-util = { version = "0.6", features = ["compat"] }

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -19,8 +19,7 @@ log = "0.4"
 rustc-hash = "1.1.0"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
-# soketto = "0.5"
-soketto = { path = "../../soketto" }
+soketto = "0.6"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.1", features = ["net"] }
 tokio-util = { version = "0.6", features = ["compat"] }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -250,13 +250,20 @@ impl Builder {
 	}
 
 	/// Set a list of allowet `Origin` headers, connections comming in with a different
-	/// origin will be denied.
+	/// origin will be denied. Values should include protocol.
 	///
-	/// Values should include protocol: `"protocol://hostname"`.
+	/// ```rust
+	/// # let mut builder = jsonrpsee_ws_server::WsServerBuilder::default();
+	/// builder.set_allowed_origins(vec!["https://example.com"]);
+	/// ```
 	///
-	/// By default allows any Origin.
-	pub fn set_allowed_origins(mut self, list: impl AsRef<[String]>) -> Self {
-		self.settings.cors = Cors::AllowList(list.as_ref().into());
+	/// By default allows any `Origin`.
+	pub fn set_allowed_origins<Origin, List>(mut self, list: List) -> Self
+	where
+		List: IntoIterator<Item = Origin>,
+		Origin: Into<String>,
+	{
+		self.settings.cors = Cors::AllowList(list.into_iter().map(Into::into).collect());
 		self
 	}
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -255,6 +255,8 @@ impl Builder {
 	/// ```
 	///
 	/// By default allows any `Origin`.
+	///
+	/// Will return an error if `list` is empty. Use [`allow_all_origins`](Builder::allow_all_origins) to restore the default.
 	pub fn set_allowed_origins<Origin, List>(mut self, list: List) -> Result<Self, Error>
 	where
 		List: IntoIterator<Item = Origin>,
@@ -269,6 +271,13 @@ impl Builder {
 		self.settings.cors = Cors::AllowList(list);
 
 		Ok(self)
+	}
+
+	/// Restores the default behavior of allowing connections with `Origin` header
+	/// containing any value. This will undo any list set by [`set_allowed_origins`](Builder::set_allowed_origins).
+	pub fn allow_all_origins(mut self) -> Self {
+		self.settings.cors = Cors::AllowAny;
+		self
 	}
 
 	/// Finalize the configuration of the server. Consumes the [`Builder`].

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -110,6 +110,8 @@ async fn background_task(
 
 		if let (Cors::AllowList(list), Some(origin)) = (&cfg.cors, req.headers().origin) {
 			if !list.iter().any(|o| o.as_bytes() == origin) {
+				// TODO: send `Response::Reject` with an appropriate status code
+
 				let error = format!("Origin denied: {}", String::from_utf8_lossy(origin));
 				log::warn!("{}", error);
 				return Err(Error::Request(error));
@@ -201,7 +203,7 @@ struct Settings {
 	max_request_body_size: u32,
 	/// Maximum number of incoming connections allowed.
 	max_connections: u64,
-
+	/// Cross-origin policy by which to accept or deny incoming requests.
 	cors: Cors,
 }
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -115,7 +115,7 @@ async fn background_task(
 		Ok(key) => {
 			let accept = Response::Accept { key, protocol: None };
 			server.send_response(&accept).await?;
-		},
+		}
 		Err(error) => {
 			let reject = Response::Reject { status_code: 403 };
 			server.send_response(&reject).await?;
@@ -222,11 +222,7 @@ struct Settings {
 
 impl Default for Settings {
 	fn default() -> Self {
-		Self {
-			max_request_body_size: TEN_MB_SIZE_BYTES,
-			max_connections: MAX_CONNECTIONS,
-			cors: Cors::AllowAny,
-		}
+		Self { max_request_body_size: TEN_MB_SIZE_BYTES, max_connections: MAX_CONNECTIONS, cors: Cors::AllowAny }
 	}
 }
 


### PR DESCRIPTION
Depends on https://github.com/paritytech/soketto/pull/35

No filters for `Host`, Substrate doesn't seem to care, it's more of interest to the likes of nginx reverse proxy for setting up virtual hosts. IIRC it was always confusing in `parity-ethereum`?