### PR TITLE
[jsonrpsee types]: unify a couple of types + more tests

### DIFF
--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -79,6 +79,5 @@ async fn proc_macros_generic_http_client_api() {
 
 	assert_eq!(Test::<String>::say_hello(&client).await.unwrap(), "hello".to_string());
 	assert_eq!(Test2::<u16, String>::foo(&client, 99_u16).await.unwrap(), "hello".to_string());
-	// TODO: https://github.com/paritytech/jsonrpsee/issues/212
-	//assert!(Registrar::register_para(&client, 99, "para").await.is_ok());
+	assert!(Registrar::register_para(&client, 99, "para").await.is_ok());
 }

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -333,7 +333,8 @@ mod test {
 		let ser =
 			serde_json::to_string(&JsonRpcSubscriptionParams { subscription: SubscriptionId::Num(12), result: "goal" })
 				.unwrap();
-		assert_eq!(ser, r#"{"subscription":12,"result":"goal"}"#);
+		let exp = r#"{"subscription":12,"result":"goal"}"#;
+		assert_eq!(ser, exp);
 	}
 
 	#[test]
@@ -341,7 +342,7 @@ mod test {
 		let ser = r#"{"subscription":"9","result":"offside"}"#;
 		assert!(
 			serde_json::from_str::<JsonRpcSubscriptionParams<()>>(ser).is_err(),
-			"invalid type should not be deser"
+			"invalid type should not be deserializable"
 		);
 		let dsr: JsonRpcSubscriptionParams<JsonValue> = serde_json::from_str(ser).unwrap();
 		assert_eq!(dsr.subscription, SubscriptionId::Str("9".into()));

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -31,14 +31,13 @@ pub struct JsonRpcInvalidRequest<'a> {
 /// JSON-RPC notification (a request object without a request ID).
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct JsonRpcNotification<'a> {
+pub struct JsonRpcNotification<'a, T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Name of the method to be invoked.
 	pub method: &'a str,
 	/// Parameter values of the request.
-	#[serde(borrow)]
-	pub params: Option<&'a RawValue>,
+	pub params: T,
 }
 
 /// Serializable [JSON-RPC object](https://www.jsonrpc.org/specification#request-object)
@@ -116,7 +115,7 @@ mod test {
 	#[test]
 	fn deserialize_valid_notif_works() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[]}"#;
-		let dsr: JsonRpcNotification = serde_json::from_str(ser).unwrap();
+		let dsr: JsonRpcNotification<&RawValue> = serde_json::from_str(ser).unwrap();
 		assert_eq!(dsr.method, "say_hello");
 		assert_eq!(dsr.jsonrpc, TwoPointZero);
 	}

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -1,4 +1,4 @@
-use crate::v2::params::{Id, JsonRpcNotificationParams, JsonRpcNotificationParamsAlloc, TwoPointZero};
+use crate::v2::params::{Id, TwoPointZero};
 use serde::{Deserialize, Serialize};
 
 /// JSON-RPC successful response object.
@@ -14,37 +14,24 @@ pub struct JsonRpcResponse<'a, T> {
 	pub id: Id<'a>,
 }
 
-/// JSON-RPC subscription response.
-#[derive(Serialize, Debug)]
-pub struct JsonRpcSubscriptionResponse<'a> {
-	/// JSON-RPC version.
-	pub jsonrpc: TwoPointZero,
-	/// Method
-	pub method: &'a str,
-	/// Params.
-	pub params: JsonRpcNotificationParams<'a>,
-}
+#[cfg(test)]
+mod tests {
+	use super::{Id, JsonRpcResponse, TwoPointZero};
 
-/// JSON-RPC subscription response.
-#[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-pub struct JsonRpcSubscriptionResponseAlloc<'a, T> {
-	/// JSON-RPC version.
-	pub jsonrpc: TwoPointZero,
-	/// Method
-	pub method: &'a str,
-	/// Params.
-	pub params: JsonRpcNotificationParamsAlloc<T>,
-}
+	#[test]
+	fn serialize_call_response() {
+		let ser =
+			serde_json::to_string(&JsonRpcResponse { jsonrpc: TwoPointZero, result: "ok", id: Id::Number(1) }).unwrap();
+		let exp = r#"{"jsonrpc":"2.0","result":"ok","id":1}"#;
+		assert_eq!(ser, exp);
+	}
 
-/// JSON-RPC notification response.
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(deny_unknown_fields)]
-pub struct JsonRpcNotifResponse<'a, T> {
-	/// JSON-RPC version.
-	pub jsonrpc: TwoPointZero,
-	/// Method
-	pub method: &'a str,
-	/// Params.
-	pub params: T,
+	#[test]
+	fn deserialize_call() {
+		let exp = JsonRpcResponse { jsonrpc: TwoPointZero, result: 99_u64, id: Id::Number(11) };
+		let dsr: JsonRpcResponse<u64> = serde_json::from_str(r#"{"jsonrpc":"2.0", "result":99, "id":11}"#).unwrap();
+		assert_eq!(dsr.jsonrpc, exp.jsonrpc);
+		assert_eq!(dsr.result, exp.result);
+		assert_eq!(dsr.id, exp.id);
+	}
 }


### PR DESCRIPTION
This PR adds some additional tests to close #276 (remaining is the ignored tests for `RpcParams` that are untyped but as long we provide `RpcParams::parse` for it, it should be fine)

Then I was annoyed of writing so much tests so I unified `JsonRpcNotifResponse and JsonRpcNotification` and `JsonRpcNotificationParamsAlloc and `JsonRpcNotificationParams`.

Thus, I replaced `RawValue` with `T` it will require allocations when deserializing but the benefit is that we don't have convert values to `RawValue` when sending stuff via the `SubscriptionSink`