### PR TITLE
Prepare v0.3.0

### DIFF
--- a/.scripts/publish.sh
+++ b/.scripts/publish.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # This script is copied from `https://github.com/paritytech/jsonrpc` with some minor tweaks.
+# Add `--dry-run` and/or `--allow-dirty` to your command line to test things before publication.
 
 set -eu
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog].
 
 ## [v0.3.0] – 2021-07-12
 
+[changed] Module API refactor [#412](https://github.com/paritytech/jsonrpsee/pull/412)
+
 [changed] Pass owned `RpcParams` to async methods [#410](https://github.com/paritytech/jsonrpsee/pull/410)
 
 [changed] Re-work re-exported types for clarity and consistency [#409](https://github.com/paritytech/jsonrpsee/pull/409)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [v0.3.0] – 2021-07-12
+
+[changed] Pass owned `RpcParams` to async methods [#410](https://github.com/paritytech/jsonrpsee/pull/410)
+
+[changed] Re-work re-exported types for clarity and consistency [#409](https://github.com/paritytech/jsonrpsee/pull/409)
+
+[changed] All requests time out [#406](https://github.com/paritytech/jsonrpsee/pull/406)
+
+[changed] Streaming `RpcParams` parsing for optional arguments [#401](https://github.com/paritytech/jsonrpsee/pull/401)
+
+[changed] Set allowed Host header values [#399](https://github.com/paritytech/jsonrpsee/pull/399)
+
+[changed] Terminate already established ws connection(s) when the server is stopped [#396](https://github.com/paritytech/jsonrpsee/pull/396)
+
+[added] Customizable JSON-RPC error codes via new enum variant on `CallErrror` [#394](https://github.com/paritytech/jsonrpsee/pull/394)
+
+[changed] Unify a few types and more tests [#389](https://github.com/paritytech/jsonrpsee/pull/389)
+
+[changed] Synchronization-less async connections in ws-server [#388](https://github.com/paritytech/jsonrpsee/pull/388)
+
+[added] Server proc macros [#387](https://github.com/paritytech/jsonrpsee/pull/387)
+
+[added] Add a way to stop servers [#386](https://github.com/paritytech/jsonrpsee/pull/386)
+
+[changed] Refactor benchmarks to use Criterion's async bencher [#385]https://github.com/paritytech/jsonrpsee/pull/385)
+
+[added] Support RPC method aliases and make `RpcModule` be `Clone` [#383]https://github.com/paritytech/jsonrpsee/pull/383)
+
+[added] CORS support and use `soketto` v0.6 [#375](https://github.com/paritytech/jsonrpsee/pull/375)
+
+[changed] Ws switch from sending TEXT instead of BINARY [#374](https://github.com/paritytech/jsonrpsee/pull/374)
+
+[added] Benchmarks for async methods and subscriptions [#372](https://github.com/paritytech/jsonrpsee/pull/372)
+
+
 ## [v0.2.0] – 2021-06-04
 
 [changed] The crate structure changed to several smaller crates, enabling users to pick and choose. The `jsonrpsee` crate works as a façade crate for users to pick&chose what components they wish to use.

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -1,0 +1,8 @@
+# How to release `jsonrpsee`
+
+1. Bump the version of all crates
+1. Run all tests
+1. In the `CHANGELOG.md` file, move everything under "Unreleased" to a new section named `## [vx.y.z] – YYYY-MM-DD`
+1. Make a dryrun like so:
+	1. Ensure you're in the project root dir
+	1. Run: `./scripts/publish.sh --dry-run --allow-dirty`

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-benchmarks"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Benchmarks for jsonrpsee"
 edition = "2018"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-examples"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Examples for jsonrpsee"
 edition = "2018"

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-http-client"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "HTTP client for JSON-RPC"
 edition = "2018"
@@ -16,8 +16,8 @@ hyper13-rustls = { package = "hyper-rustls", version = "0.21", optional = true }
 hyper14-rustls = { package = "hyper-rustls", version = "0.22", optional = true }
 hyper14 = { package = "hyper", version = "0.14", features = ["client", "http1", "http2", "tcp"], optional = true }
 hyper13 = { package = "hyper", version = "0.13", optional = true }
-jsonrpsee-types = { path = "../types", version = "0.2.0" }
-jsonrpsee-utils = { path = "../utils", version = "0.2.0", optional = true }
+jsonrpsee-types = { path = "../types", version = "0.3.0" }
+jsonrpsee-utils = { path = "../utils", version = "0.3.0", optional = true }
 log = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-http-server"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "HTTP server for JSON-RPC"
 edition = "2018"
@@ -14,8 +14,8 @@ thiserror = "1"
 hyper = { version = "0.14", features = ["server", "http1", "http2", "tcp"] }
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false }
-jsonrpsee-types = { path = "../types", version = "0.2.0" }
-jsonrpsee-utils = { path = "../utils", version = "0.2.0", features = ["server", "hyper_14"] }
+jsonrpsee-types = { path = "../types", version = "0.3.0" }
+jsonrpsee-utils = { path = "../utils", version = "0.3.0", features = ["server", "hyper_14"] }
 globset = "0.4"
 lazy_static = "1.4"
 log = "0.4"

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpsee"
 description = "JSON-RPC crate"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT"
 edition = "2018"
@@ -10,13 +10,13 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee"
 
 [dependencies]
-http-client = { path = "../http-client", version = "0.2.0", package = "jsonrpsee-http-client", optional = true }
-http-server = { path = "../http-server", version = "0.2.0", package = "jsonrpsee-http-server", optional = true }
-ws-client = { path = "../ws-client", version = "0.2.0", package = "jsonrpsee-ws-client", optional = true }
-ws-server = { path = "../ws-server", version = "0.2.0", package = "jsonrpsee-ws-server", optional = true }
-proc-macros = { path = "../proc-macros", version = "0.2.0", package = "jsonrpsee-proc-macros", optional = true }
-utils = { path = "../utils", version = "0.2.0", package = "jsonrpsee-utils", optional = true }
-types = { path = "../types", version = "0.2.0", package = "jsonrpsee-types", optional = true }
+http-client = { path = "../http-client", version = "0.3.0", package = "jsonrpsee-http-client", optional = true }
+http-server = { path = "../http-server", version = "0.3.0", package = "jsonrpsee-http-server", optional = true }
+ws-client = { path = "../ws-client", version = "0.3.0", package = "jsonrpsee-ws-client", optional = true }
+ws-server = { path = "../ws-server", version = "0.3.0", package = "jsonrpsee-ws-server", optional = true }
+proc-macros = { path = "../proc-macros", version = "0.3.0", package = "jsonrpsee-proc-macros", optional = true }
+utils = { path = "../utils", version = "0.3.0", package = "jsonrpsee-utils", optional = true }
+types = { path = "../types", version = "0.3.0", package = "jsonrpsee-types", optional = true }
 
 [features]
 client = ["http-client", "ws-client", "types"]

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpsee-proc-macros"
 description = "Procedueral macros for jsonrpsee"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-test-utils"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 edition = "2018"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-integration-tests"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Integration tests for jsonrpsee"
 edition = "2018"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-types"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Shared types for jsonrpsee"
 edition = "2018"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-utils"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utilities for jsonrpsee"
 edition = "2018"
@@ -12,7 +12,7 @@ futures-channel = { version = "0.3.14", default-features = false, optional = tru
 futures-util = { version = "0.3.14", default-features = false, optional = true }
 hyper13 = { package = "hyper", version = "0.13", default-features = false, features = ["stream"], optional = true }
 hyper14 = { package = "hyper", version = "0.14", default-features = false, features = ["stream"], optional = true }
-jsonrpsee-types = { path = "../types", version = "0.2.0", optional = true }
+jsonrpsee-types = { path = "../types", version = "0.3.0", optional = true }
 log = { version = "0.4", optional = true }
 rustc-hash = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-ws-client"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "WebSocket client for JSON-RPC"
 edition = "2018"
@@ -23,7 +23,7 @@ tokioV02-util = { package="tokio-util", version = "0.3", features = ["compat"], 
 async-trait = "0.1"
 fnv = "1"
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
-jsonrpsee-types = { path = "../types", version = "0.2.0" }
+jsonrpsee-types = { path = "../types", version = "0.3.0" }
 log = "0.4"
 serde = "1"
 serde_json = "1"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-ws-server"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "WebSocket server for JSON-RPC"
 edition = "2018"
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 thiserror = "1"
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
-jsonrpsee-types = { path = "../types", version = "0.2.0" }
-jsonrpsee-utils = { path = "../utils", version = "0.2.0", features = ["server"] }
+jsonrpsee-types = { path = "../types", version = "0.3.0" }
+jsonrpsee-utils = { path = "../utils", version = "0.3.0", features = ["server"] }
 log = "0.4"
 rustc-hash = "1.1.0"
 serde = { version = "1", default-features = false, features = ["derive"] }


### PR DESCRIPTION
- Bump versions to 0.3.0
- Add draft release checklist
- Changelog for v0.3.0
- Mention possibility of passing params to `publish.sh`
