### PR TITLE
Synchronization-less async connections in ws-server

### DIFF
--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -148,6 +148,9 @@ where
 
 		while i < this.connections.len() {
 			if this.connections[i].poll_unpin(cx).is_ready() {
+				// Using `swap_remove` since we don't care about ordering
+				// but we do care about removing being `O(1)`.
+				//
 				// We don't increment `i` in this branch, since we now
 				// have a shorter length, and potentially a new value at
 				// current index

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -106,8 +106,8 @@ impl Server {
 						continue;
 					}
 
-					let methods = methods.clone();
-					let cfg = self.cfg.clone();
+					let methods = &methods;
+					let cfg = &self.cfg;
 
 					running.push(Box::pin(background_task(socket, id, methods, cfg)));
 				},
@@ -163,8 +163,8 @@ where
 async fn background_task(
 	socket: tokio::net::TcpStream,
 	conn_id: ConnectionId,
-	methods: Methods,
-	cfg: Settings,
+	methods: &Methods,
+	cfg: &Settings,
 ) -> Result<(), Error> {
 	// For each incoming background_task we perform a handshake.
 	let mut server = SokettoServer::new(BufReader::new(BufWriter::new(socket.compat())));

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -120,7 +120,7 @@ impl Server {
 
 					driver.add(Box::pin(handshake(socket, id, methods, cfg, &shutdown, &self.stop_handle)));
 
-					id += 1;
+					id = id.wrapping_add(1);
 				}
 				Err(DriverError::Io(err)) => {
 					log::error!("Error while awaiting a new connection: {:?}", err);

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -224,7 +224,7 @@ async fn handshake(
 		}
 	}
 
-	tokio::spawn(background_task(
+	let join_result = tokio::spawn(background_task(
 		server,
 		conn_id,
 		methods.clone(),
@@ -232,8 +232,12 @@ async fn handshake(
 		shutdown.clone(),
 		stop_handle.clone(),
 	))
-	.await
-	.unwrap()
+	.await;
+
+	match join_result {
+		Err(_) => Err(Error::Custom("Background task was aborted".into())),
+		Ok(result) => result,
+	}
 }
 
 async fn background_task(

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -191,9 +191,7 @@ async fn background_task(
 		}
 	}
 
-	tokio::spawn(background_task_2(server, conn_id, methods.clone(), cfg.max_request_body_size));
-
-	Ok(())
+	tokio::spawn(background_task_2(server, conn_id, methods.clone(), cfg.max_request_body_size)).await.unwrap()
 }
 
 async fn background_task_2(

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -123,10 +123,7 @@ where
 	F: Future + Unpin,
 {
 	fn new(listener: TcpListener) -> Self {
-		ConnDriver {
-			listener,
-			connections: Vec::new(),
-		}
+		ConnDriver { listener, connections: Vec::new() }
 	}
 
 	fn count(&self) -> usize {
@@ -151,10 +148,10 @@ where
 
 		while i < this.connections.len() {
 			if this.connections[i].poll_unpin(cx).is_ready() {
-				this.connections.swap_remove(i);
 				// We don't increment `i` in this branch, since we now
 				// have a shorter length, and potentially a new value at
 				// current index
+				this.connections.swap_remove(i);
 			} else {
 				i += 1;
 			}


### PR DESCRIPTION
An experiment of sorts that will run all incoming ws connections on a single task/thread. This has multiple advantages in that we don't incur synchronization costs or atomic ref counting, so things like the `Methods` or `Settings` don't have to be wrapped in `Arc`s (methods can be shared between connections) or use `Arc`s internally (lists of allowed origins / hosts).

If we really need to use all cores for handling RPC parsing (as opposed to spawning individual method calls on their own tokio tasks), the `ws-server` could start a thread pool and poll for incoming connections on each thread (`TcpListener::poll_accept` only needs `&self`, so we can cheaply share `Arc<TcpListener>` between threads), although that would incur some costs for keeping track of the number of open connections.