### PR TITLE
Proc macro Argument parsing should permit commas inside angle brackets

### DIFF
--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -54,6 +54,9 @@ impl Parse for Argument {
 		let mut tokens = TokenStream2::new();
 		let mut scope = 0usize;
 
+		// Need to read to till either the end of the stream,
+		// or the nearest comma token that's not contained
+		// inside angle brackets.
 		loop {
 			if scope == 0 && input.peek(Token![,]) {
 				break;

--- a/proc-macros/tests/ui/correct/parse_angle_brackets.rs
+++ b/proc-macros/tests/ui/correct/parse_angle_brackets.rs
@@ -1,0 +1,16 @@
+use jsonrpsee::{proc_macros::rpc, types::RpcResult};
+
+fn main() {
+	#[rpc(server)]
+	pub trait Rpc {
+		#[subscription(
+			name = "submitAndWatchExtrinsic",
+			aliases = "author_extrinsicUpdate",
+			unsubscribe_aliases = "author_unwatchExtrinsic",
+			// Arguments are being parsed the nearest comma,
+			// angle braces need to be accounted for manually.
+			item = TransactionStatus<Hash, BlockHash>,
+		)]
+		fn dummy_subscription(&self) -> RpcResult<()>;
+	}
+}

--- a/tests/tests/resource_limiting.rs
+++ b/tests/tests/resource_limiting.rs
@@ -91,23 +91,6 @@ fn module_macro() -> RpcModule<()> {
 	().into_rpc()
 }
 
-#[tokio::test]
-async fn parse_angle_braces() {
-	// This needs to compile
-	#[rpc(server)]
-	pub trait Rpc {
-		#[subscription(
-			name = "submitAndWatchExtrinsic",
-			aliases = "author_extrinsicUpdate",
-			unsubscribe_aliases = "author_unwatchExtrinsic",
-			// Arguments are being parsed the nearest comma,
-			// angle braces need to be accounted for manually.
-			item = TransactionStatus<Hash, BlockHash>,
-		)]
-		fn dummy_subscription(&self) -> Result<(), Error>;
-	}
-}
-
 async fn websocket_server(module: RpcModule<()>) -> Result<(SocketAddr, WsStopHandle), Error> {
 	let server = WsServerBuilder::default()
 		.register_resource("CPU", 6, 2)?


### PR DESCRIPTION
This is not necessarily super robust. I've got an idea how to get around the whole "prase till comma" issue with some generics that automatically parse to expected types, instead of doing this two step parsing, will follow up with a separate PR for that.