### PR TITLE
Only return the crate name when the crate is `jsonrpsee` as well

### DIFF
--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -41,7 +41,7 @@ fn find_jsonrpsee_crate(http_name: &str, ws_name: &str) -> Result<proc_macro2::T
 	match crate_name("jsonrpsee") {
 		Ok(FoundCrate::Name(name)) => {
 			let ident = syn::Ident::new(&name, Span::call_site());
-			Ok(quote!(#ident::types))
+			Ok(quote!(#ident))
 		}
 		Ok(FoundCrate::Itself) => panic!("Deriving RPC methods in any of the `jsonrpsee crates` is not supported"),
 		Err(_) => match (crate_name(http_name), crate_name(ws_name)) {


### PR DESCRIPTION
I missed one place where "types" was added to the crate name instead of when the types are actually used. Only pops up when the crate name searched for is "jsonrpsee".﻿
