### PR TITLE
Improve feature configuration

### DIFF
--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -10,16 +10,23 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee"
 
 [dependencies]
-http-client = { path = "../http-client", version = "0.3.0", package = "jsonrpsee-http-client", optional = true }
-http-server = { path = "../http-server", version = "0.3.0", package = "jsonrpsee-http-server", optional = true }
-ws-client = { path = "../ws-client", version = "0.3.0", package = "jsonrpsee-ws-client", optional = true }
-ws-server = { path = "../ws-server", version = "0.3.0", package = "jsonrpsee-ws-server", optional = true }
-proc-macros = { path = "../proc-macros", version = "0.3.0", package = "jsonrpsee-proc-macros", optional = true }
-utils = { path = "../utils", version = "0.3.0", package = "jsonrpsee-utils", optional = true }
-types = { path = "../types", version = "0.3.0", package = "jsonrpsee-types", optional = true }
+# No support for namespaced features yet so workspace dependencies are prefixed with `jsonrpsee-`.
+# See https://github.com/rust-lang/cargo/issues/5565 for more details.
+jsonrpsee-http-client = { path = "../http-client", version = "0.3.0", package = "jsonrpsee-http-client", optional = true }
+jsonrpsee-http-server = { path = "../http-server", version = "0.3.0", package = "jsonrpsee-http-server", optional = true }
+jsonrpsee-ws-client = { path = "../ws-client", version = "0.3.0", package = "jsonrpsee-ws-client", optional = true }
+jsonrpsee-ws-server = { path = "../ws-server", version = "0.3.0", package = "jsonrpsee-ws-server", optional = true }
+jsonrpsee-proc-macros = { path = "../proc-macros", version = "0.3.0", package = "jsonrpsee-proc-macros", optional = true }
+jsonrpsee-utils = { path = "../utils", version = "0.3.0", package = "jsonrpsee-utils", optional = true }
+jsonrpsee-types = { path = "../types", version = "0.3.0", package = "jsonrpsee-types", optional = true }
 
 [features]
-client = ["http-client", "ws-client", "utils/client", "types"]
-server = ["http-server", "ws-server", "utils", "types"]
-macros = ["proc-macros", "types"]
-full = ["client", "server", "macros", "utils"]
+http-client = ["jsonrpsee-http-client", "jsonrpsee-types", "jsonrpsee-utils/client"]
+http-server = ["jsonrpsee-http-server", "jsonrpsee-types", "jsonrpsee-utils"]
+ws-client = ["jsonrpsee-ws-client", "jsonrpsee-types", "jsonrpsee-utils/client"]
+ws-server = ["jsonrpsee-ws-server", "jsonrpsee-types", "jsonrpsee-utils"]
+macros = ["jsonrpsee-proc-macros", "jsonrpsee-types"]
+
+client = ["http-client", "ws-client"]
+server = ["http-server", "ws-server"]
+full = ["client", "server", "macros"]

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -24,42 +24,54 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! jsonrpsee wrapper crate.
+//! Jsonrpsee wrapper crate.
+//!
+//! <br>
+//!
+//! # Optional features
+//!
+//! The `jsonrpsee` crate composes JSON-RPC functionality behind optional feature
+//! flags to provide for client and server communication over specific protocols.
+//! There are no default features, all functionality must be opted in to accordingly.
+//! The following features are avaliable.
+//!
+//! - **`http-client`** - JSON-RPC client functionality over HTTP protocol.
+//! - **`http-server`** - JSON-RPC server functionality over HTTP protocol.
+//! - **`ws-client`** - JSON-RPC client functionality over WebSocket protocol.
+//! - **`ws-server`** - JSON-RPC server functionality over WebSocket protocol.
+//! - **`macros`** - JSON-RPC API generation convenience by derive macros.
+//! - **`client`** - Enables `http-client` and `ws-client` features.
+//! - **`server`** - Enables `http-server` and `ws-server` features.
+//! - **`full`** - Enables `client`, `server` and `macros` features.
 
-/// JSON RPC HTTP client.
-#[cfg(feature = "client")]
-pub use http_client;
+/// JSON-RPC HTTP client.
+#[cfg(feature = "jsonrpsee-http-client")]
+pub use jsonrpsee_http_client as http_client;
 
