### PR TITLE
fix(proc macros): generate documentation for trait methods.

### DIFF
--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -24,6 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![warn(missing_docs)]
 use jsonrpsee::{
 	proc_macros::rpc,
 	types::{async_trait, error::Error, Subscription},
@@ -40,11 +41,9 @@ pub trait Rpc<Hash: Clone, StorageKey>
 where
 	Hash: std::fmt::Debug,
 {
-	/// Async method call example.
 	#[method(name = "getKeys")]
 	async fn storage_keys(&self, storage_key: StorageKey, hash: Option<Hash>) -> Result<Vec<StorageKey>, Error>;
 
-	/// Subscription that takes a `StorageKey` as input and produces a `Vec<Hash>`.
 	#[subscription(name = "subscribeStorage", item = Vec<Hash>)]
 	fn subscribe_storage(&self, keys: Option<Vec<StorageKey>>);
 }

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -24,7 +24,6 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-#![warn(missing_docs)]
 use jsonrpsee::{
 	proc_macros::rpc,
 	types::{async_trait, error::Error, Subscription},
@@ -41,9 +40,11 @@ pub trait Rpc<Hash: Clone, StorageKey>
 where
 	Hash: std::fmt::Debug,
 {
+	/// Async method call example.
 	#[method(name = "getKeys")]
 	async fn storage_keys(&self, storage_key: StorageKey, hash: Option<Hash>) -> Result<Vec<StorageKey>, Error>;
 
+	/// Subscription that takes a `StorageKey` as input and produces a `Vec<Hash>`.
 	#[subscription(name = "subscribeStorage", item = Vec<Hash>)]
 	fn subscribe_storage(&self, keys: Option<Vec<StorageKey>>);
 }

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -172,15 +172,12 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
 pub(crate) fn extract_doc_comments(attrs: &[syn::Attribute]) -> TokenStream2 {
 	let docs = attrs.iter().filter_map(|attr| {
 		if let Ok(syn::Meta::NameValue(meta)) = attr.parse_meta() {
-			if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
-				if let syn::Lit::Str(_lit) = &meta.lit {
-					Some(attr)
-				} else {
-					None
-				}
-			} else {
-				None
-			}
+			match &meta.lit {
+				syn::Lit::Str(_) => (),
+				_ => return None,
+			};
+
+			meta.path.get_ident().and_then(|ident| if ident == "doc" { Some(attr) } else { None })
 		} else {
 			None
 		}

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -170,15 +170,9 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
 /// Note that `doc comments` are expanded into `#[doc = "some comment"]`
 /// Thus, if the attribute starts with `doc` => it's regarded as a doc comment.
 pub(crate) fn extract_doc_comments(attrs: &[syn::Attribute]) -> TokenStream2 {
-	let docs = attrs.iter().filter_map(|attr| {
-		match attr.path.segments.first() {
-			Some(syn::PathSegment { ident, .. }) if ident == "doc" => (),
-			_ => return None,
-		};
-		match attr.parse_meta() {
-			Ok(syn::Meta::NameValue(meta)) if matches!(&meta.lit, syn::Lit::Str(_)) => Some(attr),
-			_ => None,
-		}
+	let docs = attrs.iter().filter(|attr| attr.path.is_ident("doc")).filter(|attr| match attr.parse_meta() {
+		Ok(syn::Meta::NameValue(meta)) if matches!(&meta.lit, syn::Lit::Str(_)) => true,
+		_ => false,
 	});
 	quote! ( #(#docs)* )
 }

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -165,6 +165,20 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
 	false
 }
 
+/// Iterates over all Attribute's and parses only the attributes that are doc comments.
+///
+/// Note that `doc comments` are expanded into `#[doc = "some comment"]`
+/// Thus, if the attribute starts with `doc` => it's regarded as a doc comment.
+pub(crate) fn extract_doc_comments(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
+	attrs
+		.iter()
+		.filter_map(|attr| match attr.path.segments.first() {
+			Some(syn::PathSegment { ident, .. }) if ident == "doc" => Some(attr.to_owned()),
+			_ => None,
+		})
+		.collect()
+}
+
 #[cfg(test)]
 mod tests {
 	use super::is_option;

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -170,11 +170,15 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
 /// Note that `doc comments` are expanded into `#[doc = "some comment"]`
 /// Thus, if the attribute starts with `doc` => it's regarded as a doc comment.
 pub(crate) fn extract_doc_comments(attrs: &[syn::Attribute]) -> TokenStream2 {
-	let docs = attrs.iter().filter_map(|attr| match attr.parse_meta() {
-		Ok(syn::Meta::NameValue(meta)) if matches!(&meta.lit, syn::Lit::Str(_)) => {
-			meta.path.get_ident().and_then(|ident| if ident == "doc" { Some(attr) } else { None })
+	let docs = attrs.iter().filter_map(|attr| {
+		match attr.path.segments.first() {
+			Some(syn::PathSegment { ident, .. }) if ident == "doc" => (),
+			_ => return None,
+		};
+		match attr.parse_meta() {
+			Ok(syn::Meta::NameValue(meta)) if matches!(&meta.lit, syn::Lit::Str(_)) => Some(attr),
+			_ => None,
 		}
-		_ => None,
 	});
 	quote! ( #(#docs)* )
 }

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -170,17 +170,11 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
 /// Note that `doc comments` are expanded into `#[doc = "some comment"]`
 /// Thus, if the attribute starts with `doc` => it's regarded as a doc comment.
 pub(crate) fn extract_doc_comments(attrs: &[syn::Attribute]) -> TokenStream2 {
-	let docs = attrs.iter().filter_map(|attr| {
-		if let Ok(syn::Meta::NameValue(meta)) = attr.parse_meta() {
-			match &meta.lit {
-				syn::Lit::Str(_) => (),
-				_ => return None,
-			};
-
+	let docs = attrs.iter().filter_map(|attr| match attr.parse_meta() {
+		Ok(syn::Meta::NameValue(meta)) if matches!(&meta.lit, syn::Lit::Str(_)) => {
 			meta.path.get_ident().and_then(|ident| if ident == "doc" { Some(attr) } else { None })
-		} else {
-			None
 		}
+		_ => None,
 	});
 	quote! ( #(#docs)* )
 }

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -108,10 +108,10 @@ impl RpcDescription {
 		};
 
 		// Doc-comment to be associated with the method.
-		let doc_comment = format!("Invokes the RPC method `{}`.", rpc_method_name);
+		let docs = &method.doc;
 
 		let method = quote! {
-			#[doc = #doc_comment]
+			#(#docs)*
 			async fn #rust_method_name(#rust_method_params) -> #returns {
 				self.#called_method(#rpc_method_name, #parameters).await
 			}
@@ -151,10 +151,10 @@ impl RpcDescription {
 		};
 
 		// Doc-comment to be associated with the method.
-		let doc_comment = format!("Subscribes to the RPC method `{}`.", rpc_sub_name);
+		let docs = &sub.doc;
 
 		let method = quote! {
-			#[doc = #doc_comment]
+			#(#docs)*
 			async fn #rust_method_name(#rust_method_params) -> #returns {
 				self.subscribe(#rpc_sub_name, #parameters, #rpc_unsub_name).await
 			}

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -108,10 +108,10 @@ impl RpcDescription {
 		};
 
 		// Doc-comment to be associated with the method.
-		let docs = &method.doc;
+		let docs = &method.docs;
 
 		let method = quote! {
-			#(#docs)*
+			#docs
 			async fn #rust_method_name(#rust_method_params) -> #returns {
 				self.#called_method(#rpc_method_name, #parameters).await
 			}
@@ -151,10 +151,10 @@ impl RpcDescription {
 		};
 
 		// Doc-comment to be associated with the method.
-		let docs = &sub.doc;
+		let docs = &sub.docs;
 
 		let method = quote! {
-			#(#docs)*
+			#docs
 			async fn #rust_method_name(#rust_method_params) -> #returns {
 				self.subscribe(#rpc_sub_name, #parameters, #rpc_unsub_name).await
 			}

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -58,23 +58,23 @@ impl RpcDescription {
 
 	fn render_methods(&self) -> Result<TokenStream2, syn::Error> {
 		let methods = self.methods.iter().map(|method| {
-			let doc = &method.doc;
+			let docs = &method.docs;
 			let method_sig = &method.signature;
 			quote! {
-				#(#doc)*
+				#docs
 				#method_sig
 			}
 		});
 
 		let subscriptions = self.subscriptions.iter().map(|sub| {
-			let doc = &sub.doc;
+			let docs = &sub.docs;
 			let subscription_sink_ty = self.jrps_server_item(quote! { SubscriptionSink });
 			// Add `SubscriptionSink` as the second input parameter to the signature.
 			let subscription_sink: syn::FnArg = syn::parse_quote!(subscription_sink: #subscription_sink_ty);
 			let mut sub_sig = sub.signature.clone();
 			sub_sig.sig.inputs.insert(1, subscription_sink);
 			quote! {
-				#(#doc)*
+				#docs
 				#sub_sig
 			}
 		});

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -35,7 +35,7 @@ use syn::Attribute;
 #[derive(Debug, Clone)]
 pub struct RpcMethod {
 	pub name: String,
-	pub doc: Vec<syn::Attribute>,
+	pub docs: TokenStream2,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
 	pub returns: Option<syn::Type>,
 	pub signature: syn::TraitItemMethod,
@@ -47,7 +47,7 @@ impl RpcMethod {
 		let attributes = attributes::Method::from_attributes(&method.attrs).respan(&method.attrs.first())?;
 		let sig = method.sig.clone();
 		let name = attributes.name.value();
-		let doc = extract_doc_comments(&method.attrs);
+		let docs = extract_doc_comments(&method.attrs);
 		let aliases = attributes.aliases.map(|a| a.value().split(',').map(Into::into).collect()).unwrap_or_default();
 		let params: Vec<_> = sig
 			.inputs
@@ -69,14 +69,14 @@ impl RpcMethod {
 		// We've analyzed attributes and don't need them anymore.
 		method.attrs.clear();
 
-		Ok(Self { aliases, name, params, returns, signature: method, doc })
+		Ok(Self { aliases, name, params, returns, signature: method, docs })
 	}
 }
 
 #[derive(Debug, Clone)]
 pub struct RpcSubscription {
 	pub name: String,
-	pub doc: Vec<syn::Attribute>,
+	pub docs: TokenStream2,
 	pub unsubscribe: String,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
 	pub item: syn::Type,
@@ -90,7 +90,7 @@ impl RpcSubscription {
 		let attributes = attributes::Subscription::from_attributes(&sub.attrs).respan(&sub.attrs.first())?;
 		let sig = sub.sig.clone();
 		let name = attributes.name.value();
-		let doc = extract_doc_comments(&sub.attrs);
+		let docs = extract_doc_comments(&sub.attrs);
 		let unsubscribe = build_unsubscribe_method(&name);
 		let item = attributes.item;
 		let aliases = attributes.aliases.map(|a| a.value().split(',').map(Into::into).collect()).unwrap_or_default();
@@ -111,7 +111,7 @@ impl RpcSubscription {
 		// We've analyzed attributes and don't need them anymore.
 		sub.attrs.clear();
 
-		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, item, signature: sub, aliases, doc })
+		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, item, signature: sub, aliases, docs })
 	}
 }
 

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -35,6 +35,7 @@ use syn::Attribute;
 #[derive(Debug, Clone)]
 pub struct RpcMethod {
 	pub name: String,
+	pub doc: Vec<syn::Attribute>,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
 	pub returns: Option<syn::Type>,
 	pub signature: syn::TraitItemMethod,
@@ -46,6 +47,7 @@ impl RpcMethod {
 		let attributes = attributes::Method::from_attributes(&method.attrs).respan(&method.attrs.first())?;
 		let sig = method.sig.clone();
 		let name = attributes.name.value();
+		let doc = crate::helpers::extract_doc_comments(&method.attrs);
 		let aliases = attributes.aliases.map(|a| a.value().split(',').map(Into::into).collect()).unwrap_or_default();
 		let params: Vec<_> = sig
 			.inputs
@@ -67,13 +69,14 @@ impl RpcMethod {
 		// We've analyzed attributes and don't need them anymore.
 		method.attrs.clear();
 
-		Ok(Self { aliases, name, params, returns, signature: method })
+		Ok(Self { aliases, name, params, returns, signature: method, doc })
 	}
 }
 
 #[derive(Debug, Clone)]
 pub struct RpcSubscription {
 	pub name: String,
+	pub doc: Vec<syn::Attribute>,
 	pub unsubscribe: String,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
 	pub item: syn::Type,
@@ -87,6 +90,7 @@ impl RpcSubscription {
 		let attributes = attributes::Subscription::from_attributes(&sub.attrs).respan(&sub.attrs.first())?;
 		let sig = sub.sig.clone();
 		let name = attributes.name.value();
+		let doc = crate::helpers::extract_doc_comments(&sub.attrs);
 		let unsubscribe = build_unsubscribe_method(&name);
 		let item = attributes.item;
 		let aliases = attributes.aliases.map(|a| a.value().split(',').map(Into::into).collect()).unwrap_or_default();
@@ -107,7 +111,7 @@ impl RpcSubscription {
 		// We've analyzed attributes and don't need them anymore.
 		sub.attrs.clear();
 
-		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, item, signature: sub, aliases })
+		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, item, signature: sub, aliases, doc })
 	}
 }
 

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -26,7 +26,7 @@
 
 //! Declaration of the JSON RPC generator procedural macros.
 
-use crate::{attributes, respan::Respan};
+use crate::{attributes, helpers::extract_doc_comments, respan::Respan};
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -47,7 +47,7 @@ impl RpcMethod {
 		let attributes = attributes::Method::from_attributes(&method.attrs).respan(&method.attrs.first())?;
 		let sig = method.sig.clone();
 		let name = attributes.name.value();
-		let doc = crate::helpers::extract_doc_comments(&method.attrs);
+		let doc = extract_doc_comments(&method.attrs);
 		let aliases = attributes.aliases.map(|a| a.value().split(',').map(Into::into).collect()).unwrap_or_default();
 		let params: Vec<_> = sig
 			.inputs
@@ -90,7 +90,7 @@ impl RpcSubscription {
 		let attributes = attributes::Subscription::from_attributes(&sub.attrs).respan(&sub.attrs.first())?;
 		let sig = sub.sig.clone();
 		let name = attributes.name.value();
-		let doc = crate::helpers::extract_doc_comments(&sub.attrs);
+		let doc = extract_doc_comments(&sub.attrs);
 		let unsubscribe = build_unsubscribe_method(&name);
 		let item = attributes.item;
 		let aliases = attributes.aliases.map(|a| a.value().split(',').map(Into::into).collect()).unwrap_or_default();

--- a/proc-macros/tests/ui/correct/rpc_deny_missing_docs.rs
+++ b/proc-macros/tests/ui/correct/rpc_deny_missing_docs.rs
@@ -1,0 +1,18 @@
+//! Test to check that the proc macros actually generates documentation.
+
+#![deny(missing_docs)]
+
+use jsonrpsee::proc_macros::rpc;
+
+#[rpc(client, server)]
+pub trait ApiWithoutDocumentation {
+	/// Async method.
+	#[method(name = "foo")]
+	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+
+	/// Subscription docs.
+	#[subscription(name = "sub", item = String)]
+	fn sub(&self);
+}
+
+fn main() {}


### PR DESCRIPTION
Closing #449

Note, we are not using the docs on the entire trait instead we are manually inserting documentation there but for that we need to parse the `TraitItem` for that so out-of-scope for this PR.

To elaborate if you do:

```rust
/// My import API but these comments are not used anywhere
#[rpc(client, server)]
pub trait MyApi {
	/// API.
	#[method(name = "api"]
	async fn api(&self) -> jsonrpsee::types::JsonRpcResult<()>;
}
```

Expands to
```rust
///Server trait implementation for the `Rpc` RPC API.
pub trait MyApiServer: Sized + Send + Sync + 'static
{
    /// API
    async fn api(&self) { ....}
}

///Client implementation for the `Rpc` RPC API.
pub trait RpcClient: jsonrpsee::types::traits::Client
{
    /// API
    async fn api(&self) { ....}
}
```

