### PR TITLE
fix(ws server): `batch` wait until all methods has been executed.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,16 +21,14 @@ criterion_group!(
 	SyncBencher::http_requests,
 	SyncBencher::batched_http_requests,
 	SyncBencher::websocket_requests,
-	// TODO: https://github.com/paritytech/jsonrpsee/issues/528
-	// SyncBencher::batched_ws_requests,
+	SyncBencher::batched_ws_requests,
 );
 criterion_group!(
 	async_benches,
 	AsyncBencher::http_requests,
 	AsyncBencher::batched_http_requests,
 	AsyncBencher::websocket_requests,
-	// TODO: https://github.com/paritytech/jsonrpsee/issues/528
-	// AsyncBencher::batched_ws_requests
+	AsyncBencher::batched_ws_requests
 );
 criterion_group!(subscriptions, AsyncBencher::subscriptions);
 criterion_main!(types_benches, sync_benches, async_benches, subscriptions);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,9 +8,11 @@ license = "MIT"
 publish = false
 
 [dev-dependencies]
+env_logger = "0.8"
+tracing-subscriber = "0.3.1"
+tracing = "0.1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
-tracing = "0.1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,10 +9,9 @@ publish = false
 
 [dev-dependencies]
 env_logger = "0.8"
-tracing-subscriber = "0.3.1"
-tracing = "0.1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
 serde_json = "1"

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -98,6 +98,13 @@ pub async fn websocket_server() -> SocketAddr {
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("hello")).unwrap();
 
+	module
+		.register_async_method("slow_hello", |_, _| async {
+			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+			Ok("hello")
+		})
+		.unwrap();
+
 	let addr = server.local_addr().unwrap();
 
 	server.start(module).unwrap();

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -381,5 +381,5 @@ async fn ws_batch_works() {
 	batch.push(("say_hello", rpc_params![]));
 	batch.push(("slow_hello", rpc_params![]));
 
-	let response: Vec<String> = client.batch_request(batch).await.unwrap();
+	assert!(client.batch_request::<String>(batch).await.is_ok())
 }

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -360,3 +360,26 @@ async fn ws_server_should_stop_subscription_after_client_drop() {
 	// assert that the server received `SubscriptionClosed` after the client was dropped.
 	assert!(matches!(rx.next().await.unwrap(), SubscriptionClosedError { .. }));
 }
