### PR TITLE
[ci]: test each individual crate's manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
-          args: --manifest-path utils/Cargo.toml
+          args: --manifest-path proc-macros/Cargo.toml
 
       - name: Cargo check test utils
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name:                      Rust Cache
         uses:                      Swatinem/rust-cache@v1.3.0
 
-      - name: Cargo check all targets
+      - name: Cargo check all targets (use Cargo.toml in workspace)
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
@@ -73,6 +73,42 @@ jobs:
         with:
           command: check
           args: --manifest-path http-client/Cargo.toml --no-default-features --features tokio02
+
+      - name: Cargo check HTTP client
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path http-client/Cargo.toml
+
+      - name: Cargo check WS client
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path ws-client/Cargo.toml
+
+      - name: Cargo check WS client with tokio02
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path ws-client/Cargo.toml --no-default-features --features tokio02
+
+      - name: Cargo check types
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path types/Cargo.toml
+
+      - name: Cargo check utils
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path utils/Cargo.toml
+
+      - name: Cargo check proc macros
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path utils/Cargo.toml
 
   tests:
     name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,77 @@ jobs:
           command: check
           args: --manifest-path utils/Cargo.toml
 
+      - name: Cargo check test utils
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path test-utils/Cargo.toml
+
+      - name: Cargo check examples
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path examples/Cargo.toml
+
   tests:
-    name: Run tests
+    name: Run tests Ubuntu
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name:                      Rust Cache
+        uses:                      Swatinem/rust-cache@v1.3.0
+
+      - name: Cargo build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --workspace
+
+      - name: Cargo test
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+
+  tests_macos:
+    name: Run tests macos
+    runs-on: macos-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name:                      Rust Cache
+        uses:                      Swatinem/rust-cache@v1.3.0
+
+      - name: Cargo build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --workspace
+
+      - name: Cargo test
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+
+  tests_windows:
+    name: Run tests Windows
+    runs-on: windows-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,12 @@ jobs:
           command: check
           args: --manifest-path http-client/Cargo.toml
 
+      - name: Cargo check HTTP server
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path http-server/Cargo.toml
+
       - name: Cargo check WS client
         uses: actions-rs/cargo@v1.0.3
         with:
@@ -91,6 +97,12 @@ jobs:
         with:
           command: check
           args: --manifest-path ws-client/Cargo.toml --no-default-features --features tokio02
+
+      - name: Cargo check WS server
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --manifest-path ws-server/Cargo.toml
 
       - name: Cargo check types
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
           override: true
           components: clippy, rustfmt
 
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.3.0
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
 
       - name: Cargo fmt
         uses: actions-rs/cargo@v1.0.3
@@ -59,8 +59,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.3.0
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
 
       - name: Cargo check all targets (use Cargo.toml in workspace)
         uses: actions-rs/cargo@v1.0.3
@@ -148,8 +148,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.3.0
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
 
       - name: Cargo build
         uses: actions-rs/cargo@v1.0.3
@@ -176,8 +176,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.3.0
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
 
       - name: Cargo build
         uses: actions-rs/cargo@v1.0.3
@@ -204,8 +204,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.3.0
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
 
       - name: Cargo build
         uses: actions-rs/cargo@v1.0.3

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 [dependencies]
 thiserror = "1"
 futures-channel = "0.3.14"
-futures-util = { version = "0.3.14", default-features = false, features = ["io"] }
+futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
 jsonrpsee-types = { path = "../types", version = "0.2.0" }
 jsonrpsee-utils = { path = "../utils", version = "0.2.0", features = ["server"] }
 log = "0.4"

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -171,8 +171,12 @@ async fn can_set_max_connections() {
 	assert!(conn2.is_ok());
 	// Third connection is rejected
 	assert!(conn3.is_err());
-	let err = conn3.unwrap_err();
-	assert!(err.to_string().contains("WebSocketHandshake failed"));
+
+	let err = match conn3 {
+		Err(soketto::handshake::Error::Io(err)) => err,
+		_ => panic!("Invalid error kind; expected std::io::Error"),
+	};
+	assert_eq!(err.kind(), std::io::ErrorKind::ConnectionReset);
 
 	// Decrement connection count
 	drop(conn2);

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -173,8 +173,6 @@ async fn can_set_max_connections() {
 	assert!(conn3.is_err());
 	let err = conn3.unwrap_err();
 	assert!(err.to_string().contains("WebSocketHandshake failed"));
-	assert!(err.to_string().contains("Connection reset by peer"), "got: {}", err);
-	// Err(Io(Os { code: 54, kind: ConnectionReset, message: \"Connection reset by peer\" }))");
 
 	// Decrement connection count
 	drop(conn2);

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -173,7 +173,7 @@ async fn can_set_max_connections() {
 	assert!(conn3.is_err());
 	let err = conn3.unwrap_err();
 	assert!(err.to_string().contains("WebSocketHandshake failed"));
-	assert!(err.to_string().contains("Connection reset by peer"));
+	assert!(err.to_string().contains("Connection reset by peer"), "got: {}", err);
 	// Err(Io(Os { code: 54, kind: ConnectionReset, message: \"Connection reset by peer\" }))");
 
 	// Decrement connection count


### PR DESCRIPTION
We have been bitten by that the CI just checks all crates compiles in the workspace (shares Cargo.lock) and features.

Thus, if a feature for an individual is not enabled for specific crate then this is not detected by CI so this PR changes that each crate using its manifest instead.

In addition:
- Fixes the `ws-server` to compile outside the workspace
- Added to run CI on macos and Windows.