### PR TITLE
Share the request id code between the http and websocket clients

### DIFF
--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -159,11 +159,11 @@ impl Client for HttpClient {
 		let mut ordered_requests = Vec::with_capacity(batch.len());
 		let mut request_set = FnvHashMap::with_capacity_and_hasher(batch.len(), Default::default());
 
+		let ids = self.id_guard.next_request_ids(batch.len())?;
 		for (pos, (method, params)) in batch.into_iter().enumerate() {
-			let id = self.id_guard.next_request_id()?;
-			batch_request.push(RequestSer::new(Id::Number(id), method, params));
-			ordered_requests.push(id);
-			request_set.insert(id, pos);
+			batch_request.push(RequestSer::new(Id::Number(ids[pos]), method, params));
+			ordered_requests.push(ids[pos]);
+			request_set.insert(ids[pos], pos);
 		}
 
 		let fut = self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(|e| {

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -94,6 +94,21 @@ async fn http_method_call_works() {
 }
 
 #[tokio::test]
+async fn http_concurrent_method_call_limits_works() {
+	let server_addr = http_server().await;
+	let uri = format!("http://{}", server_addr);
+	let client = HttpClientBuilder::default().max_concurrent_requests(1).build(&uri).unwrap();
+
+	let (first, second) = tokio::join!(
+		client.request::<String>("say_hello", ParamsSer::NoParams),
+		client.request::<String>("say_hello", ParamsSer::NoParams),
+	);
+
+	assert!(first.is_ok());
+	assert!(matches!(second, Err(Error::MaxSlotsExceeded)));
+}
+
+#[tokio::test]
 async fn ws_subscription_several_clients() {
 	let (server_addr, _) = websocket_server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
@@ -187,10 +202,29 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 }
 
 #[tokio::test]
-async fn ws_more_request_than_buffer_should_not_deadlock() {
+async fn ws_making_more_requests_than_allowed_should_not_deadlock() {
 	let server_addr = websocket_server().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = Arc::new(WsClientBuilder::default().max_concurrent_requests(2).build(&server_url).await.unwrap());
+
+	let mut requests = Vec::new();
+
+	for _ in 0..6 {
+		let c = client.clone();
+		requests.push(tokio::spawn(async move { c.request::<String>("say_hello", ParamsSer::NoParams).await }));
+	}
+
+	for req in requests {
+		let _ = req.await.unwrap();
+	}
+}
+
+#[tokio::test]
+async fn http_making_more_requests_than_allowed_should_not_deadlock() {
+	let server_addr = http_server().await;
+	let server_url = format!("http://{}", server_addr);
+	let client = HttpClientBuilder::default().max_concurrent_requests(2).build(&server_url).unwrap();
+	let client = Arc::new(client);
 
 	let mut requests = Vec::new();
 

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -203,8 +203,7 @@ impl RequestIdGuard {
 		Self { current_pending: AtomicUsize::new(0), max_concurrent_requests: limit, current_id: AtomicU64::new(0) }
 	}
 
-	/// TODO docs
-	pub fn get_slot(&self) -> Result<(), Error> {
+	fn get_slot(&self) -> Result<(), Error> {
 		self.current_pending
 			.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
 				if val >= self.max_concurrent_requests {
@@ -238,7 +237,7 @@ impl RequestIdGuard {
 		Ok(batch)
 	}
 
-	/// TODO docs
+	/// Decrease the currently pending counter by one (saturated at 0).
 	pub fn reclaim_request_id(&self) {
 		// NOTE we ignore the error here, since we are simply saturating at 0
 		let _ = self.current_pending.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -30,6 +30,7 @@ use futures_channel::{mpsc, oneshot};
 use futures_util::{future::FutureExt, sink::SinkExt, stream::StreamExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 /// Subscription kind
 #[derive(Debug)]
@@ -182,5 +183,70 @@ impl<Notif> Drop for Subscription<Notif> {
 			SubscriptionKind::Subscription(sub_id) => FrontToBack::SubscriptionClosed(sub_id),
 		};
 		let _ = self.to_back.send(msg).now_or_never();
+	}
+}
+
+#[derive(Debug)]
+/// TODO docs
+pub struct RequestIdGuard {
+	// Current pending requests.
+	current_pending: AtomicUsize,
+	/// Max concurrent pending requests allowed.
+	max_concurrent_requests: usize,
+	/// Get the next request ID.
+	current_id: AtomicU64,
+}
+
+impl RequestIdGuard {
+	/// TODO docs
+	pub fn new(limit: usize) -> Self {
+		Self { current_pending: AtomicUsize::new(0), max_concurrent_requests: limit, current_id: AtomicU64::new(0) }
+	}
+
+	/// TODO docs
+	pub fn get_slot(&self) -> Result<(), Error> {
+		self.current_pending
+			.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+				if val >= self.max_concurrent_requests {
+					None
+				} else {
+					Some(val + 1)
+				}
+			})
+			.map(|_| ())
+			.map_err(|_| Error::MaxSlotsExceeded)
+	}
+
+	/// Attempts to get the next request ID.
+	///
+	/// Fails if request limit has been exceeded.
+	pub fn next_request_id(&self) -> Result<u64, Error> {
+		self.get_slot()?;
+		let id = self.current_id.fetch_add(1, Ordering::SeqCst);
+		Ok(id)
+	}
+
+	/// Attempts to get the `n` number next IDs that only counts as one request.
+	///
+	/// Fails if request limit has been exceeded.
+	pub fn next_request_ids(&self, len: usize) -> Result<Vec<u64>, Error> {
+		self.get_slot()?;
+		let mut batch = Vec::with_capacity(len);
+		for _ in 0..len {
+			batch.push(self.current_id.fetch_add(1, Ordering::SeqCst));
+		}
+		Ok(batch)
+	}
+
+	/// TODO docs
+	pub fn reclaim_request_id(&self) {
+		// NOTE we ignore the error here, since we are simply saturating at 0
+		let _ = self.current_pending.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+			if val > 0 {
+				Some(val - 1)
+			} else {
+				None
+			}
+		});
 	}
 }

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -187,7 +187,7 @@ impl<Notif> Drop for Subscription<Notif> {
 }
 
 #[derive(Debug)]
-/// TODO docs
+/// Keep track of request IDs.
 pub struct RequestIdGuard {
 	// Current pending requests.
 	current_pending: AtomicUsize,
@@ -198,7 +198,7 @@ pub struct RequestIdGuard {
 }
 
 impl RequestIdGuard {
-	/// TODO docs
+	/// Create a new `RequestIdGuard` with the provided concurrency limit.
 	pub fn new(limit: usize) -> Self {
 		Self { current_pending: AtomicUsize::new(0), max_concurrent_requests: limit, current_id: AtomicU64::new(0) }
 	}

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -26,11 +26,10 @@
 
 use crate::transport::{Receiver as WsReceiver, Sender as WsSender, Target, WsTransportClientBuilder};
 use crate::types::{
-	RequestIdGuard,
 	traits::{Client, SubscriptionClient},
 	v2::{Id, Notification, NotificationSer, ParamsSer, RequestSer, Response, RpcError, SubscriptionResponse},
-	BatchMessage, Error, FrontToBack, RegisterNotificationMessage, RequestMessage, Subscription, SubscriptionKind,
-	SubscriptionMessage, TEN_MB_SIZE_BYTES,
+	BatchMessage, Error, FrontToBack, RegisterNotificationMessage, RequestIdGuard, RequestMessage, Subscription,
+	SubscriptionKind, SubscriptionMessage, TEN_MB_SIZE_BYTES,
 };
 use crate::{
 	helpers::{
@@ -50,10 +49,7 @@ use futures::{
 use tokio::sync::Mutex;
 
 use serde::de::DeserializeOwned;
-use std::{
-	borrow::Cow,
-	time::Duration,
-};
+use std::{borrow::Cow, time::Duration};
 
 /// Wrapper over a [`oneshot::Receiver`](futures::channel::oneshot::Receiver) that reads
 /// the underlying channel once and then stores the result in String.


### PR DESCRIPTION
Move the `RequestIdGuard` type to `jsonrpsee-types` and use it in both clients. This means the http client now also supports the `max_concurrent_requests`.



Closes #290 
