### PR TITLE
fix: nit in ServerBuilder::custom_tokio_runtime

### DIFF
--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -98,8 +98,9 @@ impl Builder {
 	/// Configure a custom [`tokio::runtime::Handle`] to run the server on.
 	///
 	/// Default: [`tokio::spawn`]
-	pub fn custom_tokio_runtime(mut self, rt: tokio::runtime::Handle) {
+	pub fn custom_tokio_runtime(mut self, rt: tokio::runtime::Handle) -> Self {
 		self.tokio_runtime = Some(rt);
+		self
 	}
 
 	/// Finalizes the configuration of the server.

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -487,8 +487,9 @@ impl Builder {
 	/// Configure a custom [`tokio::runtime::Handle`] to run the server on.
 	///
 	/// Default: [`tokio::spawn`]
-	pub fn custom_tokio_runtime(mut self, rt: tokio::runtime::Handle) {
+	pub fn custom_tokio_runtime(mut self, rt: tokio::runtime::Handle) -> Self {
 		self.settings.tokio_runtime = Some(rt);
+		self
 	}
 
 	/// Finalize the configuration of the server. Consumes the [`Builder`].


### PR DESCRIPTION
The builders must return `Self` when taking ownership which is a super nit