### PR TITLE
[WIP]: support optional params in `RpcParams::parse`

### DIFF
--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -32,10 +32,15 @@ mod helpers;
 use helpers::{http_server, websocket_server, websocket_server_with_subscription};
 use jsonrpsee::{
 	http_client::{traits::Client, Error, HttpClientBuilder},
+	types::impl_param_not_optional,
 	ws_client::{traits::SubscriptionClient, v2::params::JsonRpcParams, JsonValue, Subscription, WsClientBuilder},
 };
 use std::sync::Arc;
 use std::time::Duration;
+
+struct Foo;
+
+impl_param_not_optional!(Foo);
 
 #[tokio::test]
 async fn ws_subscription_works() {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -35,14 +35,14 @@ pub use serde_json::{to_value as to_json_value, value::RawValue as JsonRawValue,
 #[macro_export]
 macro_rules! impl_param_not_optional {
 	($ty:ident) => {
-		impl crate::MaybeOptionalParams for $ty {
+		impl $crate::MaybeOptionalParams for $ty {
 			fn default() -> Option<$ty> {
 				None
 			}
 		}
 	};
 	($ty:ident < $( $N:ident),* >) => {
-		impl<$( $N ),*> crate::MaybeOptionalParams for $ty<$( $N ),*> {
+		impl<$( $N ),*> $crate::MaybeOptionalParams for $ty<$( $N ),*> {
 			fn default() -> Option<$ty<$( $N ),*>> {
 				None
 			}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -28,3 +28,36 @@ pub use client::*;
 pub use error::Error;
 pub use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json::{to_value as to_json_value, value::RawValue as JsonRawValue, Value as JsonValue};
+
+/// Macro for mark the type to not implement `MaybeOptionalParams`
+/// Ideally, this should only be implemented for `Option<T>`
+/// but mutually exclusive trait bounds is not a thing.
+#[macro_export]
+macro_rules! impl_param_not_optional {
+	($ty:ident) => {
+		impl crate::MaybeOptionalParams for $ty {
+			fn default() -> Option<$ty> {
+				None
+			}
+		}
+	};
+	($ty:ident < $( $N:ident),* >) => {
+		impl<$( $N ),*> crate::MaybeOptionalParams for $ty<$( $N ),*> {
+			fn default() -> Option<$ty<$( $N ),*>> {
+				None
+			}
+		}
+	};
+}
+
+use alloc::collections::*;
+
+impl_param_not_optional!(String);
+impl_param_not_optional!(Vec<T>);
+impl_param_not_optional!(BTreeMap<K, V>);
+impl_param_not_optional!(bool);
+impl_param_not_optional!(u8);
+impl_param_not_optional!(u16);
+impl_param_not_optional!(u32);
+impl_param_not_optional!(u64);
+impl_param_not_optional!(JsonValue);

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -5,6 +5,9 @@
 
 extern crate alloc;
 
+#[doc(hidden)]
+pub use v2::params::MaybeOptionalParams;
+
 /// Ten megabytes.
 pub const TEN_MB_SIZE_BYTES: u32 = 10 * 1024 * 1024;
 

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -434,4 +434,12 @@ mod test {
 		let dsr: ParamsFive<String, Option<String>, Option<String>, String, Option<String>> =
 			serde_json::from_str(ser).unwrap();
 	}
+
+	#[test]
+	fn show_edge_case() {
+		let ser = r#"["foo", "bar"]"#;
+		// NOTE(niklasad1): this won't work as the second already been "visited".
+		let dsr: ParamsFive<String, Option<String>, Option<String>, String, Option<String>> =
+			serde_json::from_str(ser).unwrap();
+	}
 }

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -70,20 +70,20 @@ impl Serialize for TwoPointZero {
 }
 /// Parsed params.
 #[derive(Debug)]
-pub struct ParamsOne<A>(A);
+pub struct ParamsOne<A>(pub A);
 /// Parsed params.
 #[derive(Debug)]
-pub struct ParamsTwo<A, B>((A, B));
+pub struct ParamsTwo<A, B>(pub (A, B));
 /// Parsed params.
 #[derive(Debug)]
-pub struct ParamsThree<A, B, C>((A, B, C));
+pub struct ParamsThree<A, B, C>(pub (A, B, C));
 /// Parsed params.
 #[derive(Debug)]
 /// Parsed params.
-pub struct ParamsFour<A, B, C, D>((A, B, C, D));
+pub struct ParamsFour<A, B, C, D>(pub (A, B, C, D));
 #[derive(Debug)]
 /// Parsed params.
-pub struct ParamsFive<A, B, C, D, E>((A, B, C, D, E));
+pub struct ParamsFive<A, B, C, D, E>(pub (A, B, C, D, E));
 
 /// Marker trait to indicate that the type is optional then if it's missing just provide a default value.
 pub trait MaybeOptionalParams: Sized {

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -97,37 +97,6 @@ impl<T> MaybeOptionalParams for Option<T> {
 	}
 }
 
-/// Macro for mark the type to not implement `MaybeOptionalParams`
-/// Ideally, this should only be implemented for `Option<T>`
-/// but mutally exclusive trait bounds is not a thing.
-#[macro_export]
-macro_rules! impl_param_not_optional {
-	($ty:ident) => {
-		impl MaybeOptionalParams for $ty {
-			fn default() -> Option<$ty> {
-				None
-			}
-		}
-	};
-	($ty:ident < $( $N:ident),* >) => {
-		impl<$( $N ),*> MaybeOptionalParams for $ty<$( $N ),*> {
-			fn default() -> Option<$ty<$( $N ),*>> {
-				None
-			}
-		}
-	};
-}
-
-impl_param_not_optional!(String);
-impl_param_not_optional!(Vec<T>);
-impl_param_not_optional!(BTreeMap<K, V>);
-impl_param_not_optional!(bool);
-impl_param_not_optional!(u8);
-impl_param_not_optional!(u16);
-impl_param_not_optional!(u32);
-impl_param_not_optional!(u64);
-impl_param_not_optional!(JsonValue);
-
 macro_rules! impl_serde_replace_missing_optional_params {
 	// NOTE(niklasad1): this doesn't work for lifetimes
 	($ty:ident < $( $N:ident $(: $b0:ident $(+$b:ident)* )? ),* >) => {


### PR DESCRIPTION
Rough draft in order to close https://github.com/paritytech/jsonrpsee/issues/380

I had some issues with the conflicting `serde impls` for implementing it directly on the "tuples" such that I had to introduce `new type pattern` for ParamsOne, .. ParamsFive instead of tuples.

Thus, a bit clunky for users to use `ParamsOne` then to access the inner tuple however it seems to work except an edge case when you entered a list ["x", "y"] then if you expect [String, Option<String>, String] it won't work because the second parameter will still be parsed as `Option<String>` but that should acceptable I think.

Also, for custom types it's awkward for users to implement the trait `MaybeOptionalParams` for their types.

//cc @maciejhirsz 