### PR TITLE
[WIP]: proc macros support generic type params

### DIFF
--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -35,16 +35,20 @@ use serde::ser::Serialize;
 use std::net::SocketAddr;
 
 #[rpc(server, client, namespace = "state")]
-pub trait Rpc<Hash: DeserializeOwned + Serialize + Send + Sync + 'static> {
+pub trait Rpc<
+	Hash: DeserializeOwned + Serialize + Send + Sync + 'static,
+	Prefix: DeserializeOwned + Serialize + Send + Sync + 'static,
+>
+{
 	/// Async method call example.
 	#[method(name = "getPairs")]
-	async fn storage_pairs(&self, prefix: usize, hash: Hash) -> Result<Vec<usize>, Error>;
+	async fn storage_pairs(&self, prefix: Prefix, hash: Hash) -> Result<Vec<usize>, Error>;
 }
 
 pub struct RpcServerImpl;
 
 #[async_trait]
-impl RpcServer<Vec<u8>> for RpcServerImpl {
+impl RpcServer<Vec<u8>, usize> for RpcServerImpl {
 	async fn storage_pairs(&self, _prefix: usize, _hash: Vec<u8>) -> Result<Vec<usize>, Error> {
 		Ok(vec![1, 2, 3, 4])
 	}

--- a/proc-macros/src/new/render_server.rs
+++ b/proc-macros/src/new/render_server.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 impl RpcDescription {
 	pub(super) fn render_server(&self) -> Result<TokenStream2, syn::Error> {
 		let trait_name = quote::format_ident!("{}Server", &self.trait_def.ident);
+		let generics = self.trait_def.generics.clone();
 
 		let method_impls = self.render_methods()?;
 		let into_rpc_impl = self.render_into_rpc()?;
@@ -19,7 +20,7 @@ impl RpcDescription {
 		let trait_impl = quote! {
 			#[#async_trait]
 			#[doc = #doc_comment]
-			pub trait #trait_name: Sized + Send + Sync + 'static {
+			pub trait #trait_name #generics: Sized + Send + Sync + 'static {
 				#method_impls
 				#into_rpc_impl
 			}
@@ -176,7 +177,6 @@ impl RpcDescription {
 			quote! {
 				let mut seq = params.sequence();
 				#(#decode_fields);*
-				(#params_fields)
 			}
 		};
 
@@ -220,11 +220,12 @@ impl RpcDescription {
 
 		// Parsing of `serde_json::Value`.
 		let parsing = quote! {
-			let (#params_fields) = if params.is_object() {
+			/*let (#params_fields) = if params.is_object() {
 				#decode_map
 			} else {
 				#decode_array
-			};
+			};*/
+			#decode_array;
 		};
 
 		(parsing, params_fields)


### PR DESCRIPTION
So this the first step for support generic params on the `trait` in the `proc macros`

For now I have ignored the `JSON Map` support as it currently not is used that widely at least by us (substrate etc) and looks quite annoying to fix the `serde impls`

However, I have added an example for this in `examples/proc_macros.rs` where you can see that users need to add some trait bounds for it work but I lean towards that we should do it for the users instead? Thoughts?

