### PR TITLE
WIP: [rpc errors]: user customized error codes

### DIFF
--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use crate::v2::error::JsonRpcErrorObjectOwned;
+
 /// Convenience type for displaying errors.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Mismatch<T> {
@@ -24,7 +26,7 @@ pub enum CallError {
 	InvalidParams,
 	#[error("RPC Call failed: {0}")]
 	/// The call failed.
-	Failed(#[source] Box<dyn std::error::Error + Send + Sync>),
+	Failed(JsonRpcErrorObjectOwned),
 }
 
 /// Error type.


### PR DESCRIPTION
The motivation behind this change is that we need to provide functionality for users to configure their own error messages; that means `error code`, `error message` and `data`, https://www.jsonrpc.org/specification#error-object

Another solution in a more generic way is to have a marker trait such as:


```rust

/// Marker trait
trait JsonRpcErrorT: Send + Sync + std::error::Error + JsonRpcErrorObjectT;

impl<T: Send + Sync + std::error::Error + JsonRpcErrorObject> for T {}

/// JSON-RPC error object trait
trait JsonRpcErrorObjectT {
   fn code(&self) -> i32;
   fn message(&self) -> &str;
   fn data(&self) -> &Option<RawValue>;
}

enum CallError {
   InvalidParams,
   Failed(Box<dyn JsonRpcErrorT>))
}
```

but I had some issues getting it to work for `anyhow::Error` however it might possible to avoid the introduced allocations in this PR.