-/// JSON RPC WebSocket client.
-#[cfg(feature = "client")]
-pub use ws_client;
+/// JSON-RPC WebSocket client.
+#[cfg(feature = "jsonrpsee-ws-client")]
+pub use jsonrpsee_ws_client as ws_client;
 
-/// JSON RPC WebSocket client convenience macro to build params.
-#[cfg(feature = "client")]
-pub use utils::rpc_params;
+/// JSON-RPC HTTP server.
+#[cfg(feature = "jsonrpsee-http-server")]
+pub use jsonrpsee_http_server as http_server;
 
-/// JSON RPC HTTP server.
-#[cfg(feature = "server")]
-pub use http_server;
+/// JSON-RPC WebSocket server.
+#[cfg(feature = "jsonrpsee-ws-server")]
+pub use jsonrpsee_ws_server as ws_server;
 
-/// JSON RPC WebSocket server.
-#[cfg(feature = "server")]
-pub use ws_server;
+/// Procedural macros for JSON-RPC implementations.
+#[cfg(feature = "jsonrpsee-proc-macros")]
+pub use jsonrpsee_proc_macros as proc_macros;
+
+/// Common types used to implement JSON-RPC server and client.
+#[cfg(feature = "jsonrpsee-types")]
+pub use jsonrpsee_types as types;
+
+/// JSON-RPC WebSocket client convinience macro to build params.
+#[cfg(feature = "ws-client")]
+pub use jsonrpsee_utils::rpc_params;
 
 /// Set of RPC methods that can be mounted to the server.
-#[cfg(feature = "server")]
-pub use utils::server::rpc_module::{RpcModule, SubscriptionSink};
-
-/// Procedural macros for JSON RPC implementations.
-#[cfg(feature = "macros")]
-pub use proc_macros;
-
-/// Common types used to implement JSON RPC server and client.
-#[cfg(any(feature = "types", feature = "macros"))]
-pub mod types {
-	pub use ::types::*;
-
-	/// Set of RPC methods that can be mounted to the server.
-	#[cfg(feature = "server")]
-	pub use utils::server::rpc_module::{RpcModule, SubscriptionSink};
-}
+#[cfg(any(feature = "http-server", feature = "ws-server"))]
+pub use jsonrpsee_utils::server::rpc_module::{RpcModule, SubscriptionSink};


### PR DESCRIPTION
This PR intends to improve the feature selection for some common use cases. Closes: #271.
Users that would want to:
- 1.1 import http client only;
- 1.2 import ws client only;
- 2.1 import http server only;
- 2.2 import ws server only;
- 3.1 import http client and server only;
- 3.2 import ws client and server only;

The behaviour of the current feature flags is preserved, with one exception (clarification bellow), and adds more flags to provide for those above.
The exception: reexporting `RpcModule` and `SubscriptionSink` in the path [jsonrpsee::types::](https://github.com/paritytech/jsonrpsee/blob/5ae280a34c7205527ffbc8b4029b9be73c181099/jsonrpsee/src/lib.rs#L60) was removed as it is also reexported at root level [jsonrpsee::](https://github.com/paritytech/jsonrpsee/blob/5ae280a34c7205527ffbc8b4029b9be73c181099/jsonrpsee/src/lib.rs#L47) when server + macro are enabled.
This is to remove the path ambiguity, it also reduces the size of the resulting rlib for servers.
I didn't find the reason for having both paths, if there is I will revert it properly.

This table maps the described use cases against current flags and PR flags:
Note: compiled for x86_64-unknown-linux-gnu in debug mode.

| use case | current flag     | pr flag                             | rlib size reduction (%) |
| ------------ | ------------------ | -------------------------------- | ----------------------------- |
| 1.1          | client               | http-client                       | ~ 17                             |
| 1.2          | client               | ws-client                         | ~ 21                             |
| 2.1          | server             | http-server                      | ~ 20                             |
| 2.2          | server             | ws-server                       | ~ 26                             |
| 3.1          | client + server | http-client + http-server | ~ 11                             |
| 3.2          | client + server | ws-client + ws-server    | ~ 24                             |

Ty.