### PR TITLE
Fix errors with generics when using the proc macro

### DIFF
--- a/proc-macros/src/new/render_server.rs
+++ b/proc-macros/src/new/render_server.rs
@@ -48,7 +48,6 @@ impl RpcDescription {
 	}
 
 	fn render_into_rpc(&self) -> Result<TokenStream2, syn::Error> {
-		let jrps_error = self.jrps_server_item(quote! { types::Error });
 		let rpc_module = self.jrps_server_item(quote! { RpcModule });
 
 		let mut registered = HashSet::new();
@@ -61,6 +60,18 @@ impl RpcDescription {
 				registered.insert(name);
 			}
 		};
+
+		/// Helper that will ignore results of `register_*` method calls, and panic
+		/// if there have been any errors in debug builds.
+		///
+		/// The debug assert is a safeguard should the contract that guarantees the method
+		/// names to never conflict in the macro be broken in the future.
+		fn handle_register_result(tokens: TokenStream2) -> TokenStream2 {
+			quote! {{
+				let res = #tokens;
+				debug_assert!(res.is_ok(), "RPC macro method names should never conflict, this is a bug, please report it.");
+			}}
+		}
 
 		let methods = self
 			.methods
@@ -78,22 +89,22 @@ impl RpcDescription {
 				check_name(rpc_method_name.clone(), rust_method_name.span());
 
 				if method.signature.sig.asyncness.is_some() {
-					quote! {
+					handle_register_result(quote! {
 						rpc.register_async_method(#rpc_method_name, |params, context| {
 							let fut = async move {
 								#parsing
 								Ok(context.as_ref().#rust_method_name(#params_seq).await)
 							};
 							Box::pin(fut)
-						})?;
-					}
+						})
+					})
 				} else {
-					quote! {
+					handle_register_result(quote! {
 						rpc.register_method(#rpc_method_name, |params, context| {
 							#parsing
 							Ok(context.#rust_method_name(#params_seq))
-						})?;
-					}
+						})
+					})
 				}
 			})
 			.collect::<Vec<_>>();
@@ -116,12 +127,12 @@ impl RpcDescription {
 				check_name(rpc_sub_name.clone(), rust_method_name.span());
 				check_name(rpc_unsub_name.clone(), rust_method_name.span());
 
-				quote! {
+				handle_register_result(quote! {
 					rpc.register_subscription(#rpc_sub_name, #rpc_unsub_name, |params, sink, context| {
 						#parsing
 						Ok(context.as_ref().#rust_method_name(sink, #params_seq))
-					})?;
-				}
+					})
+				})
 			})
 			.collect::<Vec<_>>();
 
@@ -131,17 +142,13 @@ impl RpcDescription {
 		Ok(quote! {
 			#[doc = #doc_comment]
 			fn into_rpc(self) -> #rpc_module<Self> {
-				let inner = move || -> Result<#rpc_module<Self>, #jrps_error> {
-					let mut rpc = #rpc_module::new(self);
+				let mut rpc = #rpc_module::new(self);
 
-					#(#errors)*
-					#(#methods)*
-					#(#subscriptions)*
+				#(#errors)*
+				#(#methods)*
+				#(#subscriptions)*
 
-					Ok(rpc)
-				};
-
-				inner().expect("RPC macro method names should never conflict")
+				rpc
 			}
 		})
 	}


### PR DESCRIPTION
The `inner` closure was causing issues when parent types were using generics, since those types aren't usable inside closures (unless said closure would be made to be generic).

Since all we used the closure for is collect all errors to `.expect` on them at the end, this PR strips the closure altogether, and instead handles errors in place: ignoring them and panicking in debug builds if the macro somehow were to produce conflicting names.