### PR TITLE
Fix build warnings

### DIFF
--- a/http-server/src/access_control/mod.rs
+++ b/http-server/src/access_control/mod.rs
@@ -41,6 +41,8 @@ use jsonrpsee_utils::http_helpers;
 pub struct AccessControl {
 	allow_hosts: AllowHosts,
 	cors_allow_origin: Option<Vec<AccessControlAllowOrigin>>,
+	// TODO: (dp) We never set this header in the response headers.
+	#[allow(dead_code)]
 	cors_max_age: Option<u32>,
 	cors_allow_headers: AccessControlAllowHeaders,
 	continue_on_invalid_cors: bool,

--- a/http-server/src/access_control/mod.rs
+++ b/http-server/src/access_control/mod.rs
@@ -41,8 +41,6 @@ use jsonrpsee_utils::http_helpers;
 pub struct AccessControl {
 	allow_hosts: AllowHosts,
 	cors_allow_origin: Option<Vec<AccessControlAllowOrigin>>,
-	// TODO: (dp) We never set this header in the response headers.
-	#[allow(dead_code)]
 	cors_max_age: Option<u32>,
 	cors_allow_headers: AccessControlAllowHeaders,
 	continue_on_invalid_cors: bool,

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -106,7 +106,6 @@ impl Builder {
 		Ok(Server {
 			listener,
 			local_addr,
-			methods: Methods::default(),
 			access_control: self.access_control,
 			max_request_body_size: self.max_request_body_size,
 			stop_pair,
@@ -147,8 +146,6 @@ pub struct Server {
 	listener: HyperBuilder<AddrIncoming>,
 	/// Local address
 	local_addr: Option<SocketAddr>,
-	/// Registered methods.
-	methods: Methods,
 	/// Max request body size.
 	max_request_body_size: u32,
 	/// Access control

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -49,7 +49,6 @@ const MAX_CONNECTIONS: u64 = 100;
 /// A WebSocket JSON RPC server.
 #[derive(Debug)]
 pub struct Server {
-	methods: Methods,
 	listener: TcpListener,
 	cfg: Settings,
 	stop_monitor: StopMonitor,
@@ -439,7 +438,7 @@ impl Builder {
 	pub async fn build(self, addr: impl ToSocketAddrs) -> Result<Server, Error> {
 		let listener = TcpListener::bind(addr).await?;
 		let stop_monitor = StopMonitor::new();
-		Ok(Server { listener, methods: Methods::default(), cfg: self.settings, stop_monitor })
+		Ok(Server { listener, cfg: self.settings, stop_monitor })
 	}
 }
 


### PR DESCRIPTION
Looks like we had a few fields left over from recent refactorings.

The matter of `AccessControl::cors_max_age` is less clear-cut. I don't remember where we're at with preflight and CORS, but I think we support it and that we should set the `Access-Control-Max-Age` header [here](https://github.com/paritytech/jsonrpsee/blob/master/http-server/src/server.rs#L266), but only for pre-flight requests?
