### PR TITLE
Fix type paths for client macros

### DIFF
--- a/proc-macros/src/client_builder.rs
+++ b/proc-macros/src/client_builder.rs
@@ -122,11 +122,11 @@ fn build_client_functions(api: &crate::api_def::ApiDefinition) -> Result<Vec<pro
 			params_to_json.push(quote_spanned!(pat_span=>
 				map.insert(
 					#rpc_param_name,
-					#_crate::to_json_value(#generated_param_name.into()).map_err(#_crate::types::Error::ParseError)?
+					#_crate::types::to_json_value(#generated_param_name.into()).map_err(#_crate::types::Error::ParseError)?
 				);
 			));
 			params_to_array.push(quote_spanned!(pat_span=>
-				#_crate::to_json_value(#generated_param_name.into()).map_err(#_crate::types::Error::ParseError)?
+				#_crate::types::to_json_value(#generated_param_name.into()).map_err(#_crate::types::Error::ParseError)?
 			));
 		}
 

--- a/proc-macros/src/client_builder.rs
+++ b/proc-macros/src/client_builder.rs
@@ -122,11 +122,11 @@ fn build_client_functions(api: &crate::api_def::ApiDefinition) -> Result<Vec<pro
 			params_to_json.push(quote_spanned!(pat_span=>
 				map.insert(
 					#rpc_param_name,
-					#_crate::to_json_value(#generated_param_name.into()).map_err(#_crate::Error::ParseError)?
+					#_crate::to_json_value(#generated_param_name.into()).map_err(#_crate::types::Error::ParseError)?
 				);
 			));
 			params_to_array.push(quote_spanned!(pat_span=>
-				#_crate::to_json_value(#generated_param_name.into()).map_err(#_crate::Error::ParseError)?
+				#_crate::to_json_value(#generated_param_name.into()).map_err(#_crate::types::Error::ParseError)?
 			));
 		}
 
@@ -156,10 +156,10 @@ fn build_client_functions(api: &crate::api_def::ApiDefinition) -> Result<Vec<pro
 		};
 
 		client_functions.push(quote_spanned!(function.signature.span()=>
-			#visibility async fn #f_name (client: &impl #_crate::types::traits::Client #(, #params_list)*) -> core::result::Result<#ret_ty, #_crate::Error>
+			#visibility async fn #f_name (client: &impl #_crate::types::traits::Client #(, #params_list)*) -> core::result::Result<#ret_ty, #_crate::types::Error>
 			where
-				#ret_ty: #_crate::DeserializeOwned
-				#(, #params_tys: #_crate::Serialize)*
+				#ret_ty: #_crate::types::DeserializeOwned
+				#(, #params_tys: #_crate::types::Serialize)*
 			{
 				#function_body
 			}

--- a/proc-macros/src/client_builder.rs
+++ b/proc-macros/src/client_builder.rs
@@ -131,7 +131,7 @@ fn build_client_functions(api: &crate::api_def::ApiDefinition) -> Result<Vec<pro
 		}
 
 		let params_building = if params_list.is_empty() {
-			quote_spanned!(function.signature.span()=> #_crate::v2::params::JsonRpcParams::NoParams)
+			quote_spanned!(function.signature.span()=> #_crate::types::v2::params::JsonRpcParams::NoParams)
 		} else if function.attributes.positional_params {
 			quote_spanned!(function.signature.span()=> vec![#(#params_to_array),*].into())
 		} else {
@@ -156,7 +156,7 @@ fn build_client_functions(api: &crate::api_def::ApiDefinition) -> Result<Vec<pro
 		};
 
 		client_functions.push(quote_spanned!(function.signature.span()=>
-			#visibility async fn #f_name (client: &impl #_crate::traits::Client #(, #params_list)*) -> core::result::Result<#ret_ty, #_crate::Error>
+			#visibility async fn #f_name (client: &impl #_crate::types::traits::Client #(, #params_list)*) -> core::result::Result<#ret_ty, #_crate::Error>
 			where
 				#ret_ty: #_crate::DeserializeOwned
 				#(, #params_tys: #_crate::Serialize)*


### PR DESCRIPTION
After #409 the client macros broke because of the new type paths.
