### PR TITLE
Pass OwnedRpcParams to async methods

### DIFF
--- a/proc-macros/src/new/render_server.rs
+++ b/proc-macros/src/new/render_server.rs
@@ -61,9 +61,7 @@ impl RpcDescription {
 			if method.signature.sig.asyncness.is_some() {
 				quote! {
 					rpc.register_async_method(#rpc_method_name, |params, context| {
-						let owned_params = params.owned();
 						let fut = async move {
-							let params = owned_params.borrowed();
 							#parsing
 							Ok(context.as_ref().#rust_method_name(#params_seq).await)
 						};

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -307,7 +307,13 @@ mod test {
 	fn id_deserialization() {
 		let s = r#""2""#;
 		let deserialized: Id = serde_json::from_str(s).unwrap();
-		assert_eq!(deserialized, Id::Str("2".into()));
+		match deserialized {
+			Id::Str(ref cow) => {
+				assert!(cow.is_borrowed());
+				assert_eq!(cow, "2");
+			}
+			_ => panic!("Expected Id::Str"),
+		}
 
 		let s = r#"2"#;
 		let deserialized: Id = serde_json::from_str(s).unwrap();

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -284,38 +284,15 @@ impl<'a> Id<'a> {
 			_ => None,
 		}
 	}
-}
 
-/// Owned version of [`Id`] that allocates memory for the `Str` variant.
-#[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-#[serde(untagged)]
-pub enum OwnedId {
-	/// Null
-	Null,
-	/// Numeric id
-	Number(u64),
-	/// String id
-	Str(String),
-}
-
-impl OwnedId {
-	/// Converts `OwnedId` into borrowed `Id`.
-	pub fn borrowed(&self) -> Id<'_> {
+	/// Convert `Id<'a>` to `Id<'static>` so that it can be moved across threads.
+	///
+	/// This can cause an allocation if the id is a string.
+	pub fn into_owned(self) -> Id<'static> {
 		match self {
-			Self::Null => Id::Null,
-			Self::Number(num) => Id::Number(*num),
-			Self::Str(str) => Id::Str(Cow::borrowed(str)),
-		}
-	}
-}
-
-impl<'a> From<Id<'a>> for OwnedId {
-	fn from(borrowed: Id<'a>) -> Self {
-		match borrowed {
-			Id::Null => Self::Null,
-			Id::Number(num) => Self::Number(num),
-			Id::Str(num) => Self::Str(num.as_ref().to_owned()),
+			Id::Null => Id::Null,
+			Id::Number(num) => Id::Number(num),
+			Id::Str(s) => Id::Str(Cow::owned(s.into_owned())),
 		}
 	}
 }

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -60,8 +60,9 @@ impl Serialize for TwoPointZero {
 
 /// Parameters sent with the RPC request.
 ///
-/// The data containing the params is a `Cow<&str>` and can either be a borrowed `&str` of JSON from an incoming [`JsonRpcRequest`] (which in
-/// turn borrows it from the input buffer that is shared between requests); or, it can be an owned `String`.
+/// The data containing the params is a `Cow<&str>` and can either be a borrowed `&str` of JSON from an incoming
+/// [`super::request::JsonRpcRequest`] (which in turn borrows it from the input buffer that is shared between requests);
+/// or, it can be an owned `String`.
 #[derive(Clone, Debug)]
 pub struct RpcParams<'a>(Option<Cow<'a, str>>);
 

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -68,10 +68,7 @@ pub struct RpcParams<'a> {
 impl<'a> RpcParams<'a> {
 	/// Create params
 	pub fn new(json: Option<&'a str>) -> Self {
-		Self {
-			json: json.map(Into::into),
-			offset: 0,
-		}
+		Self { json: json.map(Into::into), offset: 0 }
 	}
 
 	fn next_inner<'temp, T>(&'temp mut self) -> Option<Result<T, CallError>>
@@ -106,9 +103,7 @@ impl<'a> RpcParams<'a> {
 
 				Some(Ok(value))
 			}
-			Err(_) => {
-				Some(Err(CallError::InvalidParams))
-			}
+			Err(_) => Some(Err(CallError::InvalidParams)),
 		}
 	}
 
@@ -181,13 +176,10 @@ impl<'a> RpcParams<'a> {
 	}
 
 	/// Convert `RpcParams<'a>` to `RpcParams<'static>` so that it can be moved across threads.
-    ///
+	///
 	/// This will cause an allocation if the params internally are using a borrowed JSON slice.
 	pub fn into_owned(self) -> RpcParams<'static> {
-		RpcParams {
-			json: self.json.map(|s| Cow::owned(s.into_owned())),
-			offset: self.offset,
-		}
+		RpcParams { json: self.json.map(|s| Cow::owned(s.into_owned())), offset: self.offset }
 	}
 }
 

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -215,7 +215,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 	pub fn register_async_method<R, F>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
 	where
 		R: Serialize + Send + Sync + 'static,
