### PR TITLE
Add macro to build params

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -27,7 +27,8 @@
 use jsonrpsee::{
 	http_client::HttpClientBuilder,
 	http_server::{HttpServerBuilder, RpcModule},
-	types::{traits::Client, JsonValue},
+	rpc_params,
+	types::traits::Client,
 };
 use std::net::SocketAddr;
 
@@ -38,10 +39,9 @@ async fn main() -> anyhow::Result<()> {
 	let server_addr = run_server().await?;
 	let url = format!("http://{}", server_addr);
 
-	let params: &[JsonValue] = &[1_u64.into(), 2.into(), 3.into()];
-
 	let client = HttpClientBuilder::default().build(url)?;
-	let response: Result<String, _> = client.request("say_hello", params.into()).await;
+	let params = rpc_params!(1_u64, 2, 3);
+	let response: Result<String, _> = client.request("say_hello", params).await;
 	println!("r: {:?}", response);
 
 	Ok(())

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -25,6 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
+	rpc_params,
 	types::{traits::SubscriptionClient, v2::ParamsSer},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
@@ -40,8 +41,8 @@ async fn main() -> anyhow::Result<()> {
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription with a single parameter
-	let params = ParamsSer::Array(vec![3.into()]);
-	let mut sub_params_one = client.subscribe::<Option<char>>("sub_one_param", params, "unsub_one_param").await?;
+	let mut sub_params_one =
+		client.subscribe::<Option<char>>("sub_one_param", rpc_params!(3), "unsub_one_param").await?;
 	println!("subscription with one param: {:?}", sub_params_one.next().await);
 
 	// Subscription with multiple parameters

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -25,28 +25,29 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	types::{traits::SubscriptionClient, v2::ParamsSer, Error, Subscription},
+	rpc_params,
+	types::{traits::SubscriptionClient, Error, Subscription},
 	ws_client::WsClientBuilder,
 	ws_server::{RpcModule, WsServerBuilder},
 };
 use std::net::SocketAddr;
 
-const NUM_SUBSCRIPTION_RESPONSES: usize = 10;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+	const NUM_SUBSCRIPTION_RESPONSES: usize = 5;
 	env_logger::init();
 	let addr = run_server().await?;
 	let url = format!("ws://{}", addr);
 
 	let client = WsClientBuilder::default().build(&url).await?;
 	let mut subscribe_hello: Subscription<String> =
-		client.subscribe("subscribe_hello", ParamsSer::NoParams, "unsubscribe_hello").await?;
+		client.subscribe("subscribe_hello", rpc_params!(), "unsubscribe_hello").await?;
 
 	let mut i = 0;
 	while i <= NUM_SUBSCRIPTION_RESPONSES {
 		let r = subscribe_hello.next().await;
-		log::debug!("received {:?}", r);
+		println!("received {:?}", r);
 		i += 1;
 	}
 

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -32,7 +32,6 @@ use jsonrpsee::{
 };
 use std::net::SocketAddr;
 
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	const NUM_SUBSCRIPTION_RESPONSES: usize = 5;

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -19,7 +19,7 @@ utils = { path = "../utils", version = "0.3.0", package = "jsonrpsee-utils", opt
 types = { path = "../types", version = "0.3.0", package = "jsonrpsee-types", optional = true }
 
 [features]
-client = ["http-client", "ws-client", "types"]
+client = ["http-client", "ws-client", "utils/client", "types"]
 server = ["http-server", "ws-server", "utils", "types"]
 macros = ["proc-macros", "types"]
 full = ["client", "server", "macros", "utils"]

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -34,6 +34,10 @@ pub use http_client;
 #[cfg(feature = "client")]
 pub use ws_client;
 
+/// JSON RPC WebSocket client convenience macro to build params.
+#[cfg(feature = "client")]
+pub use utils::rpc_params;
+
 /// JSON RPC HTTP server.
 #[cfg(feature = "server")]
 pub use http_server;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -35,6 +35,7 @@ server = [
 	"parking_lot",
 	"rand",
 ]
+client = ["jsonrpsee-types"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/utils/src/client.rs
+++ b/utils/src/client.rs
@@ -1,0 +1,49 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Shared utilities for `jsonrpsee` clients.
+
+#[doc(hidden)]
+pub mod __reexports {
+	pub use jsonrpsee_types::{to_json_value, v2::ParamsSer};
+}
+
+#[macro_export]
+/// Convert the given values to a [`ParamsSer`] as expected by a jsonrpsee Client (http or websocket).
+macro_rules! rpc_params {
+	($($param:expr),*) => {
+		{
+			let mut __params = vec![];
+			$(
+				__params.push($crate::client::__reexports::to_json_value($param).expect("json serialization is infallible; qed."));
+			)*
+			$crate::client::__reexports::ParamsSer::Array(__params)
+		}
+	};
+	() => {
+		$crate::client::__reexports::ParamsSer::NoParams,
+	}
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -35,3 +35,7 @@ pub mod http_helpers;
 /// Shared code for JSON-RPC servers.
 #[cfg(feature = "server")]
 pub mod server;
+
+/// Shared code for JSON-RPC clients.
+#[cfg(feature = "client")]
+pub mod client;


### PR DESCRIPTION
Add a convenience macro to build `ParamsSer` for use in clients. Ty @kianenigma.

Closes #275
