### PR TITLE
deps: replace log with tracing

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,8 @@ publish = false
 anyhow = "1"
 env_logger = "0.9"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
-log = "0.4"
+tracing = "0.1"
+tracing-subscriber = "0.2"
 tokio = { version = "1", features = ["full"] }
 
 [[example]]

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -34,7 +34,9 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	env_logger::init();
+	// init tracing `FmtSubscriber`.
+	let subscriber = tracing_subscriber::FmtSubscriber::new();
+	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
 	let (server_addr, _handle) = run_server().await?;
 	let url = format!("http://{}", server_addr);
@@ -42,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
 	let client = HttpClientBuilder::default().build(url)?;
 	let params = rpc_params!(1_u64, 2, 3);
 	let response: Result<String, _> = client.request("say_hello", params).await;
-	println!("r: {:?}", response);
+	tracing::info!("r: {:?}", response);
 
 	Ok(())
 }

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -72,7 +72,9 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	env_logger::init();
+	// init tracing `FmtSubscriber`.
+	let subscriber = tracing_subscriber::FmtSubscriber::builder().finish();
+	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
 	let (server_addr, _handle) = run_server().await?;
 	let url = format!("ws://{}", server_addr);

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -33,13 +33,16 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	env_logger::init();
+	// init tracing `FmtSubscriber`.
+	let subscriber = tracing_subscriber::FmtSubscriber::builder().finish();
+	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
 	let addr = run_server().await?;
 	let url = format!("ws://{}", addr);
 
 	let client = WsClientBuilder::default().build(&url).await?;
 	let response: String = client.request("say_hello", None).await?;
-	println!("r: {:?}", response);
+	tracing::info!("response: {:?}", response);
 
 	Ok(())
 }

--- a/examples/ws_sub_with_params.rs
+++ b/examples/ws_sub_with_params.rs
@@ -34,7 +34,10 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	env_logger::init();
+	// init tracing `FmtSubscriber`.
+	let subscriber = tracing_subscriber::FmtSubscriber::builder().finish();
+	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
 	let addr = run_server().await?;
 	let url = format!("ws://{}", addr);
 
@@ -43,12 +46,12 @@ async fn main() -> anyhow::Result<()> {
 	// Subscription with a single parameter
 	let mut sub_params_one =
 		client.subscribe::<Option<char>>("sub_one_param", rpc_params![3], "unsub_one_param").await?;
-	println!("subscription with one param: {:?}", sub_params_one.next().await);
+	tracing::info!("subscription with one param: {:?}", sub_params_one.next().await);
 
 	// Subscription with multiple parameters
 	let mut sub_params_two =
 		client.subscribe::<String>("sub_params_two", rpc_params![2, 5], "unsub_params_two").await?;
-	println!("subscription with two params: {:?}", sub_params_two.next().await);
+	tracing::info!("subscription with two params: {:?}", sub_params_two.next().await);
 
 	Ok(())
 }

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -32,10 +32,14 @@ use jsonrpsee::{
 };
 use std::net::SocketAddr;
 
+const NUM_SUBSCRIPTION_RESPONSES: usize = 5;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	const NUM_SUBSCRIPTION_RESPONSES: usize = 5;
-	env_logger::init();
+	// init tracing `FmtSubscriber`.
+	let subscriber = tracing_subscriber::FmtSubscriber::builder().finish();
+	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
 	let addr = run_server().await?;
 	let url = format!("ws://{}", addr);
 
@@ -46,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
 	let mut i = 0;
 	while i <= NUM_SUBSCRIPTION_RESPONSES {
 		let r = subscribe_hello.next().await;
-		println!("received {:?}", r);
+		tracing::info!("received {:?}", r);
 		i += 1;
 	}
 

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -15,7 +15,7 @@ hyper-rustls = "0.22"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
 jsonrpsee-types = { path = "../types", version = "0.4.1" }
 jsonrpsee-utils = { path = "../utils", version = "0.4.1", features = ["http-helpers"] }
-log = "0.4"
+tracing = "0.1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["time"] }

--- a/http-client/src/transport.rs
+++ b/http-client/src/transport.rs
@@ -39,7 +39,7 @@ impl HttpTransportClient {
 	}
 
 	async fn inner_send(&self, body: String) -> Result<hyper::Response<hyper::Body>, Error> {
-		log::debug!("send: {}", body);
+		tracing::debug!("send: {}", body);
 
 		if body.len() > self.max_request_body_size as usize {
 			return Err(Error::RequestTooLarge);

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -17,7 +17,7 @@ jsonrpsee-types = { path = "../types", version = "0.4.1" }
 jsonrpsee-utils = { path = "../utils", version = "0.4.1", features = ["server", "http-helpers"] }
 globset = "0.4"
 lazy_static = "1.4"
-log = "0.4"
+tracing = "0.1"
 serde_json = "1"
 socket2 = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/http-server/src/access_control/matcher.rs
+++ b/http-server/src/access_control/matcher.rs
@@ -25,8 +25,8 @@
 // DEALINGS IN THE SOFTWARE.
 
 use globset::{GlobBuilder, GlobMatcher};
-use log::warn;
 use std::{fmt, hash};
+use tracing::warn;
 
 /// Pattern that can be matched to string.
 pub(crate) trait Pattern {

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -222,7 +222,7 @@ impl Server {
 							Err(GenericTransportError::TooLarge) => return Ok::<_, HyperError>(response::too_large()),
 							Err(GenericTransportError::Malformed) => return Ok::<_, HyperError>(response::malformed()),
 							Err(GenericTransportError::Inner(e)) => {
-								log::error!("Internal error reading request body: {}", e);
+								tracing::error!("Internal error reading request body: {}", e);
 								return Ok::<_, HyperError>(response::internal_error());
 							}
 						};
@@ -281,7 +281,7 @@ impl Server {
 						} else {
 							collect_batch_response(rx).await
 						};
-						log::debug!("[service_fn] sending back: {:?}", &response[..cmp::min(response.len(), 1024)]);
+						tracing::debug!("[service_fn] sending back: {:?}", &response[..cmp::min(response.len(), 1024)]);
 						Ok::<_, HyperError>(response::ok_response(response))
 					}
 				}))

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", default-features = false, features = ["extra-traits", "full", "visit", "parsing"] }
 proc-macro-crate = "1"
-log = "0.4"
+tracing = "0.1"
 
 [dev-dependencies]
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -292,7 +292,7 @@ impl RpcDescription {
 						let #name: #ty = match seq.optional_next() {
 							Ok(v) => v,
 							Err(e) => {
-								log::error!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
+								tracing::error!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								return Err(e.into())
 							}
 						};
@@ -302,7 +302,7 @@ impl RpcDescription {
 						let #name: #ty = match seq.next() {
 							Ok(v) => v,
 							Err(e) => {
-								log::error!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
+								tracing::error!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								return Err(e.into())
 							}
 						};

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1"
 futures-channel = "0.3.14"
 futures-util = "0.3.14"
 hyper = { version = "0.14.10", features = ["full"] }
-log = "0.4"
+tracing = "0.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 soketto = { version = "0.7", features = ["http"] }

--- a/test-utils/src/mocks.rs
+++ b/test-utils/src/mocks.rs
@@ -278,12 +278,12 @@ async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut ex
 				 match &mode {
 					ServerMode::Subscription { subscription_response, .. } => {
 						if let Err(e) = sender.send_text(&subscription_response).await {
-							log::warn!("send response to subscription: {:?}", e);
+							tracing::warn!("send response to subscription: {:?}", e);
 						}
 					},
 					ServerMode::Notification(n) => {
 						if let Err(e) = sender.send_text(&n).await {
-							log::warn!("send notification: {:?}", e);
+							tracing::warn!("send notification: {:?}", e);
 						}
 					},
 					_ => {}
@@ -296,12 +296,12 @@ async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut ex
 					match &mode {
 						ServerMode::Response(r) => {
 							if let Err(e) = sender.send_text(&r).await {
-								log::warn!("send response to request error: {:?}", e);
+								tracing::warn!("send response to request error: {:?}", e);
 							}
 						},
 						ServerMode::Subscription { subscription_id, .. } => {
 							if let Err(e) = sender.send_text(&subscription_id).await {
-								log::warn!("send subscription id error: {:?}", e);
+								tracing::warn!("send subscription id error: {:?}", e);
 							}
 						},
 						_ => {}
@@ -340,7 +340,7 @@ async fn handler(
 	other_server: String,
 ) -> Result<hyper::Response<Body>, soketto::BoxedError> {
 	if is_upgrade_request(&req) {
-		log::debug!("{:?}", req);
+		tracing::debug!("{:?}", req);
 
 		match req.uri().path() {
 			"/myblock/two" => {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,4 +13,4 @@ futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
-log = "0.4"
+tracing = "0.1"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 futures-channel = { version = "0.3.14", features = ["sink"] }
 futures-util = { version = "0.3.14", default-features = false, features = ["std", "sink", "channel"] }
-log = { version = "0.4", default-features = false }
+tracing = { version = "0.1", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"

--- a/types/src/v2/params.rs
+++ b/types/src/v2/params.rs
@@ -158,18 +158,18 @@ impl<'a> ParamsSequence<'a> {
 		T: Deserialize<'a>,
 	{
 		let mut json = self.0;
-		log::trace!("[next_inner] Params JSON: {:?}", json);
+		tracing::trace!("[next_inner] Params JSON: {:?}", json);
 		match json.as_bytes().get(0)? {
 			b']' => {
 				self.0 = "";
 
-				log::trace!("[next_inner] Reached end of sequence.");
+				tracing::trace!("[next_inner] Reached end of sequence.");
 				return None;
 			}
 			b'[' | b',' => json = &json[1..],
 			_ => {
 				let errmsg = format!("Invalid params. Expected one of '[', ']' or ',' but found {:?}", json);
-				log::error!("[next_inner] {}", errmsg);
+				tracing::error!("[next_inner] {}", errmsg);
 				return Some(Err(CallError::InvalidParams(anyhow!(errmsg))));
 			}
 		}
@@ -183,7 +183,7 @@ impl<'a> ParamsSequence<'a> {
 				Some(Ok(value))
 			}
 			Err(e) => {
-				log::error!(
+				tracing::error!(
 					"[next_inner] Deserialization to {:?} failed. Error: {:?}, input JSON: {:?}",
 					std::any::type_name::<T>(),
 					e,

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,7 +14,7 @@ futures-channel = { version = "0.3.14", default-features = false, optional = tru
 futures-util = { version = "0.3.14", default-features = false, optional = true }
 hyper = { version = "0.14.10", default-features = false, features = ["stream"], optional = true }
 jsonrpsee-types = { path = "../types", version = "0.4.1", optional = true }
-log = { version = "0.4", optional = true }
+tracing = { version = "0.1", optional = true }
 rustc-hash = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
@@ -32,7 +32,7 @@ server = [
 	"rustc-hash",
 	"serde",
 	"serde_json",
-	"log",
+	"tracing",
 	"parking_lot",
 	"rand",
 ]

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -39,14 +39,14 @@ pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
 	let json = match serde_json::to_string(&Response { jsonrpc: TwoPointZero, id: id.clone(), result }) {
 		Ok(json) => json,
 		Err(err) => {
-			log::error!("Error serializing response: {:?}", err);
+			tracing::error!("Error serializing response: {:?}", err);
 
 			return send_error(id, tx, ErrorCode::InternalError.into());
 		}
 	};
 
 	if let Err(err) = tx.unbounded_send(json) {
-		log::error!("Error sending response to the client: {:?}", err)
+		tracing::error!("Error sending response to the client: {:?}", err)
 	}
 }
 
@@ -55,14 +55,14 @@ pub fn send_error(id: Id, tx: &MethodSink, error: ErrorObject) {
 	let json = match serde_json::to_string(&RpcError { jsonrpc: TwoPointZero, error, id }) {
 		Ok(json) => json,
 		Err(err) => {
-			log::error!("Error serializing error message: {:?}", err);
+			tracing::error!("Error serializing error message: {:?}", err);
 
 			return;
 		}
 	};
 
 	if let Err(err) = tx.unbounded_send(json) {
-		log::error!("Could not send error response to the client: {:?}", err)
+		tracing::error!("Could not send error response to the client: {:?}", err)
 	}
 }
 

--- a/ws-client/Cargo.toml
+++ b/ws-client/Cargo.toml
@@ -20,7 +20,7 @@ fnv = "1"
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 http = "0.2"
 jsonrpsee-types = { path = "../types", version = "0.4.1" }
-log = "0.4"
+tracing = "0.1"
 pin-project = "1"
 rustls-native-certs = "0.5.0"
 serde = "1"

--- a/ws-client/src/helpers.rs
+++ b/ws-client/src/helpers.rs
@@ -52,7 +52,7 @@ pub fn process_batch_response(manager: &mut RequestManager, rps: Vec<Response<Js
 	let batch_state = match manager.complete_pending_batch(digest) {
 		Some(state) => state,
 		None => {
-			log::warn!("Received unknown batch response");
+			tracing::warn!("Received unknown batch response");
 			return Err(Error::InvalidRequestId);
 		}
 	};
@@ -85,14 +85,14 @@ pub fn process_subscription_response(
 		Some(send_back_sink) => match send_back_sink.try_send(response.params.result) {
 			Ok(()) => Ok(()),
 			Err(err) => {
-				log::error!("Dropping subscription {:?} error: {:?}", sub_id, err);
+				tracing::error!("Dropping subscription {:?} error: {:?}", sub_id, err);
 				let msg = build_unsubscribe_message(manager, request_id, sub_id)
 					.expect("request ID and subscription ID valid checked above; qed");
 				Err(Some(msg))
 			}
 		},
 		None => {
-			log::error!("Subscription ID: {:?} is not an active subscription", sub_id);
+			tracing::error!("Subscription ID: {:?} is not an active subscription", sub_id);
 			Err(None)
 		}
 	}
@@ -107,13 +107,13 @@ pub fn process_notification(manager: &mut RequestManager, notif: Notification<Js
 		Some(send_back_sink) => match send_back_sink.try_send(notif.params) {
 			Ok(()) => Ok(()),
 			Err(err) => {
-				log::error!("Error sending notification, dropping handler for {:?} error: {:?}", notif.method, err);
+				tracing::error!("Error sending notification, dropping handler for {:?} error: {:?}", notif.method, err);
 				let _ = manager.remove_notification_handler(notif.method.to_owned());
 				Err(Error::Internal(err.into_send_error()))
 			}
 		},
 		None => {
-			log::error!("Notification: {:?} not a registered method", notif.method);
+			tracing::error!("Notification: {:?} not a registered method", notif.method);
 			Err(Error::UnregisteredNotification(notif.method.to_owned()))
 		}
 	}
@@ -176,7 +176,7 @@ pub fn process_single_response(
 // NOTE: we don't count this a concurrent request as it's part of a subscription.
 pub async fn stop_subscription(sender: &mut WsSender, manager: &mut RequestManager, unsub: RequestMessage) {
 	if let Err(e) = sender.send(unsub.raw).await {
-		log::error!("Send unsubscribe request failed: {:?}", e);
+		tracing::error!("Send unsubscribe request failed: {:?}", e);
 		let _ = manager.complete_pending_call(unsub.id);
 	}
 }

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -14,7 +14,7 @@ futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
 jsonrpsee-types = { path = "../types", version = "0.4.1" }
 jsonrpsee-utils = { path = "../utils", version = "0.4.1", features = ["server"] }
-log = "0.4"
+tracing = "0.1"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros"] }

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -63,7 +63,7 @@ async fn server_with_handles() -> (SocketAddr, StopHandle) {
 	let mut module = RpcModule::new(());
 	module
 		.register_method("say_hello", |_, _| {
-			log::debug!("server respond to hello");
+			tracing::debug!("server respond to hello");
 			Ok("hello")
 		})
 		.unwrap();
@@ -77,7 +77,7 @@ async fn server_with_handles() -> (SocketAddr, StopHandle) {
 	module
 		.register_async_method("say_hello_async", |_, _| {
 			async move {
-				log::debug!("server respond to hello");
+				tracing::debug!("server respond to hello");
 				// Call some async function inside.
 				futures_util::future::ready(()).await;
 				Ok("hello")


### PR DESCRIPTION
Initial work on #487 

A follow-up would be to add `spans` on the individual methods to get `metrics` such as payload size, time it took to execute and so on.

I'm not super familiar with the different tracing subscriber libraries but https://crates.io/crates/tracing-timing looks interesting but that's up the user of the server to configure but we should test a couple of them to ensure that sufficient data is emitted.
