### PR TITLE
Remove unstable rustfmt comment wrapping/limiting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,5 +2,3 @@ hard_tabs = true
 max_width = 120
 use_small_heuristics = "Max"
 edition = "2018"
-wrap_comments = true
-comment_width = 120


### PR DESCRIPTION
In #461 I missed that these options are not stable so it breaks our CI. This PR reverts that change while keeping the whitespace changes from #461.

Apologies for the noise.
