### PR TITLE
Let rustfmt wrap comments at the 120 width boundary

### DIFF
--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -334,7 +334,8 @@ async fn invalid_json_id_missing_value() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
-	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
+	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be
+	// Null.
 	assert_eq!(response.body, parse_error(Id::Null));
 }
 

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -64,8 +64,8 @@ fn find_jsonrpsee_crate(http_name: &str, ws_name: &str) -> Result<proc_macro2::T
 /// Traverses the RPC trait definition and applies the required bounds for the generic type parameters that are used.
 /// The bounds applied depend on whether the type parameter is used as a parameter, return value or subscription result
 /// and whether it's used in client or server mode.
-/// Type params get `Send + Sync + 'static` bounds and input/output parameters get `Serialize` and/or `DeserializeOwned` bounds.
-/// Inspired by <https://github.com/paritytech/jsonrpc/blob/master/derive/src/to_delegate.rs#L414>
+/// Type params get `Send + Sync + 'static` bounds and input/output parameters get `Serialize` and/or `DeserializeOwned`
+/// bounds. Inspired by <https://github.com/paritytech/jsonrpc/blob/master/derive/src/to_delegate.rs#L414>
 ///
 /// ### Example
 ///

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -54,23 +54,22 @@ pub(crate) mod visitor;
 /// For servers, it will generate a trait mostly equivalent to the input, with two main
 /// differences:
 ///
-/// - The trait will have one additional (already implemented) method, `into_rpc`, which
-///   turns any object that implements the server trait into an `RpcModule`.
-/// - For subscription methods, there will be one additional argument inserted right
-///   after `&self`: `subscription_sink: SubscriptionSink`. It should be used to
-///   actually maintain the subscription.
+/// - The trait will have one additional (already implemented) method, `into_rpc`, which turns any object that
+///   implements the server trait into an `RpcModule`.
+/// - For subscription methods, there will be one additional argument inserted right after `&self`: `subscription_sink:
+///   SubscriptionSink`. It should be used to actually maintain the subscription.
 ///
 /// Since this macro can generate up to two traits, both server and client traits will have
 /// a new name. For the `Foo` trait, server trait will be named `FooServer`, and client,
 /// correspondingly, `FooClient`.
 ///
-/// To use the `FooClient`, just import it in the context. To use the server, the `FooServer` trait must be implemented on your type first.
+/// To use the `FooClient`, just import it in the context. To use the server, the `FooServer` trait must be implemented
+/// on your type first.
 ///
 /// ## Prerequisites
 ///
-/// - Implementors of the server trait must be `Sync`, `Send`, `Sized` and `'static`.
-///   If you want to implement this trait on some type that is not thread-safe, consider
-///   using `Arc<RwLock<..>>`.
+/// - Implementors of the server trait must be `Sync`, `Send`, `Sized` and `'static`. If you want to implement this
+///   trait on some type that is not thread-safe, consider using `Arc<RwLock<..>>`.
 ///
 /// ## Examples
 ///
@@ -143,8 +142,8 @@ pub(crate) mod visitor;
 /// - `server`: generate `<Trait>Server` trait for the server implementation.
 /// - `client`: generate `<Trait>Client` extension trait that builds RPC clients to invoke a concrete RPC
 ///   implementation's methods conveniently.
-/// - `namespace`: add a prefix to all the methods and subscriptions in this RPC. For example, with namespace
-///   `foo` and method `spam`, the resulting method name will be `foo_spam`.
+/// - `namespace`: add a prefix to all the methods and subscriptions in this RPC. For example, with namespace `foo` and
+///   method `spam`, the resulting method name will be `foo_spam`.
 ///
 /// **Trait requirements:**
 ///

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,5 @@ hard_tabs = true
 max_width = 120
 use_small_heuristics = "Max"
 edition = "2018"
+wrap_comments = true
+comment_width = 120

