### PR TITLE
fix(ParamsSer): serialize to empty array

### DIFF
--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -176,9 +176,9 @@ mod test {
 			// Without ID field.
 			(r#"{"jsonrpc":"2.0","id":null,"method":"subtract","params":[42,23]}"#, None, Some(params)),
 			// Without params field
-			(r#"{"jsonrpc":"2.0","id":1,"method":"subtract","params":null}"#, Some(id), None),
+			(r#"{"jsonrpc":"2.0","id":1,"method":"subtract"}"#, Some(id), None),
 			// Without params and ID.
-			(r#"{"jsonrpc":"2.0","id":null,"method":"subtract","params":null}"#, None, None),
+			(r#"{"jsonrpc":"2.0","id":null,"method":"subtract","params":[]}"#, None, None),
 		];
 
 		for (ser, id, params) in test_vector.iter().cloned() {


### PR DESCRIPTION
Serialize `ParamsSer::NoParams` to an empty array inorder to comply with the jsonrpc v2 spec.

However, another solution is to change the types to take `Option<ParamsSer>` which could be maybe make client trait API less awkward to use,

currenty we have 

- `async fn request<'a, R>(&self, method: &'a str, params: ParamsSer<'a>)`

we could change it to:
- `async fn request<'a, R>(&self, method: &'a str, params: Option<ParamsSer<'a>>)`

Then users won't code `ParamsSer::NoParams` everytime just None, but maybe less explicit and more error prone...
