### PR TITLE
Rename and reorg types

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,8 +6,8 @@ use jsonrpsee::{
 	types::traits::SubscriptionClient,
 	types::{
 		traits::Client,
-		v2::params::{Id, JsonRpcParams},
-		v2::request::JsonRpcCallSer,
+		v2::params::{Id, Params},
+		v2::request::CallSer,
 	},
 	ws_client::WsClientBuilder,
 };
@@ -55,7 +55,7 @@ impl RequestType {
 	}
 }
 
-fn v2_serialize(req: JsonRpcCallSer<'_>) -> String {
+fn v2_serialize(req: CallSer<'_>) -> String {
 	serde_json::to_string(&req).unwrap()
 }
 
@@ -63,16 +63,16 @@ pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
 	crit.bench_function("jsonrpsee_types_v2_array_ref", |b| {
 		b.iter(|| {
 			let params = &[1_u64.into(), 2_u32.into()];
-			let params = JsonRpcParams::ArrayRef(params);
-			let request = JsonRpcCallSer::new(Id::Number(0), "say_hello", params);
+			let params = Params::ArrayRef(params);
+			let request = CallSer::new(Id::Number(0), "say_hello", params);
 			v2_serialize(request);
 		})
 	});
 
 	crit.bench_function("jsonrpsee_types_v2_vec", |b| {
 		b.iter(|| {
-			let params = JsonRpcParams::Array(vec![1_u64.into(), 2_u32.into()]);
-			let request = JsonRpcCallSer::new(Id::Number(0), "say_hello", params);
+			let params = Params::Array(vec![1_u64.into(), 2_u32.into()]);
+			let request = CallSer::new(Id::Number(0), "say_hello", params);
 			v2_serialize(request);
 		})
 	});
@@ -138,7 +138,7 @@ impl RequestBencher for AsyncBencher {
 fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str, request: RequestType) {
 	crit.bench_function(&request.group_name(name), |b| {
 		b.to_async(rt).iter(|| async {
-			black_box(client.request::<String>(request.method_name(), JsonRpcParams::NoParams).await.unwrap());
+			black_box(client.request::<String>(request.method_name(), Params::NoParams).await.unwrap());
 		})
 	});
 }
@@ -148,7 +148,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 	group.bench_function("subscribe", |b| {
 		b.to_async(rt).iter_with_large_drop(|| async {
 			black_box(
-				client.subscribe::<String>(SUB_METHOD_NAME, JsonRpcParams::NoParams, UNSUB_METHOD_NAME).await.unwrap(),
+				client.subscribe::<String>(SUB_METHOD_NAME, Params::NoParams, UNSUB_METHOD_NAME).await.unwrap(),
 			);
 		})
 	});
@@ -160,7 +160,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 				tokio::task::block_in_place(|| {
 					tokio::runtime::Handle::current().block_on(async {
 						client
-							.subscribe::<String>(SUB_METHOD_NAME, JsonRpcParams::NoParams, UNSUB_METHOD_NAME)
+							.subscribe::<String>(SUB_METHOD_NAME, Params::NoParams, UNSUB_METHOD_NAME)
 							.await
 							.unwrap()
 					})
@@ -180,7 +180,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 			|| {
 				rt.block_on(async {
 					client
-						.subscribe::<String>(SUB_METHOD_NAME, JsonRpcParams::NoParams, UNSUB_METHOD_NAME)
+						.subscribe::<String>(SUB_METHOD_NAME, Params::NoParams, UNSUB_METHOD_NAME)
 						.await
 						.unwrap()
 				})
@@ -205,7 +205,7 @@ fn run_round_trip_with_batch(
 ) {
 	let mut group = crit.benchmark_group(request.group_name(name));
 	for batch_size in [2, 5, 10, 50, 100usize].iter() {
-		let batch = vec![(request.method_name(), JsonRpcParams::NoParams); *batch_size];
+		let batch = vec![(request.method_name(), Params::NoParams); *batch_size];
 		group.throughput(Throughput::Elements(*batch_size as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(batch_size), batch_size, |b, _| {
 			b.to_async(rt).iter(|| async { client.batch_request::<String>(batch.clone()).await.unwrap() })
@@ -230,7 +230,7 @@ fn run_concurrent_round_trip<C: 'static + Client + Send + Sync>(
 					let tasks = clients.map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), JsonRpcParams::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), Params::NoParams).await.unwrap(),
 							);
 						})
 					});
@@ -265,7 +265,7 @@ fn run_ws_concurrent_connections(rt: &TokioRuntime, crit: &mut Criterion, url: &
 					let tasks = clients.into_iter().map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), JsonRpcParams::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), Params::NoParams).await.unwrap(),
 							);
 						})
 					});
@@ -293,7 +293,7 @@ fn run_http_concurrent_connections(
 					let tasks = clients.map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), JsonRpcParams::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), Params::NoParams).await.unwrap(),
 							);
 						})
 					});

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,8 +6,8 @@ use jsonrpsee::{
 	types::traits::SubscriptionClient,
 	types::{
 		traits::Client,
-		v2::params::{Id, Params},
-		v2::request::CallSer,
+		v2::params::{Id, RpcParamsSer},
+		v2::request::RequestSer,
 	},
 	ws_client::WsClientBuilder,
 };
@@ -55,7 +55,7 @@ impl RequestType {
 	}
 }
 
-fn v2_serialize(req: CallSer<'_>) -> String {
+fn v2_serialize(req: RequestSer<'_>) -> String {
 	serde_json::to_string(&req).unwrap()
 }
 
@@ -63,16 +63,16 @@ pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
 	crit.bench_function("jsonrpsee_types_v2_array_ref", |b| {
 		b.iter(|| {
 			let params = &[1_u64.into(), 2_u32.into()];
-			let params = Params::ArrayRef(params);
-			let request = CallSer::new(Id::Number(0), "say_hello", params);
+			let params = RpcParamsSer::ArrayRef(params);
+			let request = RequestSer::new(Id::Number(0), "say_hello", params);
 			v2_serialize(request);
 		})
 	});
 
 	crit.bench_function("jsonrpsee_types_v2_vec", |b| {
 		b.iter(|| {
-			let params = Params::Array(vec![1_u64.into(), 2_u32.into()]);
-			let request = CallSer::new(Id::Number(0), "say_hello", params);
+			let params = RpcParamsSer::Array(vec![1_u64.into(), 2_u32.into()]);
+			let request = RequestSer::new(Id::Number(0), "say_hello", params);
 			v2_serialize(request);
 		})
 	});
@@ -138,7 +138,7 @@ impl RequestBencher for AsyncBencher {
 fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str, request: RequestType) {
 	crit.bench_function(&request.group_name(name), |b| {
 		b.to_async(rt).iter(|| async {
-			black_box(client.request::<String>(request.method_name(), Params::NoParams).await.unwrap());
+			black_box(client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap());
 		})
 	});
 }
@@ -148,7 +148,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 	group.bench_function("subscribe", |b| {
 		b.to_async(rt).iter_with_large_drop(|| async {
 			black_box(
-				client.subscribe::<String>(SUB_METHOD_NAME, Params::NoParams, UNSUB_METHOD_NAME).await.unwrap(),
+				client.subscribe::<String>(SUB_METHOD_NAME, RpcParamsSer::NoParams, UNSUB_METHOD_NAME).await.unwrap(),
 			);
 		})
 	});
@@ -160,7 +160,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 				tokio::task::block_in_place(|| {
 					tokio::runtime::Handle::current().block_on(async {
 						client
-							.subscribe::<String>(SUB_METHOD_NAME, Params::NoParams, UNSUB_METHOD_NAME)
+							.subscribe::<String>(SUB_METHOD_NAME, RpcParamsSer::NoParams, UNSUB_METHOD_NAME)
 							.await
 							.unwrap()
 					})
@@ -180,7 +180,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 			|| {
 				rt.block_on(async {
 					client
-						.subscribe::<String>(SUB_METHOD_NAME, Params::NoParams, UNSUB_METHOD_NAME)
+						.subscribe::<String>(SUB_METHOD_NAME, RpcParamsSer::NoParams, UNSUB_METHOD_NAME)
 						.await
 						.unwrap()
 				})
@@ -205,7 +205,7 @@ fn run_round_trip_with_batch(
 ) {
 	let mut group = crit.benchmark_group(request.group_name(name));
 	for batch_size in [2, 5, 10, 50, 100usize].iter() {
-		let batch = vec![(request.method_name(), Params::NoParams); *batch_size];
+		let batch = vec![(request.method_name(), RpcParamsSer::NoParams); *batch_size];
 		group.throughput(Throughput::Elements(*batch_size as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(batch_size), batch_size, |b, _| {
 			b.to_async(rt).iter(|| async { client.batch_request::<String>(batch.clone()).await.unwrap() })
@@ -230,7 +230,7 @@ fn run_concurrent_round_trip<C: 'static + Client + Send + Sync>(
 					let tasks = clients.map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), Params::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap(),
 							);
 						})
 					});
@@ -265,7 +265,7 @@ fn run_ws_concurrent_connections(rt: &TokioRuntime, crit: &mut Criterion, url: &
 					let tasks = clients.into_iter().map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), Params::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap(),
 							);
 						})
 					});
