### PR TITLE
WIP: tracing futures for the servers

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -35,7 +35,7 @@ use std::net::SocketAddr;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// init tracing `FmtSubscriber`.
-	let subscriber = tracing_subscriber::FmtSubscriber::new();
+	let subscriber = tracing_subscriber::FmtSubscriber::builder().with_max_level(tracing::Level::DEBUG).finish();
 	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
 	let (server_addr, _handle) = run_server().await?;

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -31,11 +31,12 @@ use jsonrpsee::{
 	types::traits::Client,
 };
 use std::net::SocketAddr;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	// init tracing `FmtSubscriber`.
-	let subscriber = tracing_subscriber::FmtSubscriber::builder().with_max_level(tracing::Level::DEBUG).finish();
+	let filter = EnvFilter::try_from_default_env()?.add_directive("jsonrpsee[method_call]=trace".parse()?);
+	let subscriber = FmtSubscriber::builder().with_env_filter(filter).finish();
 	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
 	let (server_addr, _handle) = run_server().await?;

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -30,11 +30,12 @@ use jsonrpsee::{
 	ws_server::{RpcModule, WsServerBuilder},
 };
 use std::net::SocketAddr;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	// init tracing `FmtSubscriber`.
-	let subscriber = tracing_subscriber::FmtSubscriber::builder().with_max_level(tracing::Level::TRACE).finish();
+	let filter = EnvFilter::try_from_default_env()?.add_directive("jsonrpsee[method_call]=trace".parse()?);
+	let subscriber = FmtSubscriber::builder().with_env_filter(filter).finish();
 	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
 	let addr = run_server().await?;
@@ -51,7 +52,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| {
-		std::thread::sleep(std::time::Duration::from_secs(10));
+		std::thread::sleep(std::time::Duration::from_secs(1));
 		Ok("lo")
 	})?;
 	let addr = server.local_addr()?;

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -34,7 +34,7 @@ use std::net::SocketAddr;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// init tracing `FmtSubscriber`.
-	let subscriber = tracing_subscriber::FmtSubscriber::builder().finish();
+	let subscriber = tracing_subscriber::FmtSubscriber::builder().with_max_level(tracing::Level::TRACE).finish();
 	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
 	let addr = run_server().await?;
@@ -50,7 +50,10 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| Ok("lo"))?;
+	module.register_method("say_hello", |_, _| {
+		std::thread::sleep(std::time::Duration::from_secs(10));
+		Ok("lo")
+	})?;
 	let addr = server.local_addr()?;
 	server.start(module)?;
 	Ok(addr)

--- a/examples/ws_subscription.rs
+++ b/examples/ws_subscription.rs
@@ -37,7 +37,7 @@ const NUM_SUBSCRIPTION_RESPONSES: usize = 5;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// init tracing `FmtSubscriber`.
-	let subscriber = tracing_subscriber::FmtSubscriber::builder().finish();
+	let subscriber = tracing_subscriber::FmtSubscriber::builder().with_max_level(tracing::Level::DEBUG).finish();
 	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
 	let addr = run_server().await?;

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -18,6 +18,7 @@ jsonrpsee-utils = { path = "../utils", version = "0.4.1", features = ["server", 
 globset = "0.4"
 lazy_static = "1.4"
 tracing = "0.1"
+tracing-futures = "0.2.5"
 serde_json = "1"
 socket2 = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -45,6 +45,8 @@ pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
 		}
 	};
 
+	tracing::debug!("send {} bytes", json.len());
+	tracing::debug!("send {}", json);
 	if let Err(err) = tx.unbounded_send(json) {
 		tracing::error!("Error sending response to the client: {:?}", err)
 	}

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -45,8 +45,8 @@ pub fn send_response(id: Id, tx: &MethodSink, result: impl Serialize) {
 		}
 	};
 
-	tracing::debug!("send {} bytes", json.len());
-	tracing::debug!("send {}", json);
+	tracing::debug!(tx_method_call_len = json.len());
+	tracing::debug!(tx_method_call = ?json);
 	if let Err(err) = tx.unbounded_send(json) {
 		tracing::error!("Error sending response to the client: {:?}", err)
 	}

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -581,7 +581,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 						);
 						send_error(id, method_sink, ErrorCode::ServerError(-1).into());
 					}
-					tracing::debug!(execution_time_ms = ?now.elapsed().as_millis());
+					tracing::debug!(execution_time = ?now.elapsed());
 				})),
 			);
 		}
@@ -605,7 +605,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 					};
 					subscribers.lock().remove(&SubscriptionKey { conn_id, sub_id });
 					send_response(id, tx, "Unsubscribed");
