### PR TITLE
Unbox async futures

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -1,5 +1,4 @@
 use futures_channel::oneshot;
-use futures_util::future::FutureExt;
 use jsonrpsee::{
 	http_server::HttpServerBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
@@ -18,7 +17,7 @@ pub async fn http_server() -> String {
 			HttpServerBuilder::default().max_request_body_size(u32::MAX).build("127.0.0.1:0".parse().unwrap()).unwrap();
 		let mut module = RpcModule::new(());
 		module.register_method(SYNC_METHOD_NAME, |_, _| Ok("lo")).unwrap();
-		module.register_async_method(ASYNC_METHOD_NAME, |_, _| (async { Ok("lo") }).boxed()).unwrap();
+		module.register_async_method(ASYNC_METHOD_NAME, |_, _| (async { Ok("lo") })).unwrap();
 		server_started_tx.send(server.local_addr().unwrap()).unwrap();
 		server.start(module).await
 	});
@@ -32,7 +31,7 @@ pub async fn ws_server() -> String {
 		let server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 		let mut module = RpcModule::new(());
 		module.register_method(SYNC_METHOD_NAME, |_, _| Ok("lo")).unwrap();
-		module.register_async_method(ASYNC_METHOD_NAME, |_, _| (async { Ok("lo") }).boxed()).unwrap();
+		module.register_async_method(ASYNC_METHOD_NAME, |_, _| (async { Ok("lo") })).unwrap();
 		module
 			.register_subscription(SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, mut sink, _ctx| {
 				let x = "Hello";

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -17,7 +17,7 @@ pub async fn http_server() -> String {
 			HttpServerBuilder::default().max_request_body_size(u32::MAX).build("127.0.0.1:0".parse().unwrap()).unwrap();
 		let mut module = RpcModule::new(());
 		module.register_method(SYNC_METHOD_NAME, |_, _| Ok("lo")).unwrap();
-		module.register_async_method(ASYNC_METHOD_NAME, |_, _| (async { Ok("lo") })).unwrap();
+		module.register_async_method(ASYNC_METHOD_NAME, |_, _| async { Ok("lo") }).unwrap();
 		server_started_tx.send(server.local_addr().unwrap()).unwrap();
 		server.start(module).await
 	});
@@ -31,7 +31,7 @@ pub async fn ws_server() -> String {
 		let server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 		let mut module = RpcModule::new(());
 		module.register_method(SYNC_METHOD_NAME, |_, _| Ok("lo")).unwrap();
-		module.register_async_method(ASYNC_METHOD_NAME, |_, _| (async { Ok("lo") })).unwrap();
+		module.register_async_method(ASYNC_METHOD_NAME, |_, _| async { Ok("lo") }).unwrap();
 		module
 			.register_subscription(SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, mut sink, _ctx| {
 				let x = "Hello";

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -77,11 +77,9 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<Result<(), Error>>, St
 		})
 		.unwrap();
 	module
-		.register_async_method("should_ok_async", |_p, ctx| {
-			async move {
-				let _ = ctx.ok().map_err(CallError::Failed)?;
-				Ok("ok")
-			}
+		.register_async_method("should_ok_async", |_p, ctx| async move {
+			let _ = ctx.ok().map_err(CallError::Failed)?;
+			Ok("ok")
 		})
 		.unwrap();
 

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -31,7 +31,6 @@ use std::net::SocketAddr;
 use crate::types::error::{CallError, Error};
 use crate::{server::StopHandle, HttpServerBuilder, RpcModule};
 
-use futures_util::FutureExt;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, StatusCode, TestContext};
 use jsonrpsee_test_utils::TimeoutFutureExt;
@@ -48,7 +47,7 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<Result<(), Error>>, St
 	let mut module = RpcModule::new(ctx);
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| Ok("lo")).unwrap();
-	module.register_async_method("say_hello_async", |_, _| async move { Ok("lo") }.boxed()).unwrap();
+	module.register_async_method("say_hello_async", |_, _| async move { Ok("lo") }).unwrap();
 	module
 		.register_method("add", |params, _| {
 			let params: Vec<u64> = params.parse()?;
@@ -83,7 +82,6 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<Result<(), Error>>, St
 				let _ = ctx.ok().map_err(CallError::Failed)?;
 				Ok("ok")
 			}
-			.boxed()
 		})
 		.unwrap();
 

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -129,11 +129,9 @@ impl RpcDescription {
 
 				if method.signature.sig.asyncness.is_some() {
 					handle_register_result(quote! {
-						rpc.register_async_method(#rpc_method_name, |params, context| {
-							async move {
-								#parsing
-								context.as_ref().#rust_method_name(#params_seq).await
-							}
+						rpc.register_async_method(#rpc_method_name, |params, context| async move {
+							#parsing
+							context.as_ref().#rust_method_name(#params_seq).await
 						})
 					})
 				} else {

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -130,11 +130,10 @@ impl RpcDescription {
 				if method.signature.sig.asyncness.is_some() {
 					handle_register_result(quote! {
 						rpc.register_async_method(#rpc_method_name, |params, context| {
-							let fut = async move {
+							async move {
 								#parsing
 								context.as_ref().#rust_method_name(#params_seq).await
-							};
-							Box::pin(fut)
+							}
 						})
 					})
 				} else {

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -44,9 +44,9 @@ use rustc_hash::FxHashMap;
 use serde::Serialize;
 use serde_json::value::RawValue;
 use std::fmt::Debug;
+use std::future::Future;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use std::future::Future;
 
 /// A `Method` is an RPC endpoint, callable with a standard JSON-RPC request,
 /// implemented as a function pointer to a `Fn` function taking four arguments:

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -46,6 +46,7 @@ use serde_json::value::RawValue;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
+use std::future::Future;
 
 /// A `Method` is an RPC endpoint, callable with a standard JSON-RPC request,
 /// implemented as a function pointer to a `Fn` function taking four arguments:
@@ -324,10 +325,11 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 	}
 
 	/// Register a new asynchronous RPC method, which computes the response with the given callback.
-	pub fn register_async_method<R, F>(&mut self, method_name: &'static str, callback: F) -> Result<(), Error>
+	pub fn register_async_method<R, Fun, Fut>(&mut self, method_name: &'static str, callback: Fun) -> Result<(), Error>
 	where
 		R: Serialize + Send + Sync + 'static,
-		F: Fn(Params<'static>, Arc<Context>) -> BoxFuture<'static, Result<R, Error>> + Copy + Send + Sync + 'static,
+		Fut: Future<Output = Result<R, Error>> + Send,
+		Fun: (Fn(Params<'static>, Arc<Context>) -> Fut) + Copy + Send + Sync + 'static,
 	{
 		self.methods.verify_method_name(method_name)?;
 
@@ -682,7 +684,7 @@ mod tests {
 		module
 			.register_async_method("roo", |params, ctx| {
 				let ns: Vec<u8> = params.parse().expect("valid params please");
-				async move { Ok(ctx.roo(ns)) }.boxed()
+				async move { Ok(ctx.roo(ns)) }
 			})
 			.unwrap();
 		let result = module.call_with("roo", vec![12, 13]).await.unwrap();

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -86,12 +86,10 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 		})
 		.unwrap();
 	module
-		.register_async_method("add_async", |params, _| {
-			async move {
-				let params: Vec<u64> = params.parse()?;
-				let sum: u64 = params.into_iter().sum();
-				Ok(sum)
-			}
+		.register_async_method("add_async", |params, _| async move {
+			let params: Vec<u64> = params.parse()?;
+			let sum: u64 = params.into_iter().sum();
+			Ok(sum)
 		})
 		.unwrap();
 	module

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -29,7 +29,6 @@
 use crate::types::error::{CallError, Error};
 use crate::{future::StopHandle, RpcModule, WsServerBuilder};
 use anyhow::anyhow;
-use futures_util::FutureExt;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::types::{Id, TestContext, WebSocketTestClient, WebSocketTestError};
 use jsonrpsee_test_utils::TimeoutFutureExt;
@@ -84,7 +83,6 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 				futures_util::future::ready(()).await;
 				Ok("hello")
 			}
-			.boxed()
 		})
 		.unwrap();
 	module
@@ -94,7 +92,6 @@ async fn server_with_handles() -> (SocketAddr, JoinHandle<()>, StopHandle) {
 				let sum: u64 = params.into_iter().sum();
 				Ok(sum)
 			}
-			.boxed()
 		})
 		.unwrap();
 	module
@@ -144,7 +141,6 @@ async fn server_with_context() -> SocketAddr {
 				// Call some async function inside.
 				Ok(futures_util::future::ready("ok!").await)
 			}
-			.boxed()
 		})
 		.unwrap();
 
@@ -155,7 +151,6 @@ async fn server_with_context() -> SocketAddr {
 				// Async work that returns an error
 				futures_util::future::err::<(), _>(anyhow!("nah").into()).await
 			}
-			.boxed()
 		})
 		.unwrap();
 


### PR DESCRIPTION
There is no need to box futures for async methods in user space, since the closure is captured and boxed internally already.