### PR TITLE
Sniff the first byte to glean if the incoming request is a single or batch request

### DIFF
--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -217,9 +217,9 @@ impl Server {
 						let mut single = true;
 						// TODO: Cut down on some noise. Is this a terrible idea?
 						type Notif<'a> = JsonRpcNotification<'a, Option<&'a RawValue>>;
-						match body[0] {
+						match body.get(0) {
 							// Single request or notification
-							b'{' => {
+							Some(b'{') => {
 								if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&body) {
 									// NOTE: we don't need to track connection id on HTTP, so using hardcoded 0 here.
 									methods.execute(&tx, req, 0).await;
@@ -231,7 +231,7 @@ impl Server {
 								}
 							}
 							// Bacth of requests or notifications
-							b'[' => {
+							Some(b'[') => {
 								if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&body) {
 									if !batch.is_empty() {
 										single = false;

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -215,7 +215,6 @@ impl Server {
 						let (tx, mut rx) = mpsc::unbounded::<String>();
 						// Is this a single request or a batch (or error)?
 						let mut single = true;
-						// TODO: Cut down on some noise. Is this a terrible idea?
 						type Notif<'a> = JsonRpcNotification<'a, Option<&'a RawValue>>;
 						match body.get(0) {
 							// Single request or notification

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -41,7 +41,7 @@ pub fn send_error(id: Id, tx: &MethodSink, error: JsonRpcErrorObject) {
 
 /// Figure out if this is a sufficiently complete request that we can extract an [`Id`] out of, or just plain
 /// unparseable garbage.
-pub fn prepare_error<'a>(data: &'a Vec<u8>) -> (Id<'a>, JsonRpcErrorCode) {
+pub fn prepare_error(data: &[u8]) -> (Id<'_>, JsonRpcErrorCode) {
 	match serde_json::from_slice::<JsonRpcInvalidRequest>(&data) {
 		Ok(JsonRpcInvalidRequest { id }) => (id, JsonRpcErrorCode::InvalidRequest),
 		Err(_) => (Id::Null, JsonRpcErrorCode::ParseError),

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -3,8 +3,8 @@ use futures_channel::mpsc;
 use futures_util::stream::StreamExt;
 use jsonrpsee_types::v2::error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject};
 use jsonrpsee_types::v2::params::{Id, TwoPointZero};
-use jsonrpsee_types::v2::response::JsonRpcResponse;
 use jsonrpsee_types::v2::request::JsonRpcInvalidRequest;
+use jsonrpsee_types::v2::response::JsonRpcResponse;
 use serde::Serialize;
 
 /// Helper for sending JSON-RPC responses to the client
@@ -38,7 +38,6 @@ pub fn send_error(id: Id, tx: &MethodSink, error: JsonRpcErrorObject) {
 		log::error!("Error sending response to the client: {:?}", err)
 	}
 }
-
 
 /// Figure out if this is a sufficiently complete request that we can extract an [`Id`] out of, or just plain
 /// unparseable garbage.

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -271,8 +271,8 @@ async fn background_task(
 			continue;
 		}
 
-		match data[0] {
-			b'{' => {
+		match data.get(0) {
+			Some(b'{') => {
 				if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&data) {
 					log::debug!("recv: {:?}", req);
 					methods.execute(&tx, req, conn_id).await;
@@ -281,7 +281,7 @@ async fn background_task(
 					send_error(id, &tx, code.into());
 				}
 			}
-			b'[' => {
+			Some(b'[') => {
 				if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&data) {
 					if !batch.is_empty() {
 						// Batch responses must be sent back as a single message so we read the results from each request in the

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -30,11 +30,7 @@ use std::task::{Context, Poll};
 use std::{net::SocketAddr, sync::Arc};
 
 use crate::types::{
-	error::Error,
-	v2::error::JsonRpcErrorCode,
-	v2::params::Id,
-	v2::request::JsonRpcRequest,
-	TEN_MB_SIZE_BYTES,
+	error::Error, v2::error::JsonRpcErrorCode, v2::params::Id, v2::request::JsonRpcRequest, TEN_MB_SIZE_BYTES,
 };
 use futures_channel::mpsc;
 use futures_util::future::{join_all, FutureExt};

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -33,7 +33,7 @@ use crate::types::{
 	error::Error,
 	v2::error::JsonRpcErrorCode,
 	v2::params::Id,
-	v2::request::{JsonRpcInvalidRequest, JsonRpcRequest},
+	v2::request::JsonRpcRequest,
 	TEN_MB_SIZE_BYTES,
 };
 use futures_channel::mpsc;
@@ -50,7 +50,7 @@ use tokio::{
 };
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
-use jsonrpsee_utils::server::helpers::{collect_batch_response, send_error};
+use jsonrpsee_utils::server::helpers::{collect_batch_response, prepare_error, send_error};
 use jsonrpsee_utils::server::rpc_module::{ConnectionId, Methods};
 
 /// Default maximum connections allowed.
@@ -275,40 +275,42 @@ async fn background_task(
 			continue;
 		}
 
-		// For reasons outlined [here](https://github.com/serde-rs/json/issues/497), `RawValue` can't be used with
-		// untagged enums at the moment. This means we can't use an `SingleOrBatch` untagged enum here and have to try
-		// each case individually: first the single request case, then the batch case and lastly the error. For the
-		// worst case – unparseable input – we make three calls to [`serde_json::from_slice`] which is pretty annoying.
-		// Our [issue](https://github.com/paritytech/jsonrpsee/issues/296).
-		if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&data) {
-			log::debug!("recv: {:?}", req);
-			methods.execute(&tx, req, conn_id).await;
-		} else if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&data) {
-			if !batch.is_empty() {
-				// Batch responses must be sent back as a single message so we read the results from each request in the
-				// batch and read the results off of a new channel, `rx_batch`, and then send the complete batch response
-				// back to the client over `tx`.
-				let (tx_batch, mut rx_batch) = mpsc::unbounded::<String>();
-
-				join_all(batch.into_iter().map(|req| methods.execute(&tx_batch, req, conn_id))).await;
-
-				// Closes the receiving half of a channel without dropping it. This prevents any further messages from
-				// being sent on the channel.
-				rx_batch.close();
-				let results = collect_batch_response(rx_batch).await;
-				if let Err(err) = tx.unbounded_send(results) {
-					log::error!("Error sending batch response to the client: {:?}", err)
+		match data[0] {
+			b'{' => {
+				if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&data) {
+					log::debug!("recv: {:?}", req);
+					methods.execute(&tx, req, conn_id).await;
+				} else {
+					let (id, code) = prepare_error(&data);
+					send_error(id, &tx, code.into());
 				}
-			} else {
-				send_error(Id::Null, &tx, JsonRpcErrorCode::InvalidRequest.into());
 			}
-		} else {
-			let (id, code) = match serde_json::from_slice::<JsonRpcInvalidRequest>(&data) {
-				Ok(req) => (req.id, JsonRpcErrorCode::InvalidRequest),
-				Err(_) => (Id::Null, JsonRpcErrorCode::ParseError),
-			};
+			b'[' => {
+				if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&data) {
+					if !batch.is_empty() {
+						// Batch responses must be sent back as a single message so we read the results from each request in the
+						// batch and read the results off of a new channel, `rx_batch`, and then send the complete batch response
+						// back to the client over `tx`.
+						let (tx_batch, mut rx_batch) = mpsc::unbounded::<String>();
 
-			send_error(id, &tx, code.into());
+						join_all(batch.into_iter().map(|req| methods.execute(&tx_batch, req, conn_id))).await;
+
+						// Closes the receiving half of a channel without dropping it. This prevents any further messages from
+						// being sent on the channel.
+						rx_batch.close();
+						let results = collect_batch_response(rx_batch).await;
+						if let Err(err) = tx.unbounded_send(results) {
+							log::error!("Error sending batch response to the client: {:?}", err)
+						}
+					} else {
+						send_error(Id::Null, &tx, JsonRpcErrorCode::InvalidRequest.into());
+					}
+				} else {
+					let (id, code) = prepare_error(&data);
+					send_error(id, &tx, code.into());
+				}
+			}
+			_ => send_error(Id::Null, &tx, JsonRpcErrorCode::ParseError.into()),
 		}
 	}
 	Ok(())


### PR DESCRIPTION
This works around the serde limitations around `untagged` enums and `RawValue` by instead looking at the first byte of the request: if it's a `[` then it's a batch request; if it's a `{` then it's a single request.

The http case is less nice because there we have notifications (i.e. requests without an id, requiring no response).

Also see #420 as an alternative to this.

Closes #296 