@@ -293,7 +293,7 @@ fn run_http_concurrent_connections(
 					let tasks = clients.map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), Params::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap(),
 							);
 						})
 					});

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,7 +6,7 @@ use jsonrpsee::{
 	types::traits::SubscriptionClient,
 	types::{
 		traits::Client,
-		v2::params::{Id, RpcParamsSer},
+		v2::params::{Id, ParamsSer},
 		v2::request::RequestSer,
 	},
 	ws_client::WsClientBuilder,
@@ -63,7 +63,7 @@ pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
 	crit.bench_function("jsonrpsee_types_v2_array_ref", |b| {
 		b.iter(|| {
 			let params = &[1_u64.into(), 2_u32.into()];
-			let params = RpcParamsSer::ArrayRef(params);
+			let params = ParamsSer::ArrayRef(params);
 			let request = RequestSer::new(Id::Number(0), "say_hello", params);
 			v2_serialize(request);
 		})
@@ -71,7 +71,7 @@ pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
 
 	crit.bench_function("jsonrpsee_types_v2_vec", |b| {
 		b.iter(|| {
-			let params = RpcParamsSer::Array(vec![1_u64.into(), 2_u32.into()]);
+			let params = ParamsSer::Array(vec![1_u64.into(), 2_u32.into()]);
 			let request = RequestSer::new(Id::Number(0), "say_hello", params);
 			v2_serialize(request);
 		})
@@ -138,7 +138,7 @@ impl RequestBencher for AsyncBencher {
 fn run_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Client>, name: &str, request: RequestType) {
 	crit.bench_function(&request.group_name(name), |b| {
 		b.to_async(rt).iter(|| async {
-			black_box(client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap());
+			black_box(client.request::<String>(request.method_name(), ParamsSer::NoParams).await.unwrap());
 		})
 	});
 }
@@ -148,7 +148,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 	group.bench_function("subscribe", |b| {
 		b.to_async(rt).iter_with_large_drop(|| async {
 			black_box(
-				client.subscribe::<String>(SUB_METHOD_NAME, RpcParamsSer::NoParams, UNSUB_METHOD_NAME).await.unwrap(),
+				client.subscribe::<String>(SUB_METHOD_NAME, ParamsSer::NoParams, UNSUB_METHOD_NAME).await.unwrap(),
 			);
 		})
 	});
@@ -160,7 +160,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 				tokio::task::block_in_place(|| {
 					tokio::runtime::Handle::current().block_on(async {
 						client
-							.subscribe::<String>(SUB_METHOD_NAME, RpcParamsSer::NoParams, UNSUB_METHOD_NAME)
+							.subscribe::<String>(SUB_METHOD_NAME, ParamsSer::NoParams, UNSUB_METHOD_NAME)
 							.await
 							.unwrap()
 					})
@@ -179,10 +179,7 @@ fn run_sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl 
 		b.iter_with_setup(
 			|| {
 				rt.block_on(async {
-					client
-						.subscribe::<String>(SUB_METHOD_NAME, RpcParamsSer::NoParams, UNSUB_METHOD_NAME)
-						.await
-						.unwrap()
+					client.subscribe::<String>(SUB_METHOD_NAME, ParamsSer::NoParams, UNSUB_METHOD_NAME).await.unwrap()
 				})
 			},
 			|sub| {
@@ -205,7 +202,7 @@ fn run_round_trip_with_batch(
 ) {
 	let mut group = crit.benchmark_group(request.group_name(name));
 	for batch_size in [2, 5, 10, 50, 100usize].iter() {
-		let batch = vec![(request.method_name(), RpcParamsSer::NoParams); *batch_size];
+		let batch = vec![(request.method_name(), ParamsSer::NoParams); *batch_size];
 		group.throughput(Throughput::Elements(*batch_size as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(batch_size), batch_size, |b, _| {
 			b.to_async(rt).iter(|| async { client.batch_request::<String>(batch.clone()).await.unwrap() })
@@ -230,7 +227,7 @@ fn run_concurrent_round_trip<C: 'static + Client + Send + Sync>(
 					let tasks = clients.map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), ParamsSer::NoParams).await.unwrap(),
 							);
 						})
 					});
@@ -265,7 +262,7 @@ fn run_ws_concurrent_connections(rt: &TokioRuntime, crit: &mut Criterion, url: &
 					let tasks = clients.into_iter().map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), ParamsSer::NoParams).await.unwrap(),
 							);
 						})
 					});
@@ -293,7 +290,7 @@ fn run_http_concurrent_connections(
 					let tasks = clients.map(|client| {
 						rt.spawn(async move {
 							let _ = black_box(
-								client.request::<String>(request.method_name(), RpcParamsSer::NoParams).await.unwrap(),
+								client.request::<String>(request.method_name(), ParamsSer::NoParams).await.unwrap(),
 							);
 						})
 					});

--- a/examples/weather.rs
+++ b/examples/weather.rs
@@ -31,7 +31,7 @@
 //! mutation.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::RpcParamsSer},
+	types::{traits::SubscriptionClient, v2::params::ParamsSer},
 	ws_client::WsClientBuilder,
 	ws_server::RpcModule,
 	ws_server::WsServerBuilder,
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription to the London weather
-	let params = RpcParamsSer::Array(vec!["London,uk".into(), "metric".into()]);
+	let params = ParamsSer::Array(vec!["London,uk".into(), "metric".into()]);
 	let mut weather_sub = client.subscribe::<Weather>("weather_sub", params, "weather_unsub").await?;
 	while let Ok(Some(w)) = weather_sub.next().await {
 		println!("[client] London weather: {:?}", w);

--- a/examples/weather.rs
+++ b/examples/weather.rs
@@ -31,7 +31,7 @@
 //! mutation.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::JsonRpcParams},
+	types::{traits::SubscriptionClient, v2::params::Params},
 	ws_client::WsClientBuilder,
 	ws_server::RpcModule,
 	ws_server::WsServerBuilder,
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription to the London weather
-	let params = JsonRpcParams::Array(vec!["London,uk".into(), "metric".into()]);
+	let params = Params::Array(vec!["London,uk".into(), "metric".into()]);
 	let mut weather_sub = client.subscribe::<Weather>("weather_sub", params, "weather_unsub").await?;
 	while let Ok(Some(w)) = weather_sub.next().await {
 		println!("[client] London weather: {:?}", w);

--- a/examples/weather.rs
+++ b/examples/weather.rs
@@ -31,7 +31,7 @@
 //! mutation.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::Params},
+	types::{traits::SubscriptionClient, v2::params::RpcParamsSer},
 	ws_client::WsClientBuilder,
 	ws_server::RpcModule,
 	ws_server::WsServerBuilder,
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription to the London weather
-	let params = Params::Array(vec!["London,uk".into(), "metric".into()]);
+	let params = RpcParamsSer::Array(vec!["London,uk".into(), "metric".into()]);
 	let mut weather_sub = client.subscribe::<Weather>("weather_sub", params, "weather_unsub").await?;
 	while let Ok(Some(w)) = weather_sub.next().await {
 		println!("[client] London weather: {:?}", w);

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::Client, v2::params::RpcParamsSer},
+	types::{traits::Client, v2::params::ParamsSer},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
 	let url = format!("ws://{}", addr);
 
 	let client = WsClientBuilder::default().build(&url).await?;
-	let response: String = client.request("say_hello", RpcParamsSer::NoParams).await?;
+	let response: String = client.request("say_hello", ParamsSer::NoParams).await?;
 	println!("r: {:?}", response);
 
 	Ok(())

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::Client, v2::params::JsonRpcParams},
+	types::{traits::Client, v2::params::Params},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
 	let url = format!("ws://{}", addr);
 
 	let client = WsClientBuilder::default().build(&url).await?;
-	let response: String = client.request("say_hello", JsonRpcParams::NoParams).await?;
+	let response: String = client.request("say_hello", Params::NoParams).await?;
 	println!("r: {:?}", response);
 
 	Ok(())

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::Client, v2::params::Params},
+	types::{traits::Client, v2::params::RpcParamsSer},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
 	let url = format!("ws://{}", addr);
 
 	let client = WsClientBuilder::default().build(&url).await?;
-	let response: String = client.request("say_hello", Params::NoParams).await?;
+	let response: String = client.request("say_hello", RpcParamsSer::NoParams).await?;
 	println!("r: {:?}", response);
 
 	Ok(())

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::JsonRpcParams},
+	types::{traits::SubscriptionClient, v2::params::Params},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -40,12 +40,12 @@ async fn main() -> anyhow::Result<()> {
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription with a single parameter
-	let params = JsonRpcParams::Array(vec![3.into()]);
+	let params = Params::Array(vec![3.into()]);
 	let mut sub_params_one = client.subscribe::<Option<char>>("sub_one_param", params, "unsub_one_param").await?;
 	println!("subscription with one param: {:?}", sub_params_one.next().await);
 
 	// Subscription with multiple parameters
-	let params = JsonRpcParams::Array(vec![2.into(), 5.into()]);
+	let params = Params::Array(vec![2.into(), 5.into()]);
 	let mut sub_params_two = client.subscribe::<String>("sub_params_two", params, "unsub_params_two").await?;
 	println!("subscription with two params: {:?}", sub_params_two.next().await);
 

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::Params},
+	types::{traits::SubscriptionClient, v2::params::RpcParamsSer},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -40,12 +40,12 @@ async fn main() -> anyhow::Result<()> {
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription with a single parameter
-	let params = Params::Array(vec![3.into()]);
+	let params = RpcParamsSer::Array(vec![3.into()]);
 	let mut sub_params_one = client.subscribe::<Option<char>>("sub_one_param", params, "unsub_one_param").await?;
 	println!("subscription with one param: {:?}", sub_params_one.next().await);
 
 	// Subscription with multiple parameters
-	let params = Params::Array(vec![2.into(), 5.into()]);
+	let params = RpcParamsSer::Array(vec![2.into(), 5.into()]);
 	let mut sub_params_two = client.subscribe::<String>("sub_params_two", params, "unsub_params_two").await?;
 	println!("subscription with two params: {:?}", sub_params_two.next().await);
 

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::RpcParamsSer},
+	types::{traits::SubscriptionClient, v2::params::ParamsSer},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -40,12 +40,12 @@ async fn main() -> anyhow::Result<()> {
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription with a single parameter
-	let params = RpcParamsSer::Array(vec![3.into()]);
+	let params = ParamsSer::Array(vec![3.into()]);
 	let mut sub_params_one = client.subscribe::<Option<char>>("sub_one_param", params, "unsub_one_param").await?;
 	println!("subscription with one param: {:?}", sub_params_one.next().await);
 
 	// Subscription with multiple parameters
-	let params = RpcParamsSer::Array(vec![2.into(), 5.into()]);
+	let params = ParamsSer::Array(vec![2.into(), 5.into()]);
 	let mut sub_params_two = client.subscribe::<String>("sub_params_two", params, "unsub_params_two").await?;
 	println!("subscription with two params: {:?}", sub_params_two.next().await);
 

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::Params, Error, Subscription},
+	types::{traits::SubscriptionClient, v2::params::RpcParamsSer, Error, Subscription},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 
 	let client = WsClientBuilder::default().build(&url).await?;
 	let mut subscribe_hello: Subscription<String> =
-		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await?;
+		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await?;
 
 	let mut i = 0;
 	while i <= NUM_SUBSCRIPTION_RESPONSES {

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::RpcParamsSer, Error, Subscription},
+	types::{traits::SubscriptionClient, v2::params::ParamsSer, Error, Subscription},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 
 	let client = WsClientBuilder::default().build(&url).await?;
 	let mut subscribe_hello: Subscription<String> =
-		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await?;
+		client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await?;
 
 	let mut i = 0;
 	while i <= NUM_SUBSCRIPTION_RESPONSES {

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::params::JsonRpcParams, Error, Subscription},
+	types::{traits::SubscriptionClient, v2::params::Params, Error, Subscription},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 
 	let client = WsClientBuilder::default().build(&url).await?;
 	let mut subscribe_hello: Subscription<String> =
-		client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await?;
+		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await?;
 
 	let mut i = 0;
 	while i <= NUM_SUBSCRIPTION_RESPONSES {

--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -29,7 +29,7 @@ use crate::types::{
 	traits::Client,
 	v2::{
 		error::RpcError,
-		params::{Id, RpcParamsSer},
+		params::{Id, ParamsSer},
 		request::{NotificationSer, RequestSer},
 		response::Response,
 	},
@@ -88,7 +88,7 @@ pub struct HttpClient {
 
 #[async_trait]
 impl Client for HttpClient {
-	async fn notification<'a>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<(), Error> {
+	async fn notification<'a>(&self, method: &'a str, params: ParamsSer<'a>) -> Result<(), Error> {
 		let notif = NotificationSer::new(method, params);
 		let fut = self.transport.send(serde_json::to_string(&notif).map_err(Error::ParseError)?);
 		match tokio::time::timeout(self.request_timeout, fut).await {
@@ -99,7 +99,7 @@ impl Client for HttpClient {
 	}
 
 	/// Perform a request towards the server.
-	async fn request<'a, R>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<R, Error>
+	async fn request<'a, R>(&self, method: &'a str, params: ParamsSer<'a>) -> Result<R, Error>
 	where
 		R: DeserializeOwned,
 	{
@@ -131,7 +131,7 @@ impl Client for HttpClient {
 		}
 	}
 
-	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, RpcParamsSer<'a>)>) -> Result<Vec<R>, Error>
+	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, ParamsSer<'a>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone,
 	{

--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -30,7 +30,7 @@ use crate::types::{
 	v2::{
 		error::RpcError,
 		params::{Id, RpcParamsSer},
-		request::{RequestSer, NotificationSer},
+		request::{NotificationSer, RequestSer},
 		response::Response,
 	},
 	Error, TEN_MB_SIZE_BYTES,

--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -28,10 +28,10 @@ use crate::transport::HttpTransportClient;
 use crate::types::{
 	traits::Client,
 	v2::{
-		error::JsonRpcError,
-		params::{Id, JsonRpcParams},
-		request::{JsonRpcCallSer, JsonRpcNotificationSer},
-		response::JsonRpcResponse,
+		error::RpcError,
+		params::{Id, Params},
+		request::{CallSer, NotificationSer},
+		response::Response,
 	},
 	Error, TEN_MB_SIZE_BYTES,
 };
@@ -88,8 +88,8 @@ pub struct HttpClient {
 
 #[async_trait]
 impl Client for HttpClient {
-	async fn notification<'a>(&self, method: &'a str, params: JsonRpcParams<'a>) -> Result<(), Error> {
-		let notif = JsonRpcNotificationSer::new(method, params);
+	async fn notification<'a>(&self, method: &'a str, params: Params<'a>) -> Result<(), Error> {
+		let notif = NotificationSer::new(method, params);
 		let fut = self.transport.send(serde_json::to_string(&notif).map_err(Error::ParseError)?);
 		match tokio::time::timeout(self.request_timeout, fut).await {
 			Ok(Ok(ok)) => Ok(ok),
@@ -99,13 +99,13 @@ impl Client for HttpClient {
 	}
 
 	/// Perform a request towards the server.
-	async fn request<'a, R>(&self, method: &'a str, params: JsonRpcParams<'a>) -> Result<R, Error>
+	async fn request<'a, R>(&self, method: &'a str, params: Params<'a>) -> Result<R, Error>
 	where
 		R: DeserializeOwned,
 	{
 		// NOTE: `fetch_add` wraps on overflow which is intended.
 		let id = self.request_id.fetch_add(1, Ordering::SeqCst);
-		let request = JsonRpcCallSer::new(Id::Number(id), method, params);
+		let request = CallSer::new(Id::Number(id), method, params);
 
 		let fut = self.transport.send_and_read_body(serde_json::to_string(&request).map_err(Error::ParseError)?);
 		let body = match tokio::time::timeout(self.request_timeout, fut).await {
@@ -114,10 +114,10 @@ impl Client for HttpClient {
 			Ok(Err(e)) => return Err(Error::Transport(e.into())),
 		};
 
-		let response: JsonRpcResponse<_> = match serde_json::from_slice(&body) {
+		let response: Response<_> = match serde_json::from_slice(&body) {
 			Ok(response) => response,
 			Err(_) => {
-				let err: JsonRpcError = serde_json::from_slice(&body).map_err(Error::ParseError)?;
+				let err: RpcError = serde_json::from_slice(&body).map_err(Error::ParseError)?;
 				return Err(Error::Request(err.to_string()));
 			}
 		};
@@ -131,7 +131,7 @@ impl Client for HttpClient {
 		}
 	}
 
-	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, JsonRpcParams<'a>)>) -> Result<Vec<R>, Error>
+	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, Params<'a>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone,
 	{
@@ -142,7 +142,7 @@ impl Client for HttpClient {
 
 		for (pos, (method, params)) in batch.into_iter().enumerate() {
 			let id = self.request_id.fetch_add(1, Ordering::SeqCst);
-			batch_request.push(JsonRpcCallSer::new(Id::Number(id), method, params));
+			batch_request.push(CallSer::new(Id::Number(id), method, params));
 			ordered_requests.push(id);
 			request_set.insert(id, pos);
 		}
@@ -155,10 +155,10 @@ impl Client for HttpClient {
 			Ok(Err(e)) => return Err(Error::Transport(e.into())),
 		};
 
-		let rps: Vec<JsonRpcResponse<_>> = match serde_json::from_slice(&body) {
+		let rps: Vec<Response<_>> = match serde_json::from_slice(&body) {
 			Ok(response) => response,
 			Err(_) => {
-				let err: JsonRpcError = serde_json::from_slice(&body).map_err(Error::ParseError)?;
+				let err: RpcError = serde_json::from_slice(&body).map_err(Error::ParseError)?;
 				return Err(Error::Request(err.to_string()));
 			}
 		};

--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -27,8 +27,8 @@
 use crate::types::{
 	traits::Client,
 	v2::{
-		error::{RpcError, JsonRpcErrorCode, JsonRpcErrorObject},
-		params::Params,
+		error::{RpcError, ErrorCode, ErrorObject},
+		params::RpcParamsSer,
 	},
 	Error, JsonValue,
 };
@@ -53,7 +53,7 @@ async fn notification_works() {
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
 	client
-		.notification("i_dont_care_about_the_response_because_the_server_should_not_respond", Params::NoParams)
+		.notification("i_dont_care_about_the_response_because_the_server_should_not_respond", RpcParamsSer::NoParams)
 		.with_default_timeout()
 		.await
 		.unwrap()
@@ -74,34 +74,34 @@ async fn response_with_wrong_id() {
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, JsonRpcErrorCode::MethodNotFound.into());
+	assert_jsonrpc_error_response(err, ErrorCode::MethodNotFound.into());
 }
 
 #[tokio::test]
 async fn response_parse_error() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, JsonRpcErrorCode::ParseError.into());
+	assert_jsonrpc_error_response(err, ErrorCode::ParseError.into());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InvalidRequest.into());
+	assert_jsonrpc_error_response(err, ErrorCode::InvalidRequest.into());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InvalidParams.into());
+	assert_jsonrpc_error_response(err, ErrorCode::InvalidParams.into());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, JsonRpcErrorCode::InternalError.into());
+	assert_jsonrpc_error_response(err, ErrorCode::InternalError.into());
 }
 
 #[tokio::test]
@@ -114,9 +114,9 @@ async fn subscription_response_to_request() {
 #[tokio::test]
 async fn batch_request_works() {
 	let batch_request = vec![
-		("say_hello", Params::NoParams),
-		("say_goodbye", Params::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", Params::NoParams),
+		("say_hello", RpcParamsSer::NoParams),
+		("say_goodbye", RpcParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", RpcParamsSer::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}, {"jsonrpc":"2.0","result":"here's your swag","id":2}]"#.to_string();
 	let response =
@@ -127,9 +127,9 @@ async fn batch_request_works() {
 #[tokio::test]
 async fn batch_request_out_of_order_response() {
 	let batch_request = vec![
-		("say_hello", Params::NoParams),
-		("say_goodbye", Params::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", Params::NoParams),
+		("say_hello", RpcParamsSer::NoParams),
+		("say_goodbye", RpcParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", RpcParamsSer::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"here's your swag","id":2}, {"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}]"#.to_string();
 	let response =
@@ -138,7 +138,7 @@ async fn batch_request_out_of_order_response() {
 }
 
 async fn run_batch_request_with_response<'a>(
-	batch: Vec<(&'a str, Params<'a>)>,
+	batch: Vec<(&'a str, RpcParamsSer<'a>)>,
 	response: String,
 ) -> Result<Vec<String>, Error> {
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
@@ -151,10 +151,10 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
-	client.request("say_hello", Params::NoParams).with_default_timeout().await.unwrap()
+	client.request("say_hello", RpcParamsSer::NoParams).with_default_timeout().await.unwrap()
 }
 
-fn assert_jsonrpc_error_response(err: Error, exp: JsonRpcErrorObject) {
+fn assert_jsonrpc_error_response(err: Error, exp: ErrorObject) {
 	match &err {
 		Error::Request(e) => {
 			let this: RpcError = serde_json::from_str(e).unwrap();

--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -28,7 +28,7 @@ use crate::types::{
 	traits::Client,
 	v2::{
 		error::{ErrorCode, ErrorObject, RpcError},
-		params::RpcParamsSer,
+		params::ParamsSer,
 	},
 	Error, JsonValue,
 };
@@ -53,7 +53,7 @@ async fn notification_works() {
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
 	client
-		.notification("i_dont_care_about_the_response_because_the_server_should_not_respond", RpcParamsSer::NoParams)
+		.notification("i_dont_care_about_the_response_because_the_server_should_not_respond", ParamsSer::NoParams)
 		.with_default_timeout()
 		.await
 		.unwrap()
@@ -114,9 +114,9 @@ async fn subscription_response_to_request() {
 #[tokio::test]
 async fn batch_request_works() {
 	let batch_request = vec![
-		("say_hello", RpcParamsSer::NoParams),
-		("say_goodbye", RpcParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", RpcParamsSer::NoParams),
+		("say_hello", ParamsSer::NoParams),
+		("say_goodbye", ParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", ParamsSer::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}, {"jsonrpc":"2.0","result":"here's your swag","id":2}]"#.to_string();
 	let response =
@@ -127,9 +127,9 @@ async fn batch_request_works() {
 #[tokio::test]
 async fn batch_request_out_of_order_response() {
 	let batch_request = vec![
-		("say_hello", RpcParamsSer::NoParams),
-		("say_goodbye", RpcParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", RpcParamsSer::NoParams),
+		("say_hello", ParamsSer::NoParams),
+		("say_goodbye", ParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", ParamsSer::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"here's your swag","id":2}, {"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}]"#.to_string();
 	let response =
@@ -138,7 +138,7 @@ async fn batch_request_out_of_order_response() {
 }
 
 async fn run_batch_request_with_response<'a>(
-	batch: Vec<(&'a str, RpcParamsSer<'a>)>,
+	batch: Vec<(&'a str, ParamsSer<'a>)>,
 	response: String,
 ) -> Result<Vec<String>, Error> {
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
@@ -151,7 +151,7 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
-	client.request("say_hello", RpcParamsSer::NoParams).with_default_timeout().await.unwrap()
+	client.request("say_hello", ParamsSer::NoParams).with_default_timeout().await.unwrap()
 }
 
 fn assert_jsonrpc_error_response(err: Error, exp: ErrorObject) {

--- a/http-client/src/tests.rs
+++ b/http-client/src/tests.rs
@@ -27,7 +27,7 @@
 use crate::types::{
 	traits::Client,
 	v2::{
-		error::{RpcError, ErrorCode, ErrorObject},
+		error::{ErrorCode, ErrorObject, RpcError},
 		params::RpcParamsSer,
 	},
 	Error, JsonValue,

--- a/http-server/src/response.rs
+++ b/http-server/src/response.rs
@@ -27,7 +27,7 @@
 //! Contains common builders for hyper responses.
 
 use crate::types::v2::{
-	error::{RpcError, ErrorCode},
+	error::{ErrorCode, RpcError},
 	params::{Id, TwoPointZero},
 };
 
@@ -92,12 +92,9 @@ pub fn too_large() -> hyper::Response<hyper::Body> {
 
 /// Create a json response for empty or malformed requests (400)
 pub fn malformed() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&RpcError {
-		jsonrpc: TwoPointZero,
-		error: ErrorCode::ParseError.into(),
-		id: Id::Null,
-	})
-	.expect("built from known-good data; qed");
+	let error =
+		serde_json::to_string(&RpcError { jsonrpc: TwoPointZero, error: ErrorCode::ParseError.into(), id: Id::Null })
+			.expect("built from known-good data; qed");
 
 	from_template(hyper::StatusCode::BAD_REQUEST, error, JSON)
 }

--- a/http-server/src/response.rs
+++ b/http-server/src/response.rs
@@ -27,7 +27,7 @@
 //! Contains common builders for hyper responses.
 
 use crate::types::v2::{
-	error::{JsonRpcError, JsonRpcErrorCode},
+	error::{RpcError, JsonRpcErrorCode},
 	params::{Id, TwoPointZero},
 };
 
@@ -36,7 +36,7 @@ const TEXT: &str = "text/plain";
 
 /// Create a response for json internal error.
 pub fn internal_error() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&JsonRpcError {
+	let error = serde_json::to_string(&RpcError {
 		jsonrpc: TwoPointZero,
 		error: JsonRpcErrorCode::InternalError.into(),
 		id: Id::Null,
@@ -80,7 +80,7 @@ pub fn invalid_allow_headers() -> hyper::Response<hyper::Body> {
 
 /// Create a json response for oversized requests (413)
 pub fn too_large() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&JsonRpcError {
+	let error = serde_json::to_string(&RpcError {
 		jsonrpc: TwoPointZero,
 		error: JsonRpcErrorCode::OversizedRequest.into(),
 		id: Id::Null,
@@ -92,7 +92,7 @@ pub fn too_large() -> hyper::Response<hyper::Body> {
 
 /// Create a json response for empty or malformed requests (400)
 pub fn malformed() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&JsonRpcError {
+	let error = serde_json::to_string(&RpcError {
 		jsonrpc: TwoPointZero,
 		error: JsonRpcErrorCode::ParseError.into(),
 		id: Id::Null,

--- a/http-server/src/response.rs
+++ b/http-server/src/response.rs
@@ -27,7 +27,7 @@
 //! Contains common builders for hyper responses.
 
 use crate::types::v2::{
-	error::{RpcError, JsonRpcErrorCode},
+	error::{RpcError, ErrorCode},
 	params::{Id, TwoPointZero},
 };
 
@@ -38,7 +38,7 @@ const TEXT: &str = "text/plain";
 pub fn internal_error() -> hyper::Response<hyper::Body> {
 	let error = serde_json::to_string(&RpcError {
 		jsonrpc: TwoPointZero,
-		error: JsonRpcErrorCode::InternalError.into(),
+		error: ErrorCode::InternalError.into(),
 		id: Id::Null,
 	})
 	.expect("built from known-good data; qed");
@@ -82,7 +82,7 @@ pub fn invalid_allow_headers() -> hyper::Response<hyper::Body> {
 pub fn too_large() -> hyper::Response<hyper::Body> {
 	let error = serde_json::to_string(&RpcError {
 		jsonrpc: TwoPointZero,
-		error: JsonRpcErrorCode::OversizedRequest.into(),
+		error: ErrorCode::OversizedRequest.into(),
 		id: Id::Null,
 	})
 	.expect("built from known-good data; qed");
@@ -94,7 +94,7 @@ pub fn too_large() -> hyper::Response<hyper::Body> {
 pub fn malformed() -> hyper::Response<hyper::Body> {
 	let error = serde_json::to_string(&RpcError {
 		jsonrpc: TwoPointZero,
-		error: JsonRpcErrorCode::ParseError.into(),
+		error: ErrorCode::ParseError.into(),
 		id: Id::Null,
 	})
 	.expect("built from known-good data; qed");

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -38,7 +38,7 @@ use jsonrpsee_types::{
 	v2::{
 		error::JsonRpcErrorCode,
 		params::Id,
-		request::{JsonRpcNotification, JsonRpcRequest},
+		request::{Notification, Request},
 	},
 	TEN_MB_SIZE_BYTES,
 };
@@ -216,11 +216,11 @@ impl Server {
 						// NOTE(niklasad1): it's a channel because it's needed for batch requests.
 						let (tx, mut rx) = mpsc::unbounded::<String>();
 
-						type Notif<'a> = JsonRpcNotification<'a, Option<&'a RawValue>>;
+						type Notif<'a> = Notification<'a, Option<&'a RawValue>>;
 
 						// Single request or notification
 						if is_single {
-							if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&body) {
+							if let Ok(req) = serde_json::from_slice::<Request>(&body) {
 								// NOTE: we don't need to track connection id on HTTP, so using hardcoded 0 here.
 								if let Some(fut) = methods.execute(&tx, req, 0) {
 									fut.await;
@@ -233,7 +233,7 @@ impl Server {
 							}
 
 						// Batch of requests or notifications
-						} else if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&body) {
+						} else if let Ok(batch) = serde_json::from_slice::<Vec<Request>>(&body) {
 							if !batch.is_empty() {
 								join_all(batch.into_iter().filter_map(|req| methods.execute(&tx, req, 0))).await;
 							} else {

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -36,7 +36,7 @@ use hyper::{
 use jsonrpsee_types::{
 	error::{Error, GenericTransportError},
 	v2::{
-		error::JsonRpcErrorCode,
+		error::ErrorCode,
 		params::Id,
 		request::{Notification, Request},
 	},
@@ -241,7 +241,7 @@ impl Server {
 								// Array with at least one value, the response from the Server MUST be a single
 								// Response object." – The Spec.
 								is_single = true;
-								send_error(Id::Null, &tx, JsonRpcErrorCode::InvalidRequest.into());
+								send_error(Id::Null, &tx, ErrorCode::InvalidRequest.into());
 							}
 						} else if let Ok(_batch) = serde_json::from_slice::<Vec<Notif>>(&body) {
 							return Ok::<_, HyperError>(response::ok_response("".into()));

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -70,15 +70,15 @@ fn find_jsonrpsee_crate(http_name: &str, ws_name: &str) -> Result<proc_macro2::T
 /// ### Example
 ///
 /// ```
-///  use jsonrpsee::{proc_macros::rpc, types::JsonRpcResult};
+///  use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 ///
 ///  #[rpc(client, server)]
 ///  pub trait RpcTrait<A, B, C> {
 ///    #[method(name = "call")]
-///    fn call(&self, a: A) -> JsonRpcResult<B>;
+///    fn call(&self, a: A) -> RpcResult<B>;
 ///
 ///    #[subscription(name = "sub", item = Vec<C>)]
-///    fn sub(&self) -> JsonRpcResult<()>;
+///    fn sub(&self) -> RpcResult<()>;
 ///  }
 /// ```
 ///

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -203,19 +203,19 @@ pub(crate) mod visitor;
 ///
 /// // RPC is put into a separate module to clearly show names of generated entities.
 /// mod rpc_impl {
-///     use jsonrpsee::{proc_macros::rpc, types::{async_trait, JsonRpcResult}, ws_server::SubscriptionSink};
+///     use jsonrpsee::{proc_macros::rpc, types::{async_trait, RpcResult}, ws_server::SubscriptionSink};
 ///
 ///     // Generate both server and client implementations, prepend all the methods with `foo_` prefix.
 ///     #[rpc(client, server, namespace = "foo")]
 ///     pub trait MyRpc {
 ///         #[method(name = "foo")]
-///         async fn async_method(&self, param_a: u8, param_b: String) -> JsonRpcResult<u16>;
+///         async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 ///
 ///         #[method(name = "bar")]
-///         fn sync_method(&self) -> JsonRpcResult<u16>;
+///         fn sync_method(&self) -> RpcResult<u16>;
 ///
 ///         #[subscription(name = "sub", item = String)]
-///         fn sub(&self) -> JsonRpcResult<()>;
+///         fn sub(&self) -> RpcResult<()>;
 ///     }
 ///
 ///     // Structure that will implement the `MyRpcServer` trait.
@@ -225,18 +225,18 @@ pub(crate) mod visitor;
 ///     // Note that the trait name we use is `MyRpcServer`, not `MyRpc`!
 ///     #[async_trait]
 ///     impl MyRpcServer for RpcServerImpl {
-///         async fn async_method(&self, _param_a: u8, _param_b: String) -> JsonRpcResult<u16> {
+///         async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 ///             Ok(42u16)
 ///         }
 ///
-///         fn sync_method(&self) -> JsonRpcResult<u16> {
+///         fn sync_method(&self) -> RpcResult<u16> {
 ///             Ok(10u16)
 ///         }
 ///
 ///         // We could've spawned a `tokio` future that yields values while our program works,
 ///         // but for simplicity of the example we will only send two values and then close
 ///         // the subscription.
-///         fn sub(&self, mut sink: SubscriptionSink) -> JsonRpcResult<()> {
+///         fn sub(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
 ///             sink.send(&"Response_A")?;
 ///             sink.send(&"Response_B")
 ///         }

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -104,7 +104,7 @@ impl RpcDescription {
 				vec![ #(#params),* ].into()
 			}
 		} else {
-			self.jrps_client_item(quote! { types::v2::params::Params::NoParams })
+			self.jrps_client_item(quote! { types::v2::params::RpcParamsSer::NoParams })
 		};
 
 		// Doc-comment to be associated with the method.
@@ -147,7 +147,7 @@ impl RpcDescription {
 				vec![ #(#params),* ].into()
 			}
 		} else {
-			self.jrps_client_item(quote! { types::v2::params::Params::NoParams })
+			self.jrps_client_item(quote! { types::v2::params::RpcParamsSer::NoParams })
 		};
 
 		// Doc-comment to be associated with the method.

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -74,7 +74,7 @@ impl RpcDescription {
 		let jrps_error = self.jrps_client_item(quote! { types::Error });
 		// Rust method to invoke (e.g. `self.<foo>(...)`).
 		let rust_method_name = &method.signature.sig.ident;
-		// List of inputs to put into `JsonRpcParams` (e.g. `self.foo(<12, "baz">)`).
+		// List of inputs to put into `Params` (e.g. `self.foo(<12, "baz">)`).
 		// Includes `&self` receiver.
 		let rust_method_params = &method.signature.sig.inputs;
 		// Name of the RPC method (e.g. `foo_makeSpam`).
@@ -104,7 +104,7 @@ impl RpcDescription {
 				vec![ #(#params),* ].into()
 			}
 		} else {
-			self.jrps_client_item(quote! { types::v2::params::JsonRpcParams::NoParams })
+			self.jrps_client_item(quote! { types::v2::params::Params::NoParams })
 		};
 
 		// Doc-comment to be associated with the method.
@@ -124,7 +124,7 @@ impl RpcDescription {
 		let jrps_error = self.jrps_client_item(quote! { types::Error });
 		// Rust method to invoke (e.g. `self.<foo>(...)`).
 		let rust_method_name = &sub.signature.sig.ident;
-		// List of inputs to put into `JsonRpcParams` (e.g. `self.foo(<12, "baz">)`).
+		// List of inputs to put into `Params` (e.g. `self.foo(<12, "baz">)`).
 		let rust_method_params = &sub.signature.sig.inputs;
 		// Name of the RPC subscription (e.g. `foo_sub`).
 		let rpc_sub_name = self.rpc_identifier(&sub.name);
@@ -147,7 +147,7 @@ impl RpcDescription {
 				vec![ #(#params),* ].into()
 			}
 		} else {
-			self.jrps_client_item(quote! { types::v2::params::JsonRpcParams::NoParams })
+			self.jrps_client_item(quote! { types::v2::params::Params::NoParams })
 		};
 
 		// Doc-comment to be associated with the method.

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -104,7 +104,7 @@ impl RpcDescription {
 				vec![ #(#params),* ].into()
 			}
 		} else {
-			self.jrps_client_item(quote! { types::v2::params::RpcParamsSer::NoParams })
+			self.jrps_client_item(quote! { types::v2::params::ParamsSer::NoParams })
 		};
 
 		// Doc-comment to be associated with the method.
@@ -147,7 +147,7 @@ impl RpcDescription {
 				vec![ #(#params),* ].into()
 			}
 		} else {
-			self.jrps_client_item(quote! { types::v2::params::RpcParamsSer::NoParams })
+			self.jrps_client_item(quote! { types::v2::params::ParamsSer::NoParams })
 		};
 
 		// Doc-comment to be associated with the method.

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -120,7 +120,7 @@ impl RpcDescription {
 				// Name of the RPC method (e.g. `foo_makeSpam`).
 				let rpc_method_name = self.rpc_identifier(&method.name);
 				// `parsing` is the code associated with parsing structure from the
-				// provided `RpcParams` object.
+				// provided `Params` object.
 				// `params_seq` is the comma-delimited sequence of parameters.
 				let (parsing, params_seq) = self.render_params_decoding(&method.params);
 
@@ -158,7 +158,7 @@ impl RpcDescription {
 				// Name of the RPC method to unsubscribe (e.g. `foo_sub`).
 				let rpc_unsub_name = self.rpc_identifier(&sub.unsubscribe);
 				// `parsing` is the code associated with parsing structure from the
-				// provided `RpcParams` object.
+				// provided `Params` object.
 				// `params_seq` is the comma-delimited sequence of parameters.
 				let (parsing, params_seq) = self.render_params_decoding(&sub.params);
 

--- a/proc-macros/tests/ui/correct/alias_doesnt_use_namespace.rs
+++ b/proc-macros/tests/ui/correct/alias_doesnt_use_namespace.rs
@@ -1,13 +1,13 @@
-use jsonrpsee::{proc_macros::rpc, types::JsonRpcResult};
+use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 
 #[rpc(client, server, namespace = "myapi")]
 pub trait Rpc {
 	/// Alias doesn't use the namespace so not duplicated.
 	#[method(name = "getTemp", aliases = "getTemp")]
-	async fn async_method(&self, param_a: u8, param_b: String) -> JsonRpcResult<u16>;
+	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[subscription(name = "getFood", item = String, aliases = "getFood", unsubscribe_aliases = "unsubscribegetFood")]
-	fn sub(&self) -> JsonRpcResult<()>;
+	fn sub(&self) -> RpcResult<()>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -2,7 +2,7 @@
 
 use jsonrpsee::{
 	proc_macros::rpc,
-	types::{async_trait, to_json_value, traits::Client, v2::params::RpcParamsSer, RpcResult},
+	types::{async_trait, to_json_value, traits::Client, v2::params::ParamsSer, RpcResult},
 	ws_client::*,
 	ws_server::{SubscriptionSink, WsServerBuilder},
 };
@@ -107,7 +107,7 @@ async fn main() {
 	);
 
 	assert_eq!(client.request::<bool>("foo_optional_param", vec![].into()).await.unwrap(), false);
-	assert_eq!(client.request::<bool>("foo_optional_param", RpcParamsSer::NoParams).await.unwrap(), false);
+	assert_eq!(client.request::<bool>("foo_optional_param", ParamsSer::NoParams).await.unwrap(), false);
 	assert_eq!(
 		client.request::<bool>("foo_optional_param", vec![to_json_value(Some(1)).unwrap()].into()).await.unwrap(),
 		true

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -2,7 +2,7 @@
 
 use jsonrpsee::{
 	proc_macros::rpc,
-	types::{async_trait, to_json_value, traits::Client, v2::params::JsonRpcParams, JsonRpcResult},
+	types::{async_trait, to_json_value, traits::Client, v2::params::RpcParamsSer, RpcResult},
 	ws_client::*,
 	ws_server::{SubscriptionSink, WsServerBuilder},
 };
@@ -11,59 +11,59 @@ use std::{net::SocketAddr, sync::mpsc::channel};
 #[rpc(client, server, namespace = "foo")]
 pub trait Rpc {
 	#[method(name = "foo", aliases = "fooAlias, Other")]
-	async fn async_method(&self, param_a: u8, param_b: String) -> JsonRpcResult<u16>;
+	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name = "optional_params")]
-	async fn optional_params(&self, a: std::option::Option<u8>, b: String) -> JsonRpcResult<bool>;
+	async fn optional_params(&self, a: std::option::Option<u8>, b: String) -> RpcResult<bool>;
 
 	#[method(name = "optional_param")]
-	async fn optional_param(&self, a: Option<u8>) -> JsonRpcResult<bool>;
+	async fn optional_param(&self, a: Option<u8>) -> RpcResult<bool>;
 
 	#[method(name = "array_params")]
-	async fn array_params(&self, items: Vec<u64>) -> JsonRpcResult<u64>;
+	async fn array_params(&self, items: Vec<u64>) -> RpcResult<u64>;
 
 	#[method(name = "bar")]
-	fn sync_method(&self) -> JsonRpcResult<u16>;
+	fn sync_method(&self) -> RpcResult<u16>;
 
 	#[subscription(name = "sub", item = String)]
-	fn sub(&self) -> JsonRpcResult<()>;
+	fn sub(&self) -> RpcResult<()>;
 
 	#[subscription(name = "echo", aliases = "ECHO", item = u32, unsubscribe_aliases = "NotInterested, listenNoMore")]
-	fn sub_with_params(&self, val: u32) -> JsonRpcResult<()>;
+	fn sub_with_params(&self, val: u32) -> RpcResult<()>;
 }
 
 pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method(&self, _param_a: u8, _param_b: String) -> JsonRpcResult<u16> {
+	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)
 	}
 
-	async fn optional_params(&self, a: core::option::Option<u8>, _b: String) -> JsonRpcResult<bool> {
+	async fn optional_params(&self, a: core::option::Option<u8>, _b: String) -> RpcResult<bool> {
 		let res = if a.is_some() { true } else { false };
 		Ok(res)
 	}
 
-	async fn optional_param(&self, a: Option<u8>) -> JsonRpcResult<bool> {
+	async fn optional_param(&self, a: Option<u8>) -> RpcResult<bool> {
 		let res = if a.is_some() { true } else { false };
 		Ok(res)
 	}
 
-	async fn array_params(&self, items: Vec<u64>) -> JsonRpcResult<u64> {
+	async fn array_params(&self, items: Vec<u64>) -> RpcResult<u64> {
 		Ok(items.len() as u64)
 	}
 
-	fn sync_method(&self) -> JsonRpcResult<u16> {
+	fn sync_method(&self) -> RpcResult<u16> {
 		Ok(10u16)
 	}
 
-	fn sub(&self, mut sink: SubscriptionSink) -> JsonRpcResult<()> {
+	fn sub(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
 		sink.send(&"Response_A")?;
 		sink.send(&"Response_B")
 	}
 
-	fn sub_with_params(&self, mut sink: SubscriptionSink, val: u32) -> JsonRpcResult<()> {
+	fn sub_with_params(&self, mut sink: SubscriptionSink, val: u32) -> RpcResult<()> {
 		sink.send(&val)?;
 		sink.send(&val)
 	}
@@ -107,7 +107,7 @@ async fn main() {
 	);
 
 	assert_eq!(client.request::<bool>("foo_optional_param", vec![].into()).await.unwrap(), false);
-	assert_eq!(client.request::<bool>("foo_optional_param", JsonRpcParams::NoParams).await.unwrap(), false);
+	assert_eq!(client.request::<bool>("foo_optional_param", RpcParamsSer::NoParams).await.unwrap(), false);
 	assert_eq!(
 		client.request::<bool>("foo_optional_param", vec![to_json_value(Some(1)).unwrap()].into()).await.unwrap(),
 		true

--- a/proc-macros/tests/ui/correct/only_client.rs
+++ b/proc-macros/tests/ui/correct/only_client.rs
@@ -1,14 +1,14 @@
 //! Example of using proc macro to generate working client and server.
 
-use jsonrpsee::{proc_macros::rpc, types::JsonRpcResult};
+use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 
 #[rpc(client)]
 pub trait Rpc {
 	#[method(name = "foo")]
-	async fn async_method(&self, param_a: u8, param_b: String) -> JsonRpcResult<u16>;
+	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name = "bar")]
-	fn sync_method(&self) -> JsonRpcResult<u16>;
+	fn sync_method(&self) -> RpcResult<u16>;
 
 	#[subscription(name = "sub", item = String)]
 	fn sub(&self);

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -1,6 +1,6 @@
 use jsonrpsee::{
 	proc_macros::rpc,
-	types::{async_trait, JsonRpcResult},
+	types::{async_trait, RpcResult},
 	ws_server::{SubscriptionSink, WsServerBuilder},
 };
 use std::{net::SocketAddr, sync::mpsc::channel};
@@ -8,28 +8,28 @@ use std::{net::SocketAddr, sync::mpsc::channel};
 #[rpc(server)]
 pub trait Rpc {
 	#[method(name = "foo")]
-	async fn async_method(&self, param_a: u8, param_b: String) -> JsonRpcResult<u16>;
+	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name = "bar")]
-	fn sync_method(&self) -> JsonRpcResult<u16>;
+	fn sync_method(&self) -> RpcResult<u16>;
 
 	#[subscription(name = "sub", item = String)]
-	fn sub(&self) -> JsonRpcResult<()>;
+	fn sub(&self) -> RpcResult<()>;
 }
 
 pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method(&self, _param_a: u8, _param_b: String) -> JsonRpcResult<u16> {
+	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)
 	}
 
-	fn sync_method(&self) -> JsonRpcResult<u16> {
+	fn sync_method(&self) -> RpcResult<u16> {
 		Ok(10u16)
 	}
 
-	fn sub(&self, mut sink: SubscriptionSink) -> JsonRpcResult<()> {
+	fn sub(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
 		sink.send(&"Response_A")?;
 		sink.send(&"Response_B")
 	}

--- a/proc-macros/tests/ui/correct/rpc_deny_missing_docs.rs
+++ b/proc-macros/tests/ui/correct/rpc_deny_missing_docs.rs
@@ -3,16 +3,17 @@
 #![deny(missing_docs)]
 
 use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::types::RpcResult;
 
 #[rpc(client, server)]
-pub trait ApiWithoutDocumentation {
+pub trait ApiWithDocumentation {
 	/// Async method.
 	#[method(name = "foo")]
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> RpcResult<u8>;
 
 	/// Subscription docs.
 	#[subscription(name = "sub", item = String)]
-	fn sub(&self) -> jsonrpsee::types::JsonRpcResult<()>;
+	fn sub(&self) -> RpcResult<()>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/method/method_no_name.rs
+++ b/proc-macros/tests/ui/incorrect/method/method_no_name.rs
@@ -4,7 +4,7 @@ use jsonrpsee::proc_macros::rpc;
 #[rpc(client, server)]
 pub trait NoMethodName {
 	#[method()]
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> jsonrpsee::types::RpcResult<u8>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/method/method_unexpected_field.rs
+++ b/proc-macros/tests/ui/incorrect/method/method_unexpected_field.rs
@@ -4,7 +4,7 @@ use jsonrpsee::proc_macros::rpc;
 #[rpc(client, server)]
 pub trait UnexpectedField {
 	#[method(name = "foo", magic = false)]
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> jsonrpsee::types::RpcResult<u8>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_assoc_items.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_assoc_items.rs
@@ -6,7 +6,7 @@ pub trait AssociatedConst {
 	const WOO: usize;
 
 	#[method(name = "foo")]
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> jsonrpsee::types::RpcResult<u8>;
 }
 
 #[rpc(client, server)]
@@ -14,7 +14,7 @@ pub trait AssociatedType {
 	type Woo;
 
 	#[method(name = "foo")]
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> jsonrpsee::types::RpcResult<u8>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_conflicting_alias.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_conflicting_alias.rs
@@ -1,9 +1,9 @@
 use jsonrpsee::proc_macros::rpc;
-
+use jsonrpsee::types::RpcResult;
 #[rpc(client, server)]
 pub trait DuplicatedAlias {
 	#[method(name = "foo", aliases = "foo_dup, foo_dup")]
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> RpcResult<u8>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_conflicting_alias.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_conflicting_alias.stderr
@@ -1,5 +1,5 @@
 error: "foo_dup" is already defined
  --> $DIR/rpc_conflicting_alias.rs:6:11
   |
-6 |     async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+6 |     async fn async_method(&self) -> RpcResult<u8>;
   |              ^^^^^^^^^^^^

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_name_conflict.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_name_conflict.rs
@@ -1,13 +1,13 @@
-use jsonrpsee::{proc_macros::rpc, types::JsonRpcResult};
+use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 
 // Associated items are forbidden.
 #[rpc(client, server)]
 pub trait MethodNameConflict {
 	#[method(name = "foo")]
-	async fn foo(&self) -> JsonRpcResult<u8>;
+	async fn foo(&self) -> RpcResult<u8>;
 
 	#[method(name = "foo")]
-	async fn bar(&self) -> JsonRpcResult<u8>;
+	async fn bar(&self) -> RpcResult<u8>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_name_conflict.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_name_conflict.stderr
@@ -1,5 +1,5 @@
 error: "foo" is already defined
   --> $DIR/rpc_name_conflict.rs:10:11
    |
-10 |     async fn bar(&self) -> JsonRpcResult<u8>;
+10 |     async fn bar(&self) -> RpcResult<u8>;
    |              ^^^

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_no_impls.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_no_impls.rs
@@ -4,7 +4,7 @@ use jsonrpsee::proc_macros::rpc;
 #[rpc()]
 pub trait NoImpls {
 	#[method(name = "foo")]
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> jsonrpsee::types::RpcResult<u8>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_not_qualified.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_not_qualified.rs
@@ -3,7 +3,7 @@ use jsonrpsee::proc_macros::rpc;
 // Method without type marker, `#[method(…)]` or `#[subscription(…)]`.
 #[rpc(client, server)]
 pub trait NotQualified {
-	async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
+	async fn async_method(&self) -> jsonrpsee::types::RpcResult<u8>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_not_qualified.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_not_qualified.stderr
@@ -1,5 +1,5 @@
 error: Methods must have either 'method' or 'subscription' attribute
  --> $DIR/rpc_not_qualified.rs:6:2
   |
-6 |     async fn async_method(&self) -> jsonrpsee::types::JsonRpcResult<u8>;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 |     async fn async_method(&self) -> jsonrpsee::types::RpcResult<u8>;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.rs
+++ b/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.rs
@@ -1,9 +1,9 @@
-use jsonrpsee::{proc_macros::rpc, types::JsonRpcResult};
+use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 
 #[rpc(client, server)]
 pub trait DuplicatedSubAlias {
 	#[subscription(name = "alias", item = String, aliases = "hello_is_goodbye", unsubscribe_aliases = "hello_is_goodbye")]
-	fn async_method(&self) -> JsonRpcResult<()>;
+	fn async_method(&self) -> RpcResult<()>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.stderr
+++ b/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.stderr
@@ -1,5 +1,5 @@
 error: "hello_is_goodbye" is already defined
  --> $DIR/sub_conflicting_alias.rs:6:5
   |
-6 |     fn async_method(&self) -> JsonRpcResult<()>;
+6 |     fn async_method(&self) -> RpcResult<()>;
   |        ^^^^^^^^^^^^

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -34,7 +34,7 @@ use jsonrpsee::{
 	http_client::HttpClientBuilder,
 	types::{
 		traits::{Client, SubscriptionClient},
-		v2::params::JsonRpcParams,
+		v2::params::Params,
 		Error, JsonValue, Subscription,
 	},
 	ws_client::WsClientBuilder,
@@ -48,9 +48,9 @@ async fn ws_subscription_works() {
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 	let mut hello_sub: Subscription<String> =
-		client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 	let mut foo_sub: Subscription<u64> =
-		client.subscribe("subscribe_foo", JsonRpcParams::NoParams, "unsubscribe_foo").await.unwrap();
+		client.subscribe("subscribe_foo", Params::NoParams, "unsubscribe_foo").await.unwrap();
 
 	for _ in 0..10 {
 		let hello = hello_sub.next().await.unwrap();
@@ -79,7 +79,7 @@ async fn ws_method_call_works() {
 	let server_addr = websocket_server().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let response: String = client.request("say_hello", JsonRpcParams::NoParams).await.unwrap();
+	let response: String = client.request("say_hello", Params::NoParams).await.unwrap();
 	assert_eq!(&response, "hello");
 }
 
@@ -88,7 +88,7 @@ async fn http_method_call_works() {
 	let server_addr = http_server().await;
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
-	let response: String = client.request("say_hello", JsonRpcParams::NoParams).await.unwrap();
+	let response: String = client.request("say_hello", Params::NoParams).await.unwrap();
 	assert_eq!(&response, "hello");
 }
 
@@ -101,9 +101,9 @@ async fn ws_subscription_several_clients() {
 	for _ in 0..10 {
 		let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 		let hello_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+			client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 		let foo_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_foo", JsonRpcParams::NoParams, "unsubscribe_foo").await.unwrap();
+			client.subscribe("subscribe_foo", Params::NoParams, "unsubscribe_foo").await.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 }
@@ -118,9 +118,9 @@ async fn ws_subscription_several_clients_with_drop() {
 		let client =
 			WsClientBuilder::default().max_notifs_per_subscription(u32::MAX as usize).build(&server_url).await.unwrap();
 		let hello_sub: Subscription<String> =
-			client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+			client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 		let foo_sub: Subscription<u64> =
-			client.subscribe("subscribe_foo", JsonRpcParams::NoParams, "unsubscribe_foo").await.unwrap();
+			client.subscribe("subscribe_foo", Params::NoParams, "unsubscribe_foo").await.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 
@@ -163,7 +163,7 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 
 	let client = WsClientBuilder::default().max_notifs_per_subscription(4).build(&server_url).await.unwrap();
 	let mut hello_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 
 	// don't poll the subscription stream for 2 seconds, should be full now.
 	tokio::time::sleep(Duration::from_secs(2)).await;
@@ -177,11 +177,11 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 	assert!(hello_sub.next().await.unwrap().is_none());
 
 	// The client should still be useable => make sure it still works.
-	let _hello_req: JsonValue = client.request("say_hello", JsonRpcParams::NoParams).await.unwrap();
+	let _hello_req: JsonValue = client.request("say_hello", Params::NoParams).await.unwrap();
 
 	// The same subscription should be possible to register again.
 	let mut other_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 
 	other_sub.next().await.unwrap();
 }
@@ -196,7 +196,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 
 	for _ in 0..6 {
 		let c = client.clone();
-		requests.push(tokio::spawn(async move { c.request::<String>("say_hello", JsonRpcParams::NoParams).await }));
+		requests.push(tokio::spawn(async move { c.request::<String>("say_hello", Params::NoParams).await }));
 	}
 
 	for req in requests {
@@ -208,7 +208,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 #[ignore]
 async fn https_works() {
 	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io").unwrap();
-	let response: String = client.request("system_chain", JsonRpcParams::NoParams).await.unwrap();
+	let response: String = client.request("system_chain", Params::NoParams).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
 
@@ -216,7 +216,7 @@ async fn https_works() {
 #[ignore]
 async fn wss_works() {
 	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io").await.unwrap();
-	let response: String = client.request("system_chain", JsonRpcParams::NoParams).await.unwrap();
+	let response: String = client.request("system_chain", Params::NoParams).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
 
@@ -229,7 +229,7 @@ async fn ws_with_non_ascii_url_doesnt_hang_or_panic() {
 #[tokio::test]
 async fn http_with_non_ascii_url_doesnt_hang_or_panic() {
 	let client = HttpClientBuilder::default().build("http://♥♥♥♥♥♥∀∂").unwrap();
-	let err: Result<(), Error> = client.request("system_chain", JsonRpcParams::NoParams).await;
+	let err: Result<(), Error> = client.request("system_chain", Params::NoParams).await;
 	assert!(matches!(err, Err(Error::Transport(_))));
 }
 
@@ -241,10 +241,10 @@ async fn ws_unsubscribe_releases_request_slots() {
 	let client = WsClientBuilder::default().max_concurrent_requests(1).build(&server_url).await.unwrap();
 
 	let sub1: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 	drop(sub1);
 	let _: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 }
 
 #[tokio::test]
@@ -255,7 +255,7 @@ async fn server_should_be_able_to_close_subscriptions() {
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let mut sub: Subscription<String> =
-		client.subscribe("subscribe_noop", JsonRpcParams::NoParams, "unsubscribe_noop").await.unwrap();
+		client.subscribe("subscribe_noop", Params::NoParams, "unsubscribe_noop").await.unwrap();
 
 	let res = sub.next().await;
 
@@ -270,14 +270,14 @@ async fn ws_close_pending_subscription_when_server_terminated() {
 	let c1 = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let mut sub: Subscription<String> =
-		c1.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await.unwrap();
+		c1.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
 
 	assert!(matches!(sub.next().await, Ok(Some(_))));
 
 	handle.stop().unwrap().await;
 
 	let sub2: Result<Subscription<String>, _> =
-		c1.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello").await;
+		c1.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await;
 
 	// no new request should be accepted.
 	assert!(matches!(sub2, Err(_)));

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -34,7 +34,7 @@ use jsonrpsee::{
 	http_client::HttpClientBuilder,
 	types::{
 		traits::{Client, SubscriptionClient},
-		v2::params::Params,
+		v2::params::RpcParamsSer,
 		Error, JsonValue, Subscription,
 	},
 	ws_client::WsClientBuilder,
@@ -48,9 +48,9 @@ async fn ws_subscription_works() {
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 	let mut hello_sub: Subscription<String> =
-		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 	let mut foo_sub: Subscription<u64> =
-		client.subscribe("subscribe_foo", Params::NoParams, "unsubscribe_foo").await.unwrap();
+		client.subscribe("subscribe_foo", RpcParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
 
 	for _ in 0..10 {
 		let hello = hello_sub.next().await.unwrap();
@@ -79,7 +79,7 @@ async fn ws_method_call_works() {
 	let server_addr = websocket_server().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let response: String = client.request("say_hello", Params::NoParams).await.unwrap();
+	let response: String = client.request("say_hello", RpcParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "hello");
 }
 
@@ -88,7 +88,7 @@ async fn http_method_call_works() {
 	let server_addr = http_server().await;
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
-	let response: String = client.request("say_hello", Params::NoParams).await.unwrap();
+	let response: String = client.request("say_hello", RpcParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "hello");
 }
 
@@ -101,9 +101,9 @@ async fn ws_subscription_several_clients() {
 	for _ in 0..10 {
 		let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 		let hello_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+			client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 		let foo_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_foo", Params::NoParams, "unsubscribe_foo").await.unwrap();
+			client.subscribe("subscribe_foo", RpcParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 }
@@ -118,9 +118,9 @@ async fn ws_subscription_several_clients_with_drop() {
 		let client =
 			WsClientBuilder::default().max_notifs_per_subscription(u32::MAX as usize).build(&server_url).await.unwrap();
 		let hello_sub: Subscription<String> =
-			client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+			client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 		let foo_sub: Subscription<u64> =
-			client.subscribe("subscribe_foo", Params::NoParams, "unsubscribe_foo").await.unwrap();
+			client.subscribe("subscribe_foo", RpcParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 
@@ -163,7 +163,7 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 
 	let client = WsClientBuilder::default().max_notifs_per_subscription(4).build(&server_url).await.unwrap();
 	let mut hello_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 
 	// don't poll the subscription stream for 2 seconds, should be full now.
 	tokio::time::sleep(Duration::from_secs(2)).await;
@@ -177,11 +177,11 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 	assert!(hello_sub.next().await.unwrap().is_none());
 
 	// The client should still be useable => make sure it still works.
-	let _hello_req: JsonValue = client.request("say_hello", Params::NoParams).await.unwrap();
+	let _hello_req: JsonValue = client.request("say_hello", RpcParamsSer::NoParams).await.unwrap();
 
 	// The same subscription should be possible to register again.
 	let mut other_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 
 	other_sub.next().await.unwrap();
 }
@@ -196,7 +196,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 
 	for _ in 0..6 {
 		let c = client.clone();
-		requests.push(tokio::spawn(async move { c.request::<String>("say_hello", Params::NoParams).await }));
+		requests.push(tokio::spawn(async move { c.request::<String>("say_hello", RpcParamsSer::NoParams).await }));
 	}
 
 	for req in requests {
@@ -208,7 +208,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 #[ignore]
 async fn https_works() {
 	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io").unwrap();
-	let response: String = client.request("system_chain", Params::NoParams).await.unwrap();
+	let response: String = client.request("system_chain", RpcParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
 
@@ -216,7 +216,7 @@ async fn https_works() {
 #[ignore]
 async fn wss_works() {
 	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io").await.unwrap();
-	let response: String = client.request("system_chain", Params::NoParams).await.unwrap();
+	let response: String = client.request("system_chain", RpcParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
 
@@ -229,7 +229,7 @@ async fn ws_with_non_ascii_url_doesnt_hang_or_panic() {
 #[tokio::test]
 async fn http_with_non_ascii_url_doesnt_hang_or_panic() {
 	let client = HttpClientBuilder::default().build("http://♥♥♥♥♥♥∀∂").unwrap();
-	let err: Result<(), Error> = client.request("system_chain", Params::NoParams).await;
+	let err: Result<(), Error> = client.request("system_chain", RpcParamsSer::NoParams).await;
 	assert!(matches!(err, Err(Error::Transport(_))));
 }
 
@@ -241,10 +241,10 @@ async fn ws_unsubscribe_releases_request_slots() {
 	let client = WsClientBuilder::default().max_concurrent_requests(1).build(&server_url).await.unwrap();
 
 	let sub1: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 	drop(sub1);
 	let _: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 }
 
 #[tokio::test]
@@ -255,7 +255,7 @@ async fn server_should_be_able_to_close_subscriptions() {
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let mut sub: Subscription<String> =
-		client.subscribe("subscribe_noop", Params::NoParams, "unsubscribe_noop").await.unwrap();
+		client.subscribe("subscribe_noop", RpcParamsSer::NoParams, "unsubscribe_noop").await.unwrap();
 
 	let res = sub.next().await;
 
@@ -270,14 +270,14 @@ async fn ws_close_pending_subscription_when_server_terminated() {
 	let c1 = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let mut sub: Subscription<String> =
-		c1.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await.unwrap();
+		c1.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 
 	assert!(matches!(sub.next().await, Ok(Some(_))));
 
 	handle.stop().unwrap().await;
 
 	let sub2: Result<Subscription<String>, _> =
-		c1.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello").await;
+		c1.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await;
 
 	// no new request should be accepted.
 	assert!(matches!(sub2, Err(_)));

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -34,7 +34,7 @@ use jsonrpsee::{
 	http_client::HttpClientBuilder,
 	types::{
 		traits::{Client, SubscriptionClient},
-		v2::params::RpcParamsSer,
+		v2::params::ParamsSer,
 		Error, JsonValue, Subscription,
 	},
 	ws_client::WsClientBuilder,
@@ -48,9 +48,9 @@ async fn ws_subscription_works() {
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 	let mut hello_sub: Subscription<String> =
-		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 	let mut foo_sub: Subscription<u64> =
-		client.subscribe("subscribe_foo", RpcParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
+		client.subscribe("subscribe_foo", ParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
 
 	for _ in 0..10 {
 		let hello = hello_sub.next().await.unwrap();
@@ -79,7 +79,7 @@ async fn ws_method_call_works() {
 	let server_addr = websocket_server().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let response: String = client.request("say_hello", RpcParamsSer::NoParams).await.unwrap();
+	let response: String = client.request("say_hello", ParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "hello");
 }
 
@@ -88,7 +88,7 @@ async fn http_method_call_works() {
 	let server_addr = http_server().await;
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
-	let response: String = client.request("say_hello", RpcParamsSer::NoParams).await.unwrap();
+	let response: String = client.request("say_hello", ParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "hello");
 }
 
@@ -101,9 +101,9 @@ async fn ws_subscription_several_clients() {
 	for _ in 0..10 {
 		let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 		let hello_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+			client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 		let foo_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_foo", RpcParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
+			client.subscribe("subscribe_foo", ParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 }
@@ -118,9 +118,9 @@ async fn ws_subscription_several_clients_with_drop() {
 		let client =
 			WsClientBuilder::default().max_notifs_per_subscription(u32::MAX as usize).build(&server_url).await.unwrap();
 		let hello_sub: Subscription<String> =
-			client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+			client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 		let foo_sub: Subscription<u64> =
-			client.subscribe("subscribe_foo", RpcParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
+			client.subscribe("subscribe_foo", ParamsSer::NoParams, "unsubscribe_foo").await.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 
@@ -163,7 +163,7 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 
 	let client = WsClientBuilder::default().max_notifs_per_subscription(4).build(&server_url).await.unwrap();
 	let mut hello_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 
 	// don't poll the subscription stream for 2 seconds, should be full now.
 	tokio::time::sleep(Duration::from_secs(2)).await;
@@ -177,11 +177,11 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 	assert!(hello_sub.next().await.unwrap().is_none());
 
 	// The client should still be useable => make sure it still works.
-	let _hello_req: JsonValue = client.request("say_hello", RpcParamsSer::NoParams).await.unwrap();
+	let _hello_req: JsonValue = client.request("say_hello", ParamsSer::NoParams).await.unwrap();
 
 	// The same subscription should be possible to register again.
 	let mut other_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 
 	other_sub.next().await.unwrap();
 }
@@ -196,7 +196,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 
 	for _ in 0..6 {
 		let c = client.clone();
-		requests.push(tokio::spawn(async move { c.request::<String>("say_hello", RpcParamsSer::NoParams).await }));
+		requests.push(tokio::spawn(async move { c.request::<String>("say_hello", ParamsSer::NoParams).await }));
 	}
 
 	for req in requests {
@@ -208,7 +208,7 @@ async fn ws_more_request_than_buffer_should_not_deadlock() {
 #[ignore]
 async fn https_works() {
 	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io").unwrap();
-	let response: String = client.request("system_chain", RpcParamsSer::NoParams).await.unwrap();
+	let response: String = client.request("system_chain", ParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
 
@@ -216,7 +216,7 @@ async fn https_works() {
 #[ignore]
 async fn wss_works() {
 	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io").await.unwrap();
-	let response: String = client.request("system_chain", RpcParamsSer::NoParams).await.unwrap();
+	let response: String = client.request("system_chain", ParamsSer::NoParams).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
 
@@ -229,7 +229,7 @@ async fn ws_with_non_ascii_url_doesnt_hang_or_panic() {
 #[tokio::test]
 async fn http_with_non_ascii_url_doesnt_hang_or_panic() {
 	let client = HttpClientBuilder::default().build("http://♥♥♥♥♥♥∀∂").unwrap();
-	let err: Result<(), Error> = client.request("system_chain", RpcParamsSer::NoParams).await;
+	let err: Result<(), Error> = client.request("system_chain", ParamsSer::NoParams).await;
 	assert!(matches!(err, Err(Error::Transport(_))));
 }
 
@@ -241,10 +241,10 @@ async fn ws_unsubscribe_releases_request_slots() {
 	let client = WsClientBuilder::default().max_concurrent_requests(1).build(&server_url).await.unwrap();
 
 	let sub1: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 	drop(sub1);
 	let _: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+		client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 }
 
 #[tokio::test]
@@ -255,7 +255,7 @@ async fn server_should_be_able_to_close_subscriptions() {
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let mut sub: Subscription<String> =
-		client.subscribe("subscribe_noop", RpcParamsSer::NoParams, "unsubscribe_noop").await.unwrap();
+		client.subscribe("subscribe_noop", ParamsSer::NoParams, "unsubscribe_noop").await.unwrap();
 
 	let res = sub.next().await;
 
@@ -270,14 +270,14 @@ async fn ws_close_pending_subscription_when_server_terminated() {
 	let c1 = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let mut sub: Subscription<String> =
-		c1.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
+		c1.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await.unwrap();
 
 	assert!(matches!(sub.next().await, Ok(Some(_))));
 
 	handle.stop().unwrap().await;
 
 	let sub2: Result<Subscription<String>, _> =
-		c1.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello").await;
+		c1.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await;
 
 	// no new request should be accepted.
 	assert!(matches!(sub2, Err(_)));

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -35,31 +35,31 @@ use serde_json::value::RawValue;
 mod rpc_impl {
 	use jsonrpsee::{
 		proc_macros::rpc,
-		types::{async_trait, JsonRpcResult},
+		types::{async_trait, RpcResult},
 		ws_server::SubscriptionSink,
 	};
 
 	#[rpc(client, server, namespace = "foo")]
 	pub trait Rpc {
 		#[method(name = "foo")]
-		async fn async_method(&self, param_a: u8, param_b: String) -> JsonRpcResult<u16>;
+		async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 		#[method(name = "bar")]
-		fn sync_method(&self) -> JsonRpcResult<u16>;
+		fn sync_method(&self) -> RpcResult<u16>;
 
 		#[subscription(name = "sub", item = String)]
-		fn sub(&self) -> JsonRpcResult<()>;
+		fn sub(&self) -> RpcResult<()>;
 
 		#[subscription(name = "echo", aliases = "alias_echo", item = u32)]
-		fn sub_with_params(&self, val: u32) -> JsonRpcResult<()>;
+		fn sub_with_params(&self, val: u32) -> RpcResult<()>;
 
 		#[method(name = "params")]
-		fn params(&self, a: u8, b: &str) -> JsonRpcResult<String> {
+		fn params(&self, a: u8, b: &str) -> RpcResult<String> {
 			Ok(format!("Called with: {}, {}", a, b))
 		}
 
 		#[method(name = "optional_params")]
-		fn optional_params(&self, a: u32, b: Option<u32>, c: Option<u32>) -> JsonRpcResult<String> {
+		fn optional_params(&self, a: u32, b: Option<u32>, c: Option<u32>) -> RpcResult<String> {
 			Ok(format!("Called with: {}, {:?}, {:?}", a, b, c))
 		}
 
@@ -70,12 +70,12 @@ mod rpc_impl {
 			b: &'_ str,
 			c: std::borrow::Cow<'_, str>,
 			d: Option<beef::Cow<'_, str>>,
-		) -> JsonRpcResult<String> {
+		) -> RpcResult<String> {
 			Ok(format!("Called with: {}, {}, {}, {:?}", a, b, c, d))
 		}
 
 		#[method(name = "zero_copy_cow")]
-		fn zero_copy_cow(&self, a: std::borrow::Cow<'_, str>, b: beef::Cow<'_, str>) -> JsonRpcResult<String> {
+		fn zero_copy_cow(&self, a: std::borrow::Cow<'_, str>, b: beef::Cow<'_, str>) -> RpcResult<String> {
 			Ok(format!("Zero copy params: {}, {}", matches!(a, std::borrow::Cow::Borrowed(_)), b.is_borrowed()))
 		}
 	}
@@ -84,32 +84,32 @@ mod rpc_impl {
 	pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 		/// Get header of a relay chain block.
 		#[method(name = "getHeader")]
-		fn header(&self, hash: Option<Hash>) -> JsonRpcResult<Option<Header>>;
+		fn header(&self, hash: Option<Hash>) -> RpcResult<Option<Header>>;
 
 		/// Get header and body of a relay chain block.
 		#[method(name = "getBlock")]
-		async fn block(&self, hash: Option<Hash>) -> JsonRpcResult<Option<SignedBlock>>;
+		async fn block(&self, hash: Option<Hash>) -> RpcResult<Option<SignedBlock>>;
 
 		/// Get hash of the n-th block in the canon chain.
 		///
 		/// By default returns latest block hash.
 		#[method(name = "getBlockHash")]
-		fn block_hash(&self, hash: Hash) -> JsonRpcResult<Option<Hash>>;
+		fn block_hash(&self, hash: Hash) -> RpcResult<Option<Hash>>;
 
 		/// Get hash of the last finalized block in the canon chain.
 		#[method(name = "getFinalizedHead")]
-		fn finalized_head(&self) -> JsonRpcResult<Hash>;
+		fn finalized_head(&self) -> RpcResult<Hash>;
 
 		/// All head subscription
 		#[subscription(name = "subscribeAllHeads", item = Header)]
-		fn subscribe_all_heads(&self, hash: Hash) -> JsonRpcResult<()>;
+		fn subscribe_all_heads(&self, hash: Hash) -> RpcResult<()>;
 	}
 
 	/// Trait to ensure that the trait bounds are correct.
 	#[rpc(client, server, namespace = "generic_call")]
 	pub trait OnlyGenericCall<I, R> {
 		#[method(name = "getHeader")]
-		fn call(&self, input: I) -> JsonRpcResult<R>;
+		fn call(&self, input: I) -> RpcResult<R>;
 	}
 
 	/// Trait to ensure that the trait bounds are correct.
@@ -117,7 +117,7 @@ mod rpc_impl {
 	pub trait OnlyGenericSubscription<Input, R> {
 		/// Get header of a relay chain block.
 		#[subscription(name = "sub", item = Vec<R>)]
-		fn sub(&self, hash: Input) -> JsonRpcResult<()>;
+		fn sub(&self, hash: Input) -> RpcResult<()>;
 	}
 
 	/// Trait to ensure that the trait bounds are correct.
@@ -128,7 +128,7 @@ mod rpc_impl {
 		R: Copy + Clone,
 	{
 		#[method(name = "getHeader")]
-		fn call(&self, input: I) -> JsonRpcResult<R>;
+		fn call(&self, input: I) -> RpcResult<R>;
 	}
 
 	/// Trait to ensure that the trait bounds are correct.
@@ -139,28 +139,28 @@ mod rpc_impl {
 		R: Copy + Clone,
 	{
 		#[method(name = "getHeader")]
-		fn call(&self, input: I) -> JsonRpcResult<R>;
+		fn call(&self, input: I) -> RpcResult<R>;
 	}
 
 	pub struct RpcServerImpl;
 
 	#[async_trait]
 	impl RpcServer for RpcServerImpl {
-		async fn async_method(&self, _param_a: u8, _param_b: String) -> JsonRpcResult<u16> {
+		async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 			Ok(42u16)
 		}
 
-		fn sync_method(&self) -> JsonRpcResult<u16> {
+		fn sync_method(&self) -> RpcResult<u16> {
 			Ok(10u16)
 		}
 
-		fn sub(&self, mut sink: SubscriptionSink) -> JsonRpcResult<()> {
+		fn sub(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
 			sink.send(&"Response_A")?;
 			sink.send(&"Response_B")?;
 			Ok(())
 		}
 
-		fn sub_with_params(&self, mut sink: SubscriptionSink, val: u32) -> JsonRpcResult<()> {
+		fn sub_with_params(&self, mut sink: SubscriptionSink, val: u32) -> RpcResult<()> {
 			sink.send(&val)?;
 			sink.send(&val)?;
 			Ok(())
@@ -169,14 +169,14 @@ mod rpc_impl {
 
 	#[async_trait]
 	impl OnlyGenericCallServer<String, String> for RpcServerImpl {
-		fn call(&self, _: String) -> JsonRpcResult<String> {
+		fn call(&self, _: String) -> RpcResult<String> {
 			Ok("hello".to_string())
 		}
 	}
 
 	#[async_trait]
 	impl OnlyGenericSubscriptionServer<String, String> for RpcServerImpl {
-		fn sub(&self, mut sink: SubscriptionSink, _: String) -> JsonRpcResult<()> {
+		fn sub(&self, mut sink: SubscriptionSink, _: String) -> RpcResult<()> {
 			sink.send(&"hello")
 		}
 	}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -34,13 +34,13 @@ extern crate alloc;
 /// Ten megabytes.
 pub const TEN_MB_SIZE_BYTES: u32 = 10 * 1024 * 1024;
 
-/// JSON-RPC 2.0 specification related types v2.
+/// JSON-RPC v2.0 specification related types.
 pub mod v2;
 
-/// Shared error type.
+/// Error type.
 pub mod error;
 
-/// Shared client types.
+/// Client types.
 mod client;
 
 /// Traits

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -66,4 +66,4 @@ pub mod __reexports {
 }
 
 /// JSON-RPC result.
-pub type JsonRpcResult<T> = Result<T, Error>;
+pub type RpcResult<T> = std::result::Result<T, Error>;

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::v2::params::RpcParamsSer;
+use crate::v2::params::ParamsSer;
 use crate::{Error, Subscription};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -33,10 +33,10 @@ use serde::de::DeserializeOwned;
 #[async_trait]
 pub trait Client {
 	/// Send a [notification request](https://www.jsonrpc.org/specification#notification)
-	async fn notification<'a>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<(), Error>;
+	async fn notification<'a>(&self, method: &'a str, params: ParamsSer<'a>) -> Result<(), Error>;
 
 	/// Send a [method call request](https://www.jsonrpc.org/specification#request_object).
-	async fn request<'a, R>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<R, Error>
+	async fn request<'a, R>(&self, method: &'a str, params: ParamsSer<'a>) -> Result<R, Error>
 	where
 		R: DeserializeOwned;
 
@@ -46,7 +46,7 @@ pub trait Client {
 	///
 	/// Returns `Ok` if all requests in the batch were answered successfully.
 	/// Returns `Error` if any of the requests in batch fails.
-	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, RpcParamsSer<'a>)>) -> Result<Vec<R>, Error>
+	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, ParamsSer<'a>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone;
 }
@@ -68,7 +68,7 @@ pub trait SubscriptionClient: Client {
 	async fn subscribe<'a, Notif>(
 		&self,
 		subscribe_method: &'a str,
-		params: RpcParamsSer<'a>,
+		params: ParamsSer<'a>,
 		unsubscribe_method: &'a str,
 	) -> Result<Subscription<Notif>, Error>
 	where

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::v2::params::Params;
+use crate::v2::params::RpcParamsSer;
 use crate::{Error, Subscription};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -33,10 +33,10 @@ use serde::de::DeserializeOwned;
 #[async_trait]
 pub trait Client {
 	/// Send a [notification request](https://www.jsonrpc.org/specification#notification)
-	async fn notification<'a>(&self, method: &'a str, params: Params<'a>) -> Result<(), Error>;
+	async fn notification<'a>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<(), Error>;
 
 	/// Send a [method call request](https://www.jsonrpc.org/specification#request_object).
-	async fn request<'a, R>(&self, method: &'a str, params: Params<'a>) -> Result<R, Error>
+	async fn request<'a, R>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<R, Error>
 	where
 		R: DeserializeOwned;
 
@@ -46,7 +46,7 @@ pub trait Client {
 	///
 	/// Returns `Ok` if all requests in the batch were answered successfully.
 	/// Returns `Error` if any of the requests in batch fails.
-	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, Params<'a>)>) -> Result<Vec<R>, Error>
+	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, RpcParamsSer<'a>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone;
 }
@@ -68,7 +68,7 @@ pub trait SubscriptionClient: Client {
 	async fn subscribe<'a, Notif>(
 		&self,
 		subscribe_method: &'a str,
-		params: Params<'a>,
+		params: RpcParamsSer<'a>,
 		unsubscribe_method: &'a str,
 	) -> Result<Subscription<Notif>, Error>
 	where

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::v2::params::JsonRpcParams;
+use crate::v2::params::Params;
 use crate::{Error, Subscription};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -33,10 +33,10 @@ use serde::de::DeserializeOwned;
 #[async_trait]
 pub trait Client {
 	/// Send a [notification request](https://www.jsonrpc.org/specification#notification)
-	async fn notification<'a>(&self, method: &'a str, params: JsonRpcParams<'a>) -> Result<(), Error>;
+	async fn notification<'a>(&self, method: &'a str, params: Params<'a>) -> Result<(), Error>;
 
 	/// Send a [method call request](https://www.jsonrpc.org/specification#request_object).
-	async fn request<'a, R>(&self, method: &'a str, params: JsonRpcParams<'a>) -> Result<R, Error>
+	async fn request<'a, R>(&self, method: &'a str, params: Params<'a>) -> Result<R, Error>
 	where
 		R: DeserializeOwned;
 
@@ -46,7 +46,7 @@ pub trait Client {
 	///
 	/// Returns `Ok` if all requests in the batch were answered successfully.
 	/// Returns `Error` if any of the requests in batch fails.
-	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, JsonRpcParams<'a>)>) -> Result<Vec<R>, Error>
+	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, Params<'a>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone;
 }
@@ -68,7 +68,7 @@ pub trait SubscriptionClient: Client {
 	async fn subscribe<'a, Notif>(
 		&self,
 		subscribe_method: &'a str,
-		params: JsonRpcParams<'a>,
+		params: Params<'a>,
 		unsubscribe_method: &'a str,
 	) -> Result<Subscription<Notif>, Error>
 	where

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 
 /// [Failed JSON-RPC response object](https://www.jsonrpc.org/specification#response_object).
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct JsonRpcError<'a> {
+pub struct RpcError<'a> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Error.
@@ -44,7 +44,7 @@ pub struct JsonRpcError<'a> {
 	pub id: Id<'a>,
 }
 
-impl<'a> fmt::Display for JsonRpcError<'a> {
+impl<'a> fmt::Display for RpcError<'a> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "{}", serde_json::to_string(&self).expect("infallible; qed"))
 	}
@@ -202,17 +202,17 @@ impl serde::Serialize for JsonRpcErrorCode {
 
 #[cfg(test)]
 mod tests {
-	use super::{Id, JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject, TwoPointZero};
+	use super::{Id, RpcError, JsonRpcErrorCode, JsonRpcErrorObject, TwoPointZero};
 
 	#[test]
 	fn deserialize_works() {
 		let ser = r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}"#;
-		let exp = JsonRpcError {
+		let exp = RpcError {
 			jsonrpc: TwoPointZero,
 			error: JsonRpcErrorObject { code: JsonRpcErrorCode::ParseError, message: "Parse error", data: None },
 			id: Id::Null,
 		};
-		let err: JsonRpcError = serde_json::from_str(ser).unwrap();
+		let err: RpcError = serde_json::from_str(ser).unwrap();
 		assert_eq!(exp, err);
 	}
 
@@ -220,7 +220,7 @@ mod tests {
 	fn deserialize_with_optional_data() {
 		let ser = r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error", "data":"vegan"},"id":null}"#;
 		let data = serde_json::value::to_raw_value(&"vegan").unwrap();
-		let exp = JsonRpcError {
+		let exp = RpcError {
 			jsonrpc: TwoPointZero,
 			error: JsonRpcErrorObject {
 				code: JsonRpcErrorCode::ParseError,
@@ -229,14 +229,14 @@ mod tests {
 			},
 			id: Id::Null,
 		};
-		let err: JsonRpcError = serde_json::from_str(ser).unwrap();
+		let err: RpcError = serde_json::from_str(ser).unwrap();
 		assert_eq!(exp, err);
 	}
 
 	#[test]
 	fn serialize_works() {
 		let exp = r#"{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"},"id":1337}"#;
-		let err = JsonRpcError {
+		let err = RpcError {
 			jsonrpc: TwoPointZero,
 			error: JsonRpcErrorObject { code: JsonRpcErrorCode::InternalError, message: "Internal error", data: None },
 			id: Id::Number(1337),

--- a/types/src/v2/error.rs
+++ b/types/src/v2/error.rs
@@ -202,7 +202,7 @@ impl serde::Serialize for ErrorCode {
 
 #[cfg(test)]
 mod tests {
-	use super::{Id, RpcError, ErrorCode, ErrorObject, TwoPointZero};
+	use super::{ErrorCode, ErrorObject, Id, RpcError, TwoPointZero};
 
 	#[test]
 	fn deserialize_works() {
@@ -222,11 +222,7 @@ mod tests {
 		let data = serde_json::value::to_raw_value(&"vegan").unwrap();
 		let exp = RpcError {
 			jsonrpc: TwoPointZero,
-			error: ErrorObject {
-				code: ErrorCode::ParseError,
-				message: "Parse error",
-				data: Some(&*data),
-			},
+			error: ErrorObject { code: ErrorCode::ParseError, message: "Parse error", data: Some(&*data) },
 			id: Id::Null,
 		};
 		let err: RpcError = serde_json::from_str(ser).unwrap();

--- a/types/src/v2/mod.rs
+++ b/types/src/v2/mod.rs
@@ -24,6 +24,8 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+//! Types to handle in- and outgoing JSON-RPC requests and subscriptions according to the [spec](https://www.jsonrpc.org/specification).
+
 /// JSON-RPC error related types.
 pub mod error;
 /// JSON_RPC params related types.

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -356,9 +356,7 @@ impl<'a> Id<'a> {
 
 #[cfg(test)]
 mod test {
-	use super::{
-		Cow, Id, RpcParamsSer, SubscriptionParams, JsonValue, RpcParams, SubscriptionId, TwoPointZero,
-	};
+	use super::{Cow, Id, JsonValue, RpcParams, RpcParamsSer, SubscriptionId, SubscriptionParams, TwoPointZero};
 
 	#[test]
 	fn id_deserialization() {
@@ -487,9 +485,8 @@ mod test {
 
 	#[test]
 	fn subscription_params_serialize_work() {
-		let ser =
-			serde_json::to_string(&SubscriptionParams { subscription: SubscriptionId::Num(12), result: "goal" })
-				.unwrap();
+		let ser = serde_json::to_string(&SubscriptionParams { subscription: SubscriptionId::Num(12), result: "goal" })
+			.unwrap();
 		let exp = r#"{"subscription":12,"result":"goal"}"#;
 		assert_eq!(ser, exp);
 	}

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -251,7 +251,7 @@ impl<'a> RpcParamsSequence<'a> {
 /// whereas `Into<JsonValue>` doesn't in most cases.
 #[derive(Serialize, Debug, Clone)]
 #[serde(untagged)]
-pub enum JsonRpcParams<'a> {
+pub enum Params<'a> {
 	/// No params.
 	NoParams,
 	/// Positional params (heap allocated).
@@ -262,19 +262,19 @@ pub enum JsonRpcParams<'a> {
 	Map(BTreeMap<&'a str, JsonValue>),
 }
 
-impl<'a> From<BTreeMap<&'a str, JsonValue>> for JsonRpcParams<'a> {
+impl<'a> From<BTreeMap<&'a str, JsonValue>> for Params<'a> {
 	fn from(map: BTreeMap<&'a str, JsonValue>) -> Self {
 		Self::Map(map)
 	}
 }
 
-impl<'a> From<Vec<JsonValue>> for JsonRpcParams<'a> {
+impl<'a> From<Vec<JsonValue>> for Params<'a> {
 	fn from(arr: Vec<JsonValue>) -> Self {
 		Self::Array(arr)
 	}
 }
 
-impl<'a> From<&'a [JsonValue]> for JsonRpcParams<'a> {
+impl<'a> From<&'a [JsonValue]> for Params<'a> {
 	fn from(slice: &'a [JsonValue]) -> Self {
 		Self::ArrayRef(slice)
 	}
@@ -354,7 +354,7 @@ impl<'a> Id<'a> {
 #[cfg(test)]
 mod test {
 	use super::{
-		Cow, Id, JsonRpcParams, JsonRpcSubscriptionParams, JsonValue, RpcParams, SubscriptionId, TwoPointZero,
+		Cow, Id, Params, JsonRpcSubscriptionParams, JsonValue, RpcParams, SubscriptionId, TwoPointZero,
 	};
 
 	#[test]
@@ -396,11 +396,11 @@ mod test {
 	#[test]
 	fn params_serialize() {
 		let test_vector = &[
-			("null", JsonRpcParams::NoParams),
-			("[42,23]", JsonRpcParams::Array(serde_json::from_str("[42,23]").unwrap())),
+			("null", Params::NoParams),
+			("[42,23]", Params::Array(serde_json::from_str("[42,23]").unwrap())),
 			(
 				r#"{"a":42,"b":null,"c":"aa"}"#,
-				JsonRpcParams::Map(serde_json::from_str(r#"{"a":42,"b":null,"c":"aa"}"#).unwrap()),
+				Params::Map(serde_json::from_str(r#"{"a":42,"b":null,"c":"aa"}"#).unwrap()),
 			),
 		];
 

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -133,7 +133,7 @@ impl<'a> Params<'a> {
 		self.parse::<[T; 1]>().map(|[res]| res)
 	}
 
-	/// Convert `RpcParams<'a>` to `RpcParams<'static>` so that it can be moved across threads.
+	/// Convert `Params<'a>` to `Params<'static>` so that it can be moved across threads.
 	///
 	/// This will cause an allocation if the params internally are using a borrowed JSON slice.
 	pub fn into_owned(self) -> Params<'static> {
@@ -141,7 +141,7 @@ impl<'a> Params<'a> {
 	}
 }
 
-/// An `Iterator`-like parser for a sequence of `RpcParams`.
+/// An `Iterator`-like parser for a sequence of [`Params`].
 ///
 /// This will parse the params one at a time, and allows for graceful handling of optional parameters at the tail; other
 /// use cases are likely better served by [`Params::parse`]. The reason this is not an actual [`Iterator`] is that

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -36,15 +36,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::fmt;
 
-/// JSON-RPC parameter values for subscriptions.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct SubscriptionParams<T> {
-	/// Subscription ID
-	pub subscription: SubscriptionId,
-	/// Result.
-	pub result: T,
-}
-
 /// JSON-RPC v2 marker type.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct TwoPointZero;
@@ -356,7 +347,8 @@ impl<'a> Id<'a> {
 
 #[cfg(test)]
 mod test {
-	use super::{Cow, Id, JsonValue, Params, ParamsSer, SubscriptionId, SubscriptionParams, TwoPointZero};
+	use super::{Cow, Id, JsonValue, Params, ParamsSer, SubscriptionId, TwoPointZero};
+	use crate::v2::response::SubscriptionPayload;
 
 	#[test]
 	fn id_deserialization() {
@@ -485,7 +477,7 @@ mod test {
 
 	#[test]
 	fn subscription_params_serialize_work() {
-		let ser = serde_json::to_string(&SubscriptionParams { subscription: SubscriptionId::Num(12), result: "goal" })
+		let ser = serde_json::to_string(&SubscriptionPayload { subscription: SubscriptionId::Num(12), result: "goal" })
 			.unwrap();
 		let exp = r#"{"subscription":12,"result":"goal"}"#;
 		assert_eq!(ser, exp);
@@ -495,10 +487,10 @@ mod test {
 	fn subscription_params_deserialize_work() {
 		let ser = r#"{"subscription":"9","result":"offside"}"#;
 		assert!(
-			serde_json::from_str::<SubscriptionParams<()>>(ser).is_err(),
+			serde_json::from_str::<SubscriptionPayload<()>>(ser).is_err(),
 			"invalid type should not be deserializable"
 		);
-		let dsr: SubscriptionParams<JsonValue> = serde_json::from_str(ser).unwrap();
+		let dsr: SubscriptionPayload<JsonValue> = serde_json::from_str(ser).unwrap();
 		assert_eq!(dsr.subscription, SubscriptionId::Str("9".into()));
 		assert_eq!(dsr.result, serde_json::json!("offside"));
 	}

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Types to handle JSON-RPC request parameters according to the [spec](https://www.jsonrpc.org/specification#parameter_structures).
-//! Some types come with a "*Ser" variant that implements [`Serialize`]; these are used in the client.
+//! Some types come with a "*Ser" variant that implements [`serde::Serialize`]; these are used in the client.
 
 use crate::error::CallError;
 use alloc::collections::BTreeMap;
@@ -101,7 +101,7 @@ impl<'a> Params<'a> {
 		json.starts_with('{')
 	}
 
-	/// Obtain a sequence parser, [`RpcParamsSequence`].
+	/// Obtain a sequence parser, [`ParamsSequence`].
 	///
 	/// This allows sequential parsing of the incoming params, using an `Iterator`-style API and is useful when the RPC
 	/// request has optional parameters at the tail that may or may not be present.
@@ -144,7 +144,7 @@ impl<'a> Params<'a> {
 /// An `Iterator`-like parser for a sequence of `RpcParams`.
 ///
 /// This will parse the params one at a time, and allows for graceful handling of optional parameters at the tail; other
-/// use cases are likely better served by [`RpcParams::parse`]. The reason this is not an actual [`Iterator`] is that
+/// use cases are likely better served by [`Params::parse`]. The reason this is not an actual [`Iterator`] is that
 /// params parsing (often) yields values of different types.
 ///
 /// Regards empty array `[]` as no parameters provided.

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -147,14 +147,6 @@ mod test {
 		assert_eq!(dsr.jsonrpc, TwoPointZero);
 	}
 
-	// TODO(niklasad1): merge the types `JsonRpcParams` and `RpcParams` and remove `RawValue`.
-	#[test]
-	#[ignore]
-	fn deserialize_call_bad_params_should_fail() {
-		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":"lol","id":1}"#;
-		assert!(serde_json::from_str::<Request>(ser).is_err());
-	}
-
 	#[test]
 	fn deserialize_call_bad_id_should_fail() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[],"id":{}}"#;

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -27,7 +27,7 @@
 //! Types to handle JSON-RPC requests according to the [spec](https://www.jsonrpc.org/specification#request-object).
 //! Some types come with a "*Ser" variant that implements [`Serialize`]; these are used in the client.
 
-use crate::v2::params::{Id, RpcParamsSer, TwoPointZero};
+use crate::v2::params::{Id, ParamsSer, TwoPointZero};
 use beef::Cow;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
@@ -80,12 +80,12 @@ pub struct RequestSer<'a> {
 	/// Name of the method to be invoked.
 	pub method: &'a str,
 	/// Parameter values of the request.
-	pub params: RpcParamsSer<'a>,
+	pub params: ParamsSer<'a>,
 }
 
 impl<'a> RequestSer<'a> {
 	/// Create a new serializable JSON-RPC request.
-	pub fn new(id: Id<'a>, method: &'a str, params: RpcParamsSer<'a>) -> Self {
+	pub fn new(id: Id<'a>, method: &'a str, params: ParamsSer<'a>) -> Self {
 		Self { jsonrpc: TwoPointZero, id, method, params }
 	}
 }
@@ -98,19 +98,19 @@ pub struct NotificationSer<'a> {
 	/// Name of the method to be invoked.
 	pub method: &'a str,
 	/// Parameter values of the request.
-	pub params: RpcParamsSer<'a>,
+	pub params: ParamsSer<'a>,
 }
 
 impl<'a> NotificationSer<'a> {
 	/// Create a new serializable JSON-RPC request.
-	pub fn new(method: &'a str, params: RpcParamsSer<'a>) -> Self {
+	pub fn new(method: &'a str, params: ParamsSer<'a>) -> Self {
 		Self { jsonrpc: TwoPointZero, method, params }
 	}
 }
 
 #[cfg(test)]
 mod test {
-	use super::{Id, InvalidRequest, Notification, NotificationSer, Request, RequestSer, RpcParamsSer, TwoPointZero};
+	use super::{Id, InvalidRequest, Notification, NotificationSer, ParamsSer, Request, RequestSer, TwoPointZero};
 	use serde_json::{value::RawValue, Value};
 
 	fn assert_request<'a>(request: Request<'a>, id: Id<'a>, method: &str, params: Option<&str>) {
@@ -173,7 +173,7 @@ mod test {
 	fn serialize_call() {
 		let method = "subtract";
 		let id = Id::Number(1); // It's enough to check one variant, since the type itself also has tests.
-		let params: RpcParamsSer = vec![Value::Number(42.into()), Value::Number(23.into())].into(); // Same as above.
+		let params: ParamsSer = vec![Value::Number(42.into()), Value::Number(23.into())].into(); // Same as above.
 		let test_vector = &[
 			// With all fields set.
 			(
@@ -194,7 +194,7 @@ mod test {
 				jsonrpc: TwoPointZero,
 				method,
 				id: id.unwrap_or(Id::Null),
-				params: params.unwrap_or(RpcParamsSer::NoParams),
+				params: params.unwrap_or(ParamsSer::NoParams),
 			})
 			.unwrap();
 

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Types to handle JSON-RPC requests according to the [spec](https://www.jsonrpc.org/specification#request-object).
-//! Some types come with a "*Ser" variant that implements [`Serialize`]; these are used in the client.
+//! Some types come with a "*Ser" variant that implements [`serde::Serialize`]; these are used in the client.
 
 use crate::v2::params::{Id, ParamsSer, TwoPointZero};
 use beef::Cow;

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -110,10 +110,7 @@ impl<'a> NotificationSer<'a> {
 
 #[cfg(test)]
 mod test {
-	use super::{
-		Id, RequestSer, InvalidRequest, Notification, NotificationSer, RpcParamsSer,
-		Request, TwoPointZero,
-	};
+	use super::{Id, InvalidRequest, Notification, NotificationSer, Request, RequestSer, RpcParamsSer, TwoPointZero};
 	use serde_json::{value::RawValue, Value};
 
 	fn assert_request<'a>(request: Request<'a>, id: Id<'a>, method: &str, params: Option<&str>) {

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// JSON-RPC successful response object.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct JsonRpcResponse<'a, T> {
+pub struct Response<'a, T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Result.
@@ -42,20 +42,20 @@ pub struct JsonRpcResponse<'a, T> {
 
 #[cfg(test)]
 mod tests {
-	use super::{Id, JsonRpcResponse, TwoPointZero};
+	use super::{Id, Response, TwoPointZero};
 
 	#[test]
 	fn serialize_call_response() {
 		let ser =
-			serde_json::to_string(&JsonRpcResponse { jsonrpc: TwoPointZero, result: "ok", id: Id::Number(1) }).unwrap();
+			serde_json::to_string(&Response { jsonrpc: TwoPointZero, result: "ok", id: Id::Number(1) }).unwrap();
 		let exp = r#"{"jsonrpc":"2.0","result":"ok","id":1}"#;
 		assert_eq!(ser, exp);
 	}
 
 	#[test]
 	fn deserialize_call() {
-		let exp = JsonRpcResponse { jsonrpc: TwoPointZero, result: 99_u64, id: Id::Number(11) };
-		let dsr: JsonRpcResponse<u64> = serde_json::from_str(r#"{"jsonrpc":"2.0", "result":99, "id":11}"#).unwrap();
+		let exp = Response { jsonrpc: TwoPointZero, result: 99_u64, id: Id::Number(11) };
+		let dsr: Response<u64> = serde_json::from_str(r#"{"jsonrpc":"2.0", "result":99, "id":11}"#).unwrap();
 		assert_eq!(dsr.jsonrpc, exp.jsonrpc);
 		assert_eq!(dsr.result, exp.result);
 		assert_eq!(dsr.id, exp.id);

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -24,10 +24,13 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+//! Types pertaining to JSON-RPC responses.
+
 use crate::v2::params::{Id, TwoPointZero};
 use serde::{Deserialize, Serialize};
 
-/// JSON-RPC successful response object.
+
+/// JSON-RPC successful response object as defined in the [spec](https://www.jsonrpc.org/specification#response_object).
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Response<'a, T> {

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -26,7 +26,10 @@
 
 //! Types pertaining to JSON-RPC responses.
 
-use crate::v2::params::{Id, TwoPointZero};
+use crate::v2::{
+	params::{Id, SubscriptionId, TwoPointZero},
+	request::Notification,
+};
 use serde::{Deserialize, Serialize};
 
 /// JSON-RPC successful response object as defined in the [spec](https://www.jsonrpc.org/specification#response_object).
@@ -41,6 +44,18 @@ pub struct Response<'a, T> {
 	#[serde(borrow)]
 	pub id: Id<'a>,
 }
+
+/// Return value for subscriptions.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubscriptionPayload<T> {
+	/// Subscription ID
+	pub subscription: SubscriptionId,
+	/// Result.
+	pub result: T,
+}
+
+/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member.
+pub type SubscriptionResponse<'a, T> = Notification<'a, SubscriptionPayload<T>>;
 
 #[cfg(test)]
 mod tests {

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -29,7 +29,6 @@
 use crate::v2::params::{Id, TwoPointZero};
 use serde::{Deserialize, Serialize};
 
-
 /// JSON-RPC successful response object as defined in the [spec](https://www.jsonrpc.org/specification#response_object).
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -49,8 +48,7 @@ mod tests {
 
 	#[test]
 	fn serialize_call_response() {
-		let ser =
-			serde_json::to_string(&Response { jsonrpc: TwoPointZero, result: "ok", id: Id::Number(1) }).unwrap();
+		let ser = serde_json::to_string(&Response { jsonrpc: TwoPointZero, result: "ok", id: Id::Number(1) }).unwrap();
 		let exp = r#"{"jsonrpc":"2.0","result":"ok","id":1}"#;
 		assert_eq!(ser, exp);
 	}

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -27,7 +27,7 @@
 use crate::server::rpc_module::MethodSink;
 use futures_channel::mpsc;
 use futures_util::stream::StreamExt;
-use jsonrpsee_types::v2::error::{RpcError, ErrorCode, ErrorObject};
+use jsonrpsee_types::v2::error::{ErrorCode, ErrorObject, RpcError};
 use jsonrpsee_types::v2::params::{Id, TwoPointZero};
 use jsonrpsee_types::v2::request::InvalidRequest;
 use jsonrpsee_types::v2::response::Response;

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -27,15 +27,15 @@
 use crate::server::rpc_module::MethodSink;
 use futures_channel::mpsc;
 use futures_util::stream::StreamExt;
-use jsonrpsee_types::v2::error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject};
+use jsonrpsee_types::v2::error::{RpcError, JsonRpcErrorCode, JsonRpcErrorObject};
 use jsonrpsee_types::v2::params::{Id, TwoPointZero};
-use jsonrpsee_types::v2::request::JsonRpcInvalidRequest;
-use jsonrpsee_types::v2::response::JsonRpcResponse;
+use jsonrpsee_types::v2::request::InvalidRequest;
+use jsonrpsee_types::v2::response::Response;
 use serde::Serialize;
 
 /// Helper for sending JSON-RPC responses to the client
 pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
-	let json = match serde_json::to_string(&JsonRpcResponse { jsonrpc: TwoPointZero, id: id.clone(), result }) {
+	let json = match serde_json::to_string(&Response { jsonrpc: TwoPointZero, id: id.clone(), result }) {
 		Ok(json) => json,
 		Err(err) => {
 			log::error!("Error serializing response: {:?}", err);
@@ -51,7 +51,7 @@ pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
 
 /// Helper for sending JSON-RPC errors to the client
 pub fn send_error(id: Id, tx: &MethodSink, error: JsonRpcErrorObject) {
-	let json = match serde_json::to_string(&JsonRpcError { jsonrpc: TwoPointZero, error, id }) {
+	let json = match serde_json::to_string(&RpcError { jsonrpc: TwoPointZero, error, id }) {
 		Ok(json) => json,
 		Err(err) => {
 			log::error!("Error serializing error message: {:?}", err);
@@ -68,8 +68,8 @@ pub fn send_error(id: Id, tx: &MethodSink, error: JsonRpcErrorObject) {
 /// Figure out if this is a sufficiently complete request that we can extract an [`Id`] out of, or just plain
 /// unparseable garbage.
 pub fn prepare_error(data: &[u8]) -> (Id<'_>, JsonRpcErrorCode) {
-	match serde_json::from_slice::<JsonRpcInvalidRequest>(data) {
-		Ok(JsonRpcInvalidRequest { id }) => (id, JsonRpcErrorCode::InvalidRequest),
+	match serde_json::from_slice::<InvalidRequest>(data) {
+		Ok(InvalidRequest { id }) => (id, JsonRpcErrorCode::InvalidRequest),
 		Err(_) => (Id::Null, JsonRpcErrorCode::ParseError),
 	}
 }

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -27,7 +27,7 @@
 use crate::server::rpc_module::MethodSink;
 use futures_channel::mpsc;
 use futures_util::stream::StreamExt;
-use jsonrpsee_types::v2::error::{RpcError, JsonRpcErrorCode, JsonRpcErrorObject};
+use jsonrpsee_types::v2::error::{RpcError, ErrorCode, ErrorObject};
 use jsonrpsee_types::v2::params::{Id, TwoPointZero};
 use jsonrpsee_types::v2::request::InvalidRequest;
 use jsonrpsee_types::v2::response::Response;
@@ -40,7 +40,7 @@ pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
 		Err(err) => {
 			log::error!("Error serializing response: {:?}", err);
 
-			return send_error(id, tx, JsonRpcErrorCode::InternalError.into());
+			return send_error(id, tx, ErrorCode::InternalError.into());
 		}
 	};
 
@@ -50,7 +50,7 @@ pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
 }
 
 /// Helper for sending JSON-RPC errors to the client
-pub fn send_error(id: Id, tx: &MethodSink, error: JsonRpcErrorObject) {
+pub fn send_error(id: Id, tx: &MethodSink, error: ErrorObject) {
 	let json = match serde_json::to_string(&RpcError { jsonrpc: TwoPointZero, error, id }) {
 		Ok(json) => json,
 		Err(err) => {
@@ -67,10 +67,10 @@ pub fn send_error(id: Id, tx: &MethodSink, error: JsonRpcErrorObject) {
 
 /// Figure out if this is a sufficiently complete request that we can extract an [`Id`] out of, or just plain
 /// unparseable garbage.
-pub fn prepare_error(data: &[u8]) -> (Id<'_>, JsonRpcErrorCode) {
+pub fn prepare_error(data: &[u8]) -> (Id<'_>, ErrorCode) {
 	match serde_json::from_slice::<InvalidRequest>(data) {
-		Ok(InvalidRequest { id }) => (id, JsonRpcErrorCode::InvalidRequest),
-		Err(_) => (Id::Null, JsonRpcErrorCode::ParseError),
+		Ok(InvalidRequest { id }) => (id, ErrorCode::InvalidRequest),
+		Err(_) => (Id::Null, ErrorCode::ParseError),
 	}
 }
 

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -329,9 +329,9 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 
 	/// Register a new RPC subscription that invokes callback on every subscription request.
 	/// The callback itself takes three parameters:
-	///     - RpcParams: JSONRPC parameters in the subscription request.
-	///     - SubscriptionSink: A sink to send messages to the subscriber.
-	///     - Context: Any type that can be embedded into the RpcContextModule.
+	///     - [`Params`]: JSONRPC parameters in the subscription request.
+	///     - [`SubscriptionSink`]: A sink to send messages to the subscriber.
+	///     - Context: Any type that can be embedded into the [`RpcModule`].
 	///
 	/// # Examples
 	///
@@ -431,7 +431,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		Ok(())
 	}
 
-	/// Register an `alias` name for an `existing_method`.
+	/// Register an alias for an existing_method. Alias uniqueness is enforced at compile time.
 	pub fn register_alias(&mut self, alias: &'static str, existing_method: &'static str) -> Result<(), Error> {
 		self.methods.verify_method_name(alias)?;
 

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -35,7 +35,7 @@ use jsonrpsee_types::v2::error::{
 use jsonrpsee_types::v2::params::{
 	Id, JsonRpcSubscriptionParams, RpcParams, SubscriptionId as JsonRpcSubscriptionId, TwoPointZero,
 };
-use jsonrpsee_types::v2::request::{JsonRpcNotification, JsonRpcRequest};
+use jsonrpsee_types::v2::request::{Notification, Request};
 
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
@@ -84,7 +84,7 @@ impl MethodCallback {
 	pub fn execute(
 		&self,
 		tx: &MethodSink,
-		req: JsonRpcRequest<'_>,
+		req: Request<'_>,
 		conn_id: ConnectionId,
 	) -> Option<BoxFuture<'static, ()>> {
 		let id = req.id.clone();
@@ -168,7 +168,7 @@ impl Methods {
 	pub fn execute(
 		&self,
 		tx: &MethodSink,
-		req: JsonRpcRequest<'_>,
+		req: Request<'_>,
 		conn_id: ConnectionId,
 	) -> Option<BoxFuture<'static, ()>> {
 		match self.callbacks.get(&*req.method) {
@@ -183,7 +183,7 @@ impl Methods {
 	/// Helper alternative to `execute`, useful for writing unit tests without having to spin
 	/// a server up.
 	pub async fn call(&self, method: &str, params: Option<Box<RawValue>>) -> Option<String> {
-		let req = JsonRpcRequest {
+		let req = Request {
 			jsonrpc: TwoPointZero,
 			id: Id::Number(0),
 			method: Cow::borrowed(method),
@@ -486,7 +486,7 @@ impl SubscriptionSink {
 	}
 
 	fn build_message<T: Serialize>(&self, result: &T) -> Result<String, Error> {
-		serde_json::to_string(&JsonRpcNotification {
+		serde_json::to_string(&Notification {
 			jsonrpc: TwoPointZero,
 			method: self.method,
 			params: JsonRpcSubscriptionParams {

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -759,15 +759,14 @@ mod tests {
 		let (sub_id, mut my_sub_stream) = module.test_subscription("my_sub", None).await;
 		for i in (0..=2).rev() {
 			let my_sub = my_sub_stream.next().await.unwrap();
-			let my_sub = serde_json::from_str::<Notification<SubscriptionPayload<char>>>(&my_sub).unwrap();
+			let my_sub = serde_json::from_str::<SubscriptionResponse<char>>(&my_sub).unwrap();
 			assert_eq!(my_sub.params.result, std::char::from_digit(i, 10).unwrap());
 			assert_eq!(my_sub.params.subscription, v2::params::SubscriptionId::Num(sub_id));
 		}
 
 		// The subscription is now closed
 		let my_sub = my_sub_stream.next().await.unwrap();
-		let my_sub =
-			serde_json::from_str::<Notification<SubscriptionPayload<SubscriptionClosedError>>>(&my_sub).unwrap();
+		let my_sub = serde_json::from_str::<SubscriptionResponse<SubscriptionClosedError>>(&my_sub).unwrap();
 		assert_eq!(my_sub.params.result, format!("Subscription: {} is closed and dropped", sub_id).to_string().into());
 	}
 }

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -487,7 +487,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		Ok(())
 	}
 
-	/// Register an alias for an existing_method. Alias uniqueness is enforced at compile time.
+	/// Register an alias for an existing_method. Alias uniqueness is enforced.
 	pub fn register_alias(&mut self, alias: &'static str, existing_method: &'static str) -> Result<(), Error> {
 		self.methods.verify_method_name(alias)?;
 
@@ -579,7 +579,6 @@ fn subscription_closed_err(sub_id: u64) -> Error {
 mod tests {
 	use super::*;
 	use jsonrpsee_types::v2;
-	use jsonrpsee_types::v2::request::Notification;
 	use serde::Deserialize;
 	use std::collections::HashMap;
 

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -51,9 +51,9 @@ use futures::{
 	prelude::*,
 	sink::SinkExt,
 };
+use jsonrpsee_types::v2::response::SubscriptionResponse;
 use tokio::sync::Mutex;
 
-use jsonrpsee_types::v2::params::SubscriptionParams;
 use jsonrpsee_types::SubscriptionKind;
 use serde::de::DeserializeOwned;
 use std::{
@@ -628,9 +628,9 @@ async fn background_task(
 					}
 				}
 				// Subscription response.
-				else if let Ok(notif) = serde_json::from_slice::<Notification<SubscriptionParams<_>>>(&raw) {
-					log::debug!("[backend]: recv subscription {:?}", notif);
-					if let Err(Some(unsub)) = process_subscription_response(&mut manager, notif) {
+				else if let Ok(response) = serde_json::from_slice::<SubscriptionResponse<_>>(&raw) {
+					log::debug!("[backend]: recv subscription {:?}", response);
+					if let Err(Some(unsub)) = process_subscription_response(&mut manager, response) {
 						let _ = stop_subscription(&mut sender, &mut manager, unsub).await;
 					}
 				}

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -29,7 +29,7 @@ use crate::types::{
 	traits::{Client, SubscriptionClient},
 	v2::{
 		error::RpcError,
-		params::{Id, RpcParamsSer},
+		params::{Id, ParamsSer},
 		request::{Notification, NotificationSer, RequestSer},
 		response::Response,
 	},
@@ -306,7 +306,7 @@ impl WsClient {
 
 #[async_trait]
 impl Client for WsClient {
-	async fn notification<'a>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<(), Error> {
+	async fn notification<'a>(&self, method: &'a str, params: ParamsSer<'a>) -> Result<(), Error> {
 		// NOTE: we use this to guard against max number of concurrent requests.
 		let _req_id = self.id_guard.next_request_id()?;
 		let notif = NotificationSer::new(method, params);
@@ -333,7 +333,7 @@ impl Client for WsClient {
 		}
 	}
 
-	async fn request<'a, R>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<R, Error>
+	async fn request<'a, R>(&self, method: &'a str, params: ParamsSer<'a>) -> Result<R, Error>
 	where
 		R: DeserializeOwned,
 	{
@@ -367,7 +367,7 @@ impl Client for WsClient {
 		serde_json::from_value(json_value).map_err(Error::ParseError)
 	}
 
-	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, RpcParamsSer<'a>)>) -> Result<Vec<R>, Error>
+	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, ParamsSer<'a>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone,
 	{
@@ -420,7 +420,7 @@ impl SubscriptionClient for WsClient {
 	async fn subscribe<'a, N>(
 		&self,
 		subscribe_method: &'a str,
-		params: RpcParamsSer<'a>,
+		params: ParamsSer<'a>,
 		unsubscribe_method: &'a str,
 	) -> Result<Subscription<N>, Error>
 	where

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -30,7 +30,7 @@ use crate::types::{
 	v2::{
 		error::RpcError,
 		params::{Id, RpcParamsSer},
-		request::{RequestSer, Notification, NotificationSer},
+		request::{Notification, NotificationSer, RequestSer},
 		response::Response,
 	},
 	BatchMessage, Error, FrontToBack, RegisterNotificationMessage, RequestMessage, Subscription, SubscriptionMessage,
@@ -628,9 +628,7 @@ async fn background_task(
 					}
 				}
 				// Subscription response.
-				else if let Ok(notif) =
-					serde_json::from_slice::<Notification<SubscriptionParams<_>>>(&raw)
-				{
+				else if let Ok(notif) = serde_json::from_slice::<Notification<SubscriptionParams<_>>>(&raw) {
 					log::debug!("[backend]: recv subscription {:?}", notif);
 					if let Err(Some(unsub)) = process_subscription_response(&mut manager, notif) {
 						let _ = stop_subscription(&mut sender, &mut manager, unsub).await;

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -29,8 +29,8 @@ use crate::types::{
 	traits::{Client, SubscriptionClient},
 	v2::{
 		error::RpcError,
-		params::{Id, Params},
-		request::{CallSer, Notification, NotificationSer},
+		params::{Id, RpcParamsSer},
+		request::{RequestSer, Notification, NotificationSer},
 		response::Response,
 	},
 	BatchMessage, Error, FrontToBack, RegisterNotificationMessage, RequestMessage, Subscription, SubscriptionMessage,
@@ -53,7 +53,7 @@ use futures::{
 };
 use tokio::sync::Mutex;
 
-use jsonrpsee_types::v2::params::JsonRpcSubscriptionParams;
+use jsonrpsee_types::v2::params::SubscriptionParams;
 use jsonrpsee_types::SubscriptionKind;
 use serde::de::DeserializeOwned;
 use std::{
@@ -306,7 +306,7 @@ impl WsClient {
 
 #[async_trait]
 impl Client for WsClient {
-	async fn notification<'a>(&self, method: &'a str, params: Params<'a>) -> Result<(), Error> {
+	async fn notification<'a>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<(), Error> {
 		// NOTE: we use this to guard against max number of concurrent requests.
 		let _req_id = self.id_guard.next_request_id()?;
 		let notif = NotificationSer::new(method, params);
@@ -333,13 +333,13 @@ impl Client for WsClient {
 		}
 	}
 
-	async fn request<'a, R>(&self, method: &'a str, params: Params<'a>) -> Result<R, Error>
+	async fn request<'a, R>(&self, method: &'a str, params: RpcParamsSer<'a>) -> Result<R, Error>
 	where
 		R: DeserializeOwned,
 	{
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		let req_id = self.id_guard.next_request_id()?;
-		let raw = serde_json::to_string(&CallSer::new(Id::Number(req_id), method, params)).map_err(|e| {
+		let raw = serde_json::to_string(&RequestSer::new(Id::Number(req_id), method, params)).map_err(|e| {
 			self.id_guard.reclaim_request_id();
 			Error::ParseError(e)
 		})?;
@@ -367,7 +367,7 @@ impl Client for WsClient {
 		serde_json::from_value(json_value).map_err(Error::ParseError)
 	}
 
-	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, Params<'a>)>) -> Result<Vec<R>, Error>
+	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, RpcParamsSer<'a>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone,
 	{
@@ -375,7 +375,7 @@ impl Client for WsClient {
 		let mut batches = Vec::with_capacity(batch.len());
 
 		for (idx, (method, params)) in batch.into_iter().enumerate() {
-			batches.push(CallSer::new(Id::Number(batch_ids[idx]), method, params));
+			batches.push(RequestSer::new(Id::Number(batch_ids[idx]), method, params));
 		}
 
 		let (send_back_tx, send_back_rx) = oneshot::channel();
@@ -420,7 +420,7 @@ impl SubscriptionClient for WsClient {
 	async fn subscribe<'a, N>(
 		&self,
 		subscribe_method: &'a str,
-		params: Params<'a>,
+		params: RpcParamsSer<'a>,
 		unsubscribe_method: &'a str,
 	) -> Result<Subscription<N>, Error>
 	where
@@ -434,7 +434,7 @@ impl SubscriptionClient for WsClient {
 
 		let ids = self.id_guard.next_request_ids(2)?;
 		let raw =
-			serde_json::to_string(&CallSer::new(Id::Number(ids[0]), subscribe_method, params)).map_err(|e| {
+			serde_json::to_string(&RequestSer::new(Id::Number(ids[0]), subscribe_method, params)).map_err(|e| {
 				self.id_guard.reclaim_request_id();
 				Error::ParseError(e)
 			})?;
@@ -629,7 +629,7 @@ async fn background_task(
 				}
 				// Subscription response.
 				else if let Ok(notif) =
-					serde_json::from_slice::<Notification<JsonRpcSubscriptionParams<_>>>(&raw)
+					serde_json::from_slice::<Notification<SubscriptionParams<_>>>(&raw)
 				{
 					log::debug!("[backend]: recv subscription {:?}", notif);
 					if let Err(Some(unsub)) = process_subscription_response(&mut manager, notif) {

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -28,8 +28,8 @@ use crate::manager::{RequestManager, RequestStatus};
 use crate::transport::Sender as WsSender;
 use crate::types::v2::{
 	error::RpcError,
-	params::{Id, Params, JsonRpcSubscriptionParams, SubscriptionId},
-	request::{CallSer, Notification},
+	params::{Id, RpcParamsSer, SubscriptionParams, SubscriptionId},
+	request::{RequestSer, Notification},
 	response::Response,
 };
 use crate::types::{Error, RequestMessage};
@@ -76,7 +76,7 @@ pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<Response<Js
 /// Returns `Err(Some(msg))` if the subscription was full.
 pub fn process_subscription_response(
 	manager: &mut RequestManager,
-	notif: Notification<JsonRpcSubscriptionParams<JsonValue>>,
+	notif: Notification<SubscriptionParams<JsonValue>>,
 ) -> Result<(), Option<RequestMessage>> {
 	let sub_id = notif.params.subscription;
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
@@ -193,8 +193,8 @@ pub fn build_unsubscribe_message(
 	let (unsub_req_id, _, unsub, sub_id) = manager.remove_subscription(sub_req_id, sub_id)?;
 	let sub_id_slice: &[JsonValue] = &[sub_id.into()];
 	// TODO: https://github.com/paritytech/jsonrpsee/issues/275
-	let params = Params::ArrayRef(sub_id_slice);
-	let raw = serde_json::to_string(&CallSer::new(Id::Number(unsub_req_id), &unsub, params)).ok()?;
+	let params = RpcParamsSer::ArrayRef(sub_id_slice);
+	let raw = serde_json::to_string(&RequestSer::new(Id::Number(unsub_req_id), &unsub, params)).ok()?;
 	Some(RequestMessage { raw, id: unsub_req_id, send_back: None })
 }
 

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -28,8 +28,8 @@ use crate::manager::{RequestManager, RequestStatus};
 use crate::transport::Sender as WsSender;
 use crate::types::v2::{
 	error::RpcError,
-	params::{Id, RpcParamsSer, SubscriptionParams, SubscriptionId},
-	request::{RequestSer, Notification},
+	params::{Id, RpcParamsSer, SubscriptionId, SubscriptionParams},
+	request::{Notification, RequestSer},
 	response::Response,
 };
 use crate::types::{Error, RequestMessage};

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -28,7 +28,7 @@ use crate::manager::{RequestManager, RequestStatus};
 use crate::transport::Sender as WsSender;
 use crate::types::v2::{
 	error::RpcError,
-	params::{Id, RpcParamsSer, SubscriptionId, SubscriptionParams},
+	params::{Id, ParamsSer, SubscriptionId, SubscriptionParams},
 	request::{Notification, RequestSer},
 	response::Response,
 };
@@ -193,7 +193,7 @@ pub fn build_unsubscribe_message(
 	let (unsub_req_id, _, unsub, sub_id) = manager.remove_subscription(sub_req_id, sub_id)?;
 	let sub_id_slice: &[JsonValue] = &[sub_id.into()];
 	// TODO: https://github.com/paritytech/jsonrpsee/issues/275
-	let params = RpcParamsSer::ArrayRef(sub_id_slice);
+	let params = ParamsSer::ArrayRef(sub_id_slice);
 	let raw = serde_json::to_string(&RequestSer::new(Id::Number(unsub_req_id), &unsub, params)).ok()?;
 	Some(RequestMessage { raw, id: unsub_req_id, send_back: None })
 }

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -73,7 +73,7 @@ pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<Response<Js
 ///
 /// Returns `Ok()` if the response was successfully sent to the frontend.
 /// Return `Err(None)` if the subscription was not found.
-/// Returns `Err(Some(msg))` if the channel to the frontend was full.
+/// Returns `Err(Some(msg))` if the channel to the `Subscription` was full.
 pub fn process_subscription_response(
 	manager: &mut RequestManager,
 	response: SubscriptionResponse<JsonValue>,

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -27,10 +27,10 @@
 use crate::manager::{RequestManager, RequestStatus};
 use crate::transport::Sender as WsSender;
 use crate::types::v2::{
-	error::JsonRpcError,
-	params::{Id, JsonRpcParams, JsonRpcSubscriptionParams, SubscriptionId},
-	request::{JsonRpcCallSer, JsonRpcNotification},
-	response::JsonRpcResponse,
+	error::RpcError,
+	params::{Id, Params, JsonRpcSubscriptionParams, SubscriptionId},
+	request::{CallSer, Notification},
+	response::Response,
 };
 use crate::types::{Error, RequestMessage};
 use futures::channel::{mpsc, oneshot};
@@ -40,7 +40,7 @@ use std::time::Duration;
 /// Attempts to process a batch response.
 ///
 /// On success the result is sent to the frontend.
-pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<JsonRpcResponse<JsonValue>>) -> Result<(), Error> {
+pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<Response<JsonValue>>) -> Result<(), Error> {
 	let mut digest = Vec::with_capacity(rps.len());
 	let mut ordered_responses = vec![JsonValue::Null; rps.len()];
 	let mut rps_unordered: Vec<_> = Vec::with_capacity(rps.len());
@@ -76,7 +76,7 @@ pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<JsonRpcResp
 /// Returns `Err(Some(msg))` if the subscription was full.
 pub fn process_subscription_response(
 	manager: &mut RequestManager,
-	notif: JsonRpcNotification<JsonRpcSubscriptionParams<JsonValue>>,
+	notif: Notification<JsonRpcSubscriptionParams<JsonValue>>,
 ) -> Result<(), Option<RequestMessage>> {
 	let sub_id = notif.params.subscription;
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
@@ -105,7 +105,7 @@ pub fn process_subscription_response(
 ///
 /// Returns Ok() if the response was successfully handled
 /// Returns Err() if there was no handler for the method
-pub fn process_notification(manager: &mut RequestManager, notif: JsonRpcNotification<JsonValue>) -> Result<(), Error> {
+pub fn process_notification(manager: &mut RequestManager, notif: Notification<JsonValue>) -> Result<(), Error> {
 	match manager.as_notification_handler_mut(notif.method.to_owned()) {
 		Some(send_back_sink) => match send_back_sink.try_send(notif.params) {
 			Ok(()) => Ok(()),
@@ -129,7 +129,7 @@ pub fn process_notification(manager: &mut RequestManager, notif: JsonRpcNotifica
 /// Returns `Err(_)` if the response couldn't be handled.
 pub fn process_single_response(
 	manager: &mut RequestManager,
-	response: JsonRpcResponse<JsonValue>,
+	response: Response<JsonValue>,
 	max_capacity_per_subscription: usize,
 ) -> Result<Option<RequestMessage>, Error> {
 	let response_id = response.id.as_number().copied().ok_or(Error::InvalidRequestId)?;
@@ -193,8 +193,8 @@ pub fn build_unsubscribe_message(
 	let (unsub_req_id, _, unsub, sub_id) = manager.remove_subscription(sub_req_id, sub_id)?;
 	let sub_id_slice: &[JsonValue] = &[sub_id.into()];
 	// TODO: https://github.com/paritytech/jsonrpsee/issues/275
-	let params = JsonRpcParams::ArrayRef(sub_id_slice);
-	let raw = serde_json::to_string(&JsonRpcCallSer::new(Id::Number(unsub_req_id), &unsub, params)).ok()?;
+	let params = Params::ArrayRef(sub_id_slice);
+	let raw = serde_json::to_string(&CallSer::new(Id::Number(unsub_req_id), &unsub, params)).ok()?;
 	Some(RequestMessage { raw, id: unsub_req_id, send_back: None })
 }
 
@@ -202,7 +202,7 @@ pub fn build_unsubscribe_message(
 ///
 /// Returns `Ok` if the response was successfully sent.
 /// Returns `Err(_)` if the response ID was not found.
-pub fn process_error_response(manager: &mut RequestManager, err: JsonRpcError) -> Result<(), Error> {
+pub fn process_error_response(manager: &mut RequestManager, err: RpcError) -> Result<(), Error> {
 	let id = err.id.as_number().copied().ok_or(Error::InvalidRequestId)?;
 	match manager.request_status(&id) {
 		RequestStatus::PendingMethodCall => {

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -28,7 +28,7 @@
 use crate::types::{
 	traits::{Client, SubscriptionClient},
 	v2::{
-		error::{RpcError, ErrorCode, ErrorObject},
+		error::{ErrorCode, ErrorObject, RpcError},
 		params::RpcParamsSer,
 	},
 	Error, Subscription,

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -28,8 +28,8 @@
 use crate::types::{
 	traits::{Client, SubscriptionClient},
 	v2::{
-		error::{JsonRpcError, JsonRpcErrorCode, JsonRpcErrorObject},
-		params::JsonRpcParams,
+		error::{RpcError, JsonRpcErrorCode, JsonRpcErrorObject},
+		params::Params,
 	},
 	Error, Subscription,
 };
@@ -58,7 +58,7 @@ async fn notif_works() {
 		.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
-	assert!(client.notification("notif", JsonRpcParams::NoParams).with_default_timeout().await.unwrap().is_ok());
+	assert!(client.notification("notif", Params::NoParams).with_default_timeout().await.unwrap().is_ok());
 }
 
 #[tokio::test]
@@ -119,7 +119,7 @@ async fn subscription_works() {
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	{
 		let mut sub: Subscription<String> = client
-			.subscribe("subscribe_hello", JsonRpcParams::NoParams, "unsubscribe_hello")
+			.subscribe("subscribe_hello", Params::NoParams, "unsubscribe_hello")
 			.with_default_timeout()
 			.await
 			.unwrap()
@@ -193,9 +193,9 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 #[tokio::test]
 async fn batch_request_works() {
 	let batch_request = vec![
-		("say_hello", JsonRpcParams::NoParams),
-		("say_goodbye", JsonRpcParams::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", JsonRpcParams::NoParams),
+		("say_hello", Params::NoParams),
+		("say_goodbye", Params::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", Params::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}, {"jsonrpc":"2.0","result":"here's your swag","id":2}]"#.to_string();
 	let response =
@@ -206,9 +206,9 @@ async fn batch_request_works() {
 #[tokio::test]
 async fn batch_request_out_of_order_response() {
 	let batch_request = vec![
-		("say_hello", JsonRpcParams::NoParams),
-		("say_goodbye", JsonRpcParams::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", JsonRpcParams::NoParams),
+		("say_hello", Params::NoParams),
+		("say_goodbye", Params::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", Params::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"here's your swag","id":2}, {"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}]"#.to_string();
 	let response =
@@ -228,14 +228,14 @@ async fn is_connected_works() {
 	let uri = to_ws_uri_string(server.local_addr());
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	assert!(client.is_connected());
-	client.request::<String>("say_hello", JsonRpcParams::NoParams).with_default_timeout().await.unwrap().unwrap_err();
+	client.request::<String>("say_hello", Params::NoParams).with_default_timeout().await.unwrap().unwrap_err();
 	// give the background thread some time to terminate.
 	std::thread::sleep(std::time::Duration::from_millis(100));
 	assert!(!client.is_connected())
 }
 
 async fn run_batch_request_with_response<'a>(
-	batch: Vec<(&'a str, JsonRpcParams<'a>)>,
+	batch: Vec<(&'a str, Params<'a>)>,
 	response: String,
 ) -> Result<Vec<String>, Error> {
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), response)
@@ -254,13 +254,13 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 		.unwrap();
 	let uri = format!("ws://{}", server.local_addr());
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
-	client.request("say_hello", JsonRpcParams::NoParams).with_default_timeout().await.unwrap()
+	client.request("say_hello", Params::NoParams).with_default_timeout().await.unwrap()
 }
 
 fn assert_error_response(err: Error, exp: JsonRpcErrorObject) {
 	match &err {
 		Error::Request(e) => {
-			let this: JsonRpcError = serde_json::from_str(e).unwrap();
+			let this: RpcError = serde_json::from_str(e).unwrap();
 			assert_eq!(this.error, exp);
 		}
 		e => panic!("Expected error: \"{}\", got: {:?}", err, e),

--- a/ws-client/src/tests.rs
+++ b/ws-client/src/tests.rs
@@ -29,7 +29,7 @@ use crate::types::{
 	traits::{Client, SubscriptionClient},
 	v2::{
 		error::{ErrorCode, ErrorObject, RpcError},
-		params::RpcParamsSer,
+		params::ParamsSer,
 	},
 	Error, Subscription,
 };
@@ -58,7 +58,7 @@ async fn notif_works() {
 		.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
-	assert!(client.notification("notif", RpcParamsSer::NoParams).with_default_timeout().await.unwrap().is_ok());
+	assert!(client.notification("notif", ParamsSer::NoParams).with_default_timeout().await.unwrap().is_ok());
 }
 
 #[tokio::test]
@@ -119,7 +119,7 @@ async fn subscription_works() {
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	{
 		let mut sub: Subscription<String> = client
-			.subscribe("subscribe_hello", RpcParamsSer::NoParams, "unsubscribe_hello")
+			.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello")
 			.with_default_timeout()
 			.await
 			.unwrap()
@@ -193,9 +193,9 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 #[tokio::test]
 async fn batch_request_works() {
 	let batch_request = vec![
-		("say_hello", RpcParamsSer::NoParams),
-		("say_goodbye", RpcParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", RpcParamsSer::NoParams),
+		("say_hello", ParamsSer::NoParams),
+		("say_goodbye", ParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", ParamsSer::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}, {"jsonrpc":"2.0","result":"here's your swag","id":2}]"#.to_string();
 	let response =
@@ -206,9 +206,9 @@ async fn batch_request_works() {
 #[tokio::test]
 async fn batch_request_out_of_order_response() {
 	let batch_request = vec![
-		("say_hello", RpcParamsSer::NoParams),
-		("say_goodbye", RpcParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
-		("get_swag", RpcParamsSer::NoParams),
+		("say_hello", ParamsSer::NoParams),
+		("say_goodbye", ParamsSer::Array(vec![0_u64.into(), 1.into(), 2.into()])),
+		("get_swag", ParamsSer::NoParams),
 	];
 	let server_response = r#"[{"jsonrpc":"2.0","result":"here's your swag","id":2}, {"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","result":"goodbye","id":1}]"#.to_string();
 	let response =
@@ -228,14 +228,14 @@ async fn is_connected_works() {
 	let uri = to_ws_uri_string(server.local_addr());
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	assert!(client.is_connected());
-	client.request::<String>("say_hello", RpcParamsSer::NoParams).with_default_timeout().await.unwrap().unwrap_err();
+	client.request::<String>("say_hello", ParamsSer::NoParams).with_default_timeout().await.unwrap().unwrap_err();
 	// give the background thread some time to terminate.
 	std::thread::sleep(std::time::Duration::from_millis(100));
 	assert!(!client.is_connected())
 }
 
 async fn run_batch_request_with_response<'a>(
-	batch: Vec<(&'a str, RpcParamsSer<'a>)>,
+	batch: Vec<(&'a str, ParamsSer<'a>)>,
 	response: String,
 ) -> Result<Vec<String>, Error> {
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), response)
@@ -254,7 +254,7 @@ async fn run_request_with_response(response: String) -> Result<JsonValue, Error>
 		.unwrap();
 	let uri = format!("ws://{}", server.local_addr());
 	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
-	client.request("say_hello", RpcParamsSer::NoParams).with_default_timeout().await.unwrap()
+	client.request("say_hello", ParamsSer::NoParams).with_default_timeout().await.unwrap()
 }
 
 fn assert_error_response(err: Error, exp: ErrorObject) {

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -30,9 +30,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::future::{FutureDriver, StopHandle, StopMonitor};
-use crate::types::{
-	error::Error, v2::error::ErrorCode, v2::params::Id, v2::request::Request, TEN_MB_SIZE_BYTES,
-};
+use crate::types::{error::Error, v2::error::ErrorCode, v2::params::Id, v2::request::Request, TEN_MB_SIZE_BYTES};
 use futures_channel::mpsc;
 use futures_util::io::{BufReader, BufWriter};
 // use futures_util::future::FutureExt;

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -31,7 +31,7 @@ use std::task::{Context, Poll};
 
 use crate::future::{FutureDriver, StopHandle, StopMonitor};
 use crate::types::{
-	error::Error, v2::error::JsonRpcErrorCode, v2::params::Id, v2::request::Request, TEN_MB_SIZE_BYTES,
+	error::Error, v2::error::ErrorCode, v2::params::Id, v2::request::Request, TEN_MB_SIZE_BYTES,
 };
 use futures_channel::mpsc;
 use futures_util::io::{BufReader, BufWriter};
@@ -226,7 +226,7 @@ async fn background_task(
 
 		if data.len() > max_request_body_size as usize {
 			log::warn!("Request is too big ({} bytes, max is {})", data.len(), max_request_body_size);
-			send_error(Id::Null, &tx, JsonRpcErrorCode::OversizedRequest.into());
+			send_error(Id::Null, &tx, ErrorCode::OversizedRequest.into());
 			continue;
 		}
 
@@ -262,14 +262,14 @@ async fn background_task(
 							log::error!("Error sending batch response to the client: {:?}", err)
 						}
 					} else {
-						send_error(Id::Null, &tx, JsonRpcErrorCode::InvalidRequest.into());
+						send_error(Id::Null, &tx, ErrorCode::InvalidRequest.into());
 					}
 				} else {
 					let (id, code) = prepare_error(&data);
 					send_error(id, &tx, code.into());
 				}
 			}
-			_ => send_error(Id::Null, &tx, JsonRpcErrorCode::ParseError.into()),
+			_ => send_error(Id::Null, &tx, ErrorCode::ParseError.into()),
 		}
 	}
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -31,7 +31,7 @@ use std::task::{Context, Poll};
 
 use crate::future::{FutureDriver, StopHandle, StopMonitor};
 use crate::types::{
-	error::Error, v2::error::JsonRpcErrorCode, v2::params::Id, v2::request::JsonRpcRequest, TEN_MB_SIZE_BYTES,
+	error::Error, v2::error::JsonRpcErrorCode, v2::params::Id, v2::request::Request, TEN_MB_SIZE_BYTES,
 };
 use futures_channel::mpsc;
 use futures_util::io::{BufReader, BufWriter};
@@ -232,7 +232,7 @@ async fn background_task(
 
 		match data.get(0) {
 			Some(b'{') => {
-				if let Ok(req) = serde_json::from_slice::<JsonRpcRequest>(&data) {
+				if let Ok(req) = serde_json::from_slice::<Request>(&data) {
 					log::debug!("recv: {:?}", req);
 					if let Some(fut) = methods.execute(&tx, req, conn_id) {
 						method_executors.add(fut);
@@ -243,7 +243,7 @@ async fn background_task(
 				}
 			}
 			Some(b'[') => {
-				if let Ok(batch) = serde_json::from_slice::<Vec<JsonRpcRequest>>(&data) {
+				if let Ok(batch) = serde_json::from_slice::<Vec<Request>>(&data) {
 					if !batch.is_empty() {
 						// Batch responses must be sent back as a single message so we read the results from each request in the
 						// batch and read the results off of a new channel, `rx_batch`, and then send the complete batch response


### PR DESCRIPTION
⚠️  Breaking change ⚠️ 

Closes #457﻿.

The changes here mostly removes the `JsonRpc` prefix from the types that come from the spec. I have kept a prefix for some types with a very common stdlib version such as `Result` and `Error`. I also changed the serializable versions to consistently use the `*Ser` postfix (not loving this convention but have no better suggestion).

I'm tempted to make the `jsonrpsee-types` paths more shallow, i.e. re-export all the modules under `v2`, so that instead of doing `jsonrpsee-types::v2::error::RpcError` we'd have `jsonrpsee-types::v2::RpcError`; instead of `jsonrpsee-types::v2::response::Response` we'd have `jsonrpsee-types::v2::Response` etc. Thoughts?