### PR TITLE
Use criterion's async bencher

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 publish = false
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
 futures-channel = "0.3.15"
 futures-util = "0.3.15"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }


### PR DESCRIPTION
Doesn't change much in terms of both diff and bench results, but IMHO makes the code a bit more clear (by removing the necessity of `block_on` in every single bench).

Note that we still need to pre-create runtime and manually pass it everywhere, since we need the server to be spawned outside of the bench and run in the same runtime.

Also, I rewrote `run_concurrent_round_trip` in a functional style to avoid allocating `Vec` inside of the bench body.