### PR TITLE
fix(ws client): use query part of URL.

### DIFF
--- a/ws-client/src/transport.rs
+++ b/ws-client/src/transport.rs
@@ -218,6 +218,7 @@ impl<'a> WsTransportClientBuilder<'a> {
 			}
 		};
 
+		log::debug!("Connecting to target: {:?}", self.target);
 		let mut client =
 			WsRawClient::new(BufReader::new(BufWriter::new(tcp_stream)), &self.target.host_header, &self.target.path);
 		if let Some(origin) = self.origin_header.as_ref() {


### PR DESCRIPTION
Fixes #428, we didn't take that query part of the URL into account and it wasn't sent in GET request because of that.