-		F: Fn(RpcParams, Arc<Context>) -> BoxFuture<'static, Result<R, CallError>> + Copy + Send + Sync + 'static,
+		F: Fn(OwnedRpcParams, Arc<Context>) -> BoxFuture<'static, Result<R, CallError>> + Copy + Send + Sync + 'static,
 	{
 		self.methods.verify_method_name(method_name)?;
 
@@ -226,7 +226,6 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 			MethodCallback::Async(Arc::new(move |id, params, tx, _| {
 				let ctx = ctx.clone();
 				let future = async move {
-					let params = params.borrowed();
 					let id = id.borrowed();
 					match callback(params, ctx).await {
 						Ok(res) => send_response(id, &tx, res),

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -271,8 +271,8 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 	/// use jsonrpsee_utils::server::rpc_module::RpcModule;
 	///
 	/// let mut ctx = RpcModule::new(99_usize);
-	/// ctx.register_subscription("sub", "unsub", |mut params, mut sink, ctx| {
-	///     let x: usize = params.next()?;
+	/// ctx.register_subscription("sub", "unsub", |params, mut sink, ctx| {
+	///     let x: usize = params.one()?;
 	///     std::thread::spawn(move || {
 	///         let sum = x + (*ctx);
 	///         sink.send(&sum)

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -5,10 +5,7 @@ use futures_util::FutureExt;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient};
 use jsonrpsee_test_utils::TimeoutFutureExt;
-use jsonrpsee_types::{
-	error::{CallError, Error},
-	v2::params::RpcParams,
-};
+use jsonrpsee_types::error::{CallError, Error};
 use serde_json::Value as JsonValue;
 use std::fmt;
 use std::net::SocketAddr;
@@ -25,13 +22,15 @@ impl fmt::Display for MyAppError {
 impl std::error::Error for MyAppError {}
 
 /// Spawns a dummy `JSONRPC v2 WebSocket`
-/// It has two hardcoded methods: "say_hello" and "add"
 async fn server() -> SocketAddr {
 	server_with_handles().await.0
 }
 
 /// Spawns a dummy `JSONRPC v2 WebSocket`
-/// It has two hardcoded methods: "say_hello" and "add"
+/// It has the following methods:
+/// 	sync methods: `say_hello` and `add`
+///		async: `say_hello_async` and `add_sync`
+/// 	other: `invalid_params` (always returns `CallError::InvalidParams`), `call_fail` (always returns `CallError::Failed`), `sleep_for`
 /// Returns the address together with handles for server future and server stop.
 async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 	let mut server = WsServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
@@ -43,7 +42,14 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 		})
 		.unwrap();
 	module
-		.register_async_method("say_hello_async", |_: RpcParams, _| {
+		.register_method("add", |params, _| {
+			let params: Vec<u64> = params.parse()?;
+			let sum: u64 = params.into_iter().sum();
+			Ok(sum)
+		})
+		.unwrap();
+	module
+		.register_async_method("say_hello_async", |_, _| {
 			async move {
 				log::debug!("server respond to hello");
 				// Call some async function inside.
@@ -53,13 +59,13 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 			.boxed()
 		})
 		.unwrap();
-	module
-		.register_method("add", |params, _| {
+	module.register_async_method("add_async", |params, _| {
+		async move {
 			let params: Vec<u64> = params.parse()?;
 			let sum: u64 = params.into_iter().sum();
 			Ok(sum)
-		})
-		.unwrap();
+		}.boxed()
+	}).unwrap();
 	module.register_method("invalid_params", |_params, _| Err::<(), _>(CallError::InvalidParams)).unwrap();
 	module.register_method("call_fail", |_params, _| Err::<(), _>(CallError::Failed(Box::new(MyAppError)))).unwrap();
 	module
@@ -308,6 +314,16 @@ async fn async_method_call_with_ok_context() {
 	let req = r#"{"jsonrpc":"2.0","method":"should_ok_async", "params":[],"id":1}"#;
 	let response = client.send_request_text(req).await.unwrap();
 	assert_eq!(response, ok_response("ok!".into(), Id::Num(1)));
+}
+
+#[tokio::test]
+async fn async_method_call_with_params() {
+	let addr = server().await;
+	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+
+	let req = r#"{"jsonrpc":"2.0","method":"add_async", "params":[1, 2],"id":1}"#;
+	let response = client.send_request_text(req).await.unwrap();
+	assert_eq!(response, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
 }
 
 #[tokio::test]

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -59,13 +59,16 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 			.boxed()
 		})
 		.unwrap();
-	module.register_async_method("add_async", |params, _| {
-		async move {
-			let params: Vec<u64> = params.parse()?;
-			let sum: u64 = params.into_iter().sum();
-			Ok(sum)
-		}.boxed()
-	}).unwrap();
+	module
+		.register_async_method("add_async", |params, _| {
+			async move {
+				let params: Vec<u64> = params.parse()?;
+				let sum: u64 = params.into_iter().sum();
+				Ok(sum)
+			}
+			.boxed()
+		})
+		.unwrap();
 	module.register_method("invalid_params", |_params, _| Err::<(), _>(CallError::InvalidParams)).unwrap();
 	module.register_method("call_fail", |_params, _| Err::<(), _>(CallError::Failed(Box::new(MyAppError)))).unwrap();
 	module


### PR DESCRIPTION
Pass `OwnedRpcParams` to async methods to allow deserializing to happen asynchronously as well.

Closes #408﻿
