### PR TITLE
deps: remove rustls

### DIFF
--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -25,7 +25,6 @@ soketto = "0.6"
 pin-project = "1"
 thiserror = "1"
 url = "2"
-rustls = "0.19.1"
 rustls-native-certs = "0.5.0"
 
 [dev-dependencies]

--- a/ws-client/src/transport.rs
+++ b/ws-client/src/transport.rs
@@ -33,6 +33,7 @@ use thiserror::Error;
 use tokio::net::TcpStream;
 use tokio_rustls::{
 	client::TlsStream,
+	rustls::ClientConfig,
 	webpki::{DNSNameRef, InvalidDNSNameError},
 	TlsConnector,
 };
@@ -174,7 +175,7 @@ impl<'a> WsTransportClientBuilder<'a> {
 	pub async fn build(self) -> Result<(Sender, Receiver), WsHandshakeError> {
 		let connector = match self.target.mode {
 			Mode::Tls => {
-				let mut client_config = rustls::ClientConfig::default();
+				let mut client_config = ClientConfig::default();
 				if let CertificateStore::Native = self.certificate_store {
 					client_config.root_store = rustls_native_certs::load_native_certs()
 						.map_err(|(_, e)| WsHandshakeError::CertificateStore(e))?;


### PR DESCRIPTION
It turns out that `hyper-rustls` already re-exports ClientConfig so no need to use rustls for that purpose then. Moreover, we can't update `rustls` until `hyper-rustls` updates anyway.

Also fixes the dependabot alert in  #488