+
+#[tokio::test]
+async fn ws_batch_works() {
+	let subscriber = tracing_subscriber::FmtSubscriber::builder()
+		// all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
+		// will be written to stdout.
+		.with_max_level(tracing::Level::TRACE)
+		// completes the builder.
+		.finish();
+
+	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+	let server_addr = websocket_server().await;
+	let server_url = format!("ws://{}", server_addr);
+	let client = Arc::new(WsClientBuilder::default().build(&server_url).await.unwrap());
+
+	let mut batch = Vec::new();
+
+	batch.push(("say_hello", rpc_params![]));
+	batch.push(("slow_hello", rpc_params![]));
+
+	let response: Vec<String> = client.batch_request(batch).await.unwrap();
+}

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -363,23 +363,15 @@ async fn ws_server_should_stop_subscription_after_client_drop() {
 
 #[tokio::test]
 async fn ws_batch_works() {
-	let subscriber = tracing_subscriber::FmtSubscriber::builder()
-		// all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
-		// will be written to stdout.
-		.with_max_level(tracing::Level::TRACE)
-		// completes the builder.
-		.finish();
-
-	tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-
 	let server_addr = websocket_server().await;
 	let server_url = format!("ws://{}", server_addr);
-	let client = Arc::new(WsClientBuilder::default().build(&server_url).await.unwrap());
+	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let mut batch = Vec::new();
 
 	batch.push(("say_hello", rpc_params![]));
 	batch.push(("slow_hello", rpc_params![]));
 
-	assert!(client.batch_request::<String>(batch).await.is_ok())
+	let responses: Vec<String> = client.batch_request(batch).await.unwrap();
+	assert_eq!(responses, vec!["hello".to_string(), "hello".to_string()]);
 }

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -305,15 +305,15 @@ impl Methods {
 		tracing::trace!("[Methods::execute_with_resources] Executing request: {:?}", req);
 		match self.callbacks.get(&*req.method) {
 			Some(callback) => match callback.claim(&req.method, resources) {
-				Ok(guard) => callback.execute(tx, req, conn_id, Some(guard)),
+				Ok(guard) => callback.execute(&tx, req, conn_id, Some(guard)),
 				Err(err) => {
 					tracing::error!("[Methods::execute_with_resources] failed to lock resources: {:?}", err);
-					send_error(req.id, tx, ErrorCode::ServerIsBusy.into());
+					send_error(req.id, &tx, ErrorCode::ServerIsBusy.into());
 					None
 				}
 			},
 			None => {
-				send_error(req.id, tx, ErrorCode::MethodNotFound.into());
+				send_error(req.id, &tx, ErrorCode::MethodNotFound.into());
 				None
 			}
 		}

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -305,15 +305,15 @@ impl Methods {
 		tracing::trace!("[Methods::execute_with_resources] Executing request: {:?}", req);
 		match self.callbacks.get(&*req.method) {
 			Some(callback) => match callback.claim(&req.method, resources) {
-				Ok(guard) => callback.execute(&tx, req, conn_id, Some(guard)),
+				Ok(guard) => callback.execute(tx, req, conn_id, Some(guard)),
 				Err(err) => {
 					tracing::error!("[Methods::execute_with_resources] failed to lock resources: {:?}", err);
-					send_error(req.id, &tx, ErrorCode::ServerIsBusy.into());
+					send_error(req.id, tx, ErrorCode::ServerIsBusy.into());
 					None
 				}
 			},
 			None => {
-				send_error(req.id, &tx, ErrorCode::MethodNotFound.into());
+				send_error(req.id, tx, ErrorCode::MethodNotFound.into());
 				None
 			}
 		}

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -314,7 +314,7 @@ async fn background_task(
 						if !batch.is_empty() {
 							let futs = batch
 								.into_iter()
-								.filter_map(|req| m.execute_with_resources(&tx_batch, req, conn_id, &r));
+								.filter_map(|req| m.execute_with_resources(&tx_batch, req, conn_id, r));
 							futures_util::future::join_all(futs).await;
 
 							// All methods has now completed by `join_all` above

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -312,7 +312,7 @@ async fn background_task(
 						if !batch.is_empty() {
 							let methods_stream =
 								stream::iter(batch.into_iter().filter_map(|req| {
-									methods.execute_with_resources(&tx_batch, req, conn_id, &resources)
+									methods.execute_with_resources(&tx_batch, req, conn_id, resources)
 								}));
 
 							let results = methods_stream

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -264,10 +264,12 @@ async fn background_task(
 		// will be possible.
 	});
 
+	// Buffer for incoming data.
+	let mut data = Vec::with_capacity(100);
 	let mut method_executors = FutureDriver::default();
 
 	while !stop_server.shutdown_requested() {
-		let mut data = Vec::new();
+		data.clear();
 
 		if let Err(e) = method_executors.select_with(receiver.receive_data(&mut data)).await {
 			tracing::error!("Could not receive WS data: {:?}; closing connection", e);
@@ -328,7 +330,7 @@ async fn background_task(
 							send_error(Id::Null, &tx2, ErrorCode::InvalidRequest.into());
 						}
 					} else {
-						let (id, code) = prepare_error(&data);
+						let (id, code) = prepare_error(&d);
 						send_error(id, &tx2, code.into());
 					}
 				};


### PR DESCRIPTION
This fixes a bug in the ws-server when any `async methods` are included in batch, the futures were not awaited on that "may" cause method calls to be ignored. In worst case just send back `]`
