### PR TITLE
Method aliases + RpcModule: Clone

### DIFF
--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -66,6 +66,9 @@ pub enum Error {
 	/// Method was already registered.
 	#[error("Method: {0} was already registered")]
 	MethodAlreadyRegistered(String),
+	/// Method with that name has not yet been registered.
+	#[error("Method: {0} has not yet been registered")]
+	MethodNotFound(String),
 	/// Subscribe and unsubscribe method names are the same.
 	#[error("Cannot use the same method name for subscribe and unsubscribe, used: {0}")]
 	SubscriptionNameConflict(String),

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -82,7 +82,7 @@ impl Debug for MethodCallback {
 	}
 }
 
-/// Collection of synchronous and asynchronous methods.
+/// Reference counted collection of synchronous and asynchronous methods.
 #[derive(Default, Debug, Clone)]
 pub struct Methods {
 	callbacks: Arc<FxHashMap<&'static str, MethodCallback>>,
@@ -139,6 +139,11 @@ impl Methods {
 	/// Returns a `Vec` with all the method names registered on this server.
 	pub fn method_names(&self) -> Vec<&'static str> {
 		self.callbacks.keys().copied().collect()
+	}
+
+	/// Get the reference count this instance of `Methods`.
+	pub fn ref_count(&self) -> usize {
+		Arc::strong_count(&self.callbacks)
 	}
 }
 

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -141,7 +141,7 @@ impl Methods {
 		self.callbacks.keys().copied().collect()
 	}
 
-	/// Get the reference count this instance of `Methods`.
+	/// Get the reference count for this instance of `Methods`.
 	pub fn ref_count(&self) -> usize {
 		Arc::strong_count(&self.callbacks)
 	}

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -343,7 +343,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 
 		let callback = match self.methods.callbacks.get(existing_method) {
 			Some(callback) => callback.clone(),
-			None => return Err(Error::MethodNotFound(existing_method.into()))
+			None => return Err(Error::MethodNotFound(existing_method.into())),
 		};
 
 		self.methods.mut_callbacks().insert(alias, callback);

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -140,11 +140,6 @@ impl Methods {
 	pub fn method_names(&self) -> Vec<&'static str> {
 		self.callbacks.keys().copied().collect()
 	}
-
-	/// Get the reference count for this instance of `Methods`.
-	pub fn ref_count(&self) -> usize {
-		Arc::strong_count(&self.callbacks)
-	}
 }
 
 /// Sets of JSON-RPC methods can be organized into a "module"s that are in turn registered on the server or,

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -56,7 +56,7 @@ impl Server {
 	/// Register all methods from a [`Methods`] of provided [`RpcModule`] on this server.
 	/// In case a method already is registered with the same name, no method is added and a [`Error::MethodAlreadyRegistered`]
 	/// is returned. Note that the [`RpcModule`] is consumed after this call.
-	pub fn register_module<Context: Send + Sync + 'static>(&mut self, module: RpcModule<Context>) -> Result<(), Error> {
+	pub fn register_module<Context>(&mut self, module: RpcModule<Context>) -> Result<(), Error> {
 		self.methods.merge(module.into_methods())?;
 		Ok(())
 	}


### PR DESCRIPTION
+ Added `register_alias` (closes #378).
+ `RpcModule` and `Methods` both now implement `Clone` (closes #328).
+ `Methods` is now using an opaque internal `Arc`, `ws_server` no longer wraps `Methods` in `Arc`.