-					tracing::debug!(execution_time_ms = ?now.elapsed().as_millis());
+					tracing::debug!(execution_time = ?now.elapsed());
 				})),
 			);
 		}

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -414,7 +414,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 				match callback(params, &*ctx) {
 					Ok(res) => {
 						let rp = send_response(id, &tx, res);
-						tracing::debug!("finished {:?}", now.elapsed());
+						tracing::debug!(execution_time = ?now.elapsed());
 						rp
 					}
 					Err(err) => send_call_error(id, tx, err),
@@ -446,7 +446,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 					match callback(params, ctx).await {
 						Ok(res) => {
 							let rp = send_response(id, &tx, res);
-							tracing::debug!("finished {:?}", now.elapsed());
+							tracing::debug!(execution_time = ?now.elapsed());
 							rp
 						}
 						Err(err) => send_call_error(id, &tx, err),
@@ -485,7 +485,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 					match callback(params, ctx) {
 						Ok(res) => {
 							let rp = send_response(id, &tx, res);
-							tracing::debug!("finished {:?}", now.elapsed());
+							tracing::debug!(execution_time = ?now.elapsed());
 							rp
 						}
 						Err(err) => send_call_error(id, &tx, err),
@@ -581,7 +581,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 						);
 						send_error(id, method_sink, ErrorCode::ServerError(-1).into());
 					}
-					tracing::debug!("finished {:?}", now.elapsed());
+					tracing::debug!(execution_time_ms = ?now.elapsed().as_millis());
 				})),
 			);
 		}
@@ -605,7 +605,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 					};
 					subscribers.lock().remove(&SubscriptionKey { conn_id, sub_id });
 					send_response(id, tx, "Unsubscribed");
-					tracing::debug!("finished {:?}", now.elapsed());
+					tracing::debug!(execution_time_ms = ?now.elapsed().as_millis());
 				})),
 			);
 		}

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -15,6 +15,7 @@ futures-util = { version = "0.3.14", default-features = false, features = ["io",
 jsonrpsee-types = { path = "../types", version = "0.4.1" }
 jsonrpsee-utils = { path = "../utils", version = "0.4.1", features = ["server"] }
 tracing = "0.1"
+tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros"] }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -288,8 +288,8 @@ async fn background_task(
 				if let Ok(req) = serde_json::from_slice::<Request>(&data) {
 					let span = tracing::span!(tracing::Level::DEBUG, "method_call", %req.method);
 					let _enter = span.enter();
-					tracing::debug!("recv {} bytes", data.len());
-					tracing::trace!("recv: {:?}", req);
+					tracing::debug!(rx_method_call_len = data.len());
+					tracing::trace!(rx_method_call = ?req);
 
 					if let Some(fut) = methods.execute_with_resources(&tx, req, conn_id, &resources) {
 						fut.await.in_current_span();
@@ -303,8 +303,8 @@ async fn background_task(
 				if let Ok(batch) = serde_json::from_slice::<Vec<Request>>(&data) {
 					let span = tracing::span!(tracing::Level::DEBUG, "batch_call", batch = batch.len());
 					let _enter = span.enter();
-					tracing::debug!("recv {} bytes", data.len());
-					tracing::trace!("recv: {:?}", batch);
+					tracing::debug!(rx_batch_call_len = data.len());
+					tracing::trace!(rx_batch = ?batch);
 
 					if !batch.is_empty() {
 						// Batch responses must be sent back as a single message so we read the results from each


### PR DESCRIPTION
Continuation of #487

Example output:

```
Oct 26 15:00:28.093 DEBUG method_call{req.method=say_hello}: jsonrpsee_ws_server::server: rx_method_call_len=45
Oct 26 15:00:28.093 TRACE method_call{req.method=say_hello}: jsonrpsee_ws_server::server: rx_method_call=Request { jsonrpc: TwoPointZero, id: Number(0), method: "say_hello", params: None }
Oct 26 15:00:29.094 DEBUG method_call{req.method=say_hello}: jsonrpsee_utils::server::helpers: tx_method_call_len=38
Oct 26 15:00:29.094 DEBUG method_call{req.method=say_hello}: jsonrpsee_utils::server::helpers: tx_method_call="{\"jsonrpc\":\"2.0\",\"result\":\"lo\",\"id\":0}"
Oct 26 15:00:29.094 DEBUG method_call{req.method=say_hello}: jsonrpsee_utils::server::rpc_module: execution_time=1.000502295s
```

Should solve:
> Support to log the request, including its payload*
> Support to log the response, including its payload* and the timing

I have used `debug` to only print payload sizes and `trace` to print the entire payload.
Perhaps we should make it possible to truncate the payloads when it exceeds some limit....