--- a/test-utils/src/types.rs
+++ b/test-utils/src/types.rs
@@ -145,7 +145,8 @@ pub struct WebSocketTestServer {
 }
 
 impl WebSocketTestServer {
-	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded response` for every connection.
+	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded response` for every
+	// connection.
 	pub async fn with_hardcoded_response(sockaddr: SocketAddr, response: String) -> Self {
 		let listener = tokio::net::TcpListener::bind(sockaddr).await.unwrap();
 		let local_addr = listener.local_addr().unwrap();
@@ -155,7 +156,8 @@ impl WebSocketTestServer {
 		Self { local_addr, exit: tx }
 	}
 
-	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded notification` for every connection.
+	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded notification` for every
+	// connection.
 	pub async fn with_hardcoded_notification(sockaddr: SocketAddr, notification: String) -> Self {
 		let (tx, rx) = mpsc::channel::<()>(1);
 		let (addr_tx, addr_rx) = oneshot::channel();
@@ -174,7 +176,8 @@ impl WebSocketTestServer {
 		Self { local_addr, exit: tx }
 	}
 
-	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured subscription ID and subscription response.
+	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured subscription ID and subscription
+	// response.
 	//
 	// NOTE: ignores the actual subscription and unsubscription method.
 	pub async fn with_hardcoded_subscription(

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -64,7 +64,8 @@ pub trait SubscriptionClient: Client {
 	///
 	/// The `unsubscribe_method` is used to close the subscription
 	///
-	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further documentation.
+	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further
+	/// documentation.
 	async fn subscribe<'a, Notif>(
 		&self,
 		subscribe_method: &'a str,
@@ -76,7 +77,8 @@ pub trait SubscriptionClient: Client {
 
 	/// Register a method subscription, this is used to filter only server notifications that a user is interested in.
 	///
-	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further documentation.
+	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further
+	/// documentation.
 	async fn subscribe_to_method<'a, Notif>(&self, method: &'a str) -> Result<Subscription<Notif>, Error>
 	where
 		Notif: DeserializeOwned;

--- a/utils/src/http_helpers.rs
+++ b/utils/src/http_helpers.rs
@@ -39,8 +39,8 @@ pub async fn read_body(
 	mut body: hyper::Body,
 	max_request_body_size: u32,
 ) -> Result<(Vec<u8>, bool), GenericTransportError<hyper::Error>> {
-	// NOTE(niklasad1): Values bigger than `u32::MAX` will be turned into zero here. This is unlikely to occur in practice
-	// and for that case we fallback to allocating in the while-loop below instead of pre-allocating.
+	// NOTE(niklasad1): Values bigger than `u32::MAX` will be turned into zero here. This is unlikely to occur in
+	// practice and for that case we fallback to allocating in the while-loop below instead of pre-allocating.
 	let body_size = read_header_content_length(headers).unwrap_or(0);
 
 	if body_size > max_request_body_size {

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -234,14 +234,15 @@ impl<'a> WsClientBuilder<'a> {
 		self
 	}
 
-	/// Set max concurrent notification capacity for each subscription; when the capacity is exceeded the subscription will be dropped.
+	/// Set max concurrent notification capacity for each subscription; when the capacity is exceeded the subscription
+	/// will be dropped.
 	///
-	/// You can also prevent the subscription being dropped by calling [`Subscription::next()`](crate::types::Subscription) frequently enough
-	/// such that the buffer capacity doesn't exceeds.
+	/// You can also prevent the subscription being dropped by calling
+	/// [`Subscription::next()`](crate::types::Subscription) frequently enough such that the buffer capacity doesn't
+	/// exceeds.
 	///
 	/// **Note**: The actual capacity is `num_senders + max_subscription_capacity`
 	/// because it is passed to [`futures::channel::mpsc::channel`].
-	///
 	pub fn max_notifs_per_subscription(mut self, max: usize) -> Self {
 		self.max_notifs_per_subscription = max;
 		self

--- a/ws-client/src/manager.rs
+++ b/ws-client/src/manager.rs
@@ -77,9 +77,11 @@ pub struct BatchState {
 /// Manages and monitors JSONRPC v2 method calls and subscriptions.
 pub struct RequestManager {
 	/// List of requests that are waiting for a response from the server.
-	// NOTE: FnvHashMap is used here because RequestId is not under the caller's control and is known to be a short key.
+	// NOTE: FnvHashMap is used here because RequestId is not under the caller's control and is known to be a short
+	// key.
 	requests: FnvHashMap<RequestId, Kind>,
-	/// Reverse lookup, to find a request ID in constant time by `subscription ID` instead of looking through all requests.
+	/// Reverse lookup, to find a request ID in constant time by `subscription ID` instead of looking through all
+	/// requests.
 	subscriptions: HashMap<SubscriptionId, RequestId>,
 	/// Pending batch requests
 	batches: FnvHashMap<Vec<RequestId>, BatchState>,

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -245,17 +245,17 @@ async fn background_task(
 			Some(b'[') => {
 				if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&data) {
 					if !batch.is_empty() {
-						// Batch responses must be sent back as a single message so we read the results from each request in the
-						// batch and read the results off of a new channel, `rx_batch`, and then send the complete batch response
-						// back to the client over `tx`.
+						// Batch responses must be sent back as a single message so we read the results from each
+						// request in the batch and read the results off of a new channel, `rx_batch`, and then send the
+						// complete batch response back to the client over `tx`.
 						let (tx_batch, mut rx_batch) = mpsc::unbounded::<String>();
 
 						for fut in batch.into_iter().filter_map(|req| methods.execute(&tx_batch, req, conn_id)) {
 							method_executors.add(fut);
 						}
 
-						// Closes the receiving half of a channel without dropping it. This prevents any further messages from
-						// being sent on the channel.
+						// Closes the receiving half of a channel without dropping it. This prevents any further
+						// messages from being sent on the channel.
 						rx_batch.close();
 						let results = collect_batch_response(rx_batch).await;
 						if let Err(err) = tx.unbounded_send(results) {
@@ -356,7 +356,8 @@ impl Builder {
 	///
 	/// By default allows any `Origin`.
 	///
-	/// Will return an error if `list` is empty. Use [`allow_all_origins`](Builder::allow_all_origins) to restore the default.
+	/// Will return an error if `list` is empty. Use [`allow_all_origins`](Builder::allow_all_origins) to restore the
+	/// default.
 	pub fn set_allowed_origins<Origin, List>(mut self, list: List) -> Result<Self, Error>
 	where
 		List: IntoIterator<Item = Origin>,
@@ -391,7 +392,8 @@ impl Builder {
 	///
 	/// By default allows any `Host`.
 	///
-	/// Will return an error if `list` is empty. Use [`allow_all_hosts`](Builder::allow_all_hosts) to restore the default.
+	/// Will return an error if `list` is empty. Use [`allow_all_hosts`](Builder::allow_all_hosts) to restore the
+	/// default.
 	pub fn set_allowed_hosts<Host, List>(mut self, list: List) -> Result<Self, Error>
 	where
 		List: IntoIterator<Item = Host>,

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -57,8 +57,8 @@ async fn server() -> SocketAddr {
 /// It has the following methods:
 ///     sync methods: `say_hello` and `add`
 ///     async: `say_hello_async` and `add_sync`
-///     other: `invalid_params` (always returns `CallError::InvalidParams`), `call_fail` (always returns `CallError::Failed`), `sleep_for`
-/// Returns the address together with handles for server future and server stop.
+///     other: `invalid_params` (always returns `CallError::InvalidParams`), `call_fail` (always returns
+/// `CallError::Failed`), `sleep_for` Returns the address together with handles for server future and server stop.
 async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut module = RpcModule::new(());
@@ -435,7 +435,8 @@ async fn invalid_json_id_missing_value() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
-	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
+	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be
+	// Null.
 	assert_eq!(response, parse_error(Id::Null));
 }
 


### PR DESCRIPTION
One interesting rule is `format_code_in_doc_comments` but it's not stable yet so leaving that out for now.﻿
