### PR TITLE
clients: request ID as RAII guard

### DIFF
--- a/http-client/src/client.rs
+++ b/http-client/src/client.rs
@@ -167,8 +167,7 @@ impl Client for HttpClient {
 			request_set.insert(ids.inner()[pos], pos);
 		}
 
-		let fut =
-			self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
+		let fut = self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
 
 		let body = match tokio::time::timeout(self.request_timeout, fut).await {
 			Ok(Ok(body)) => body,

--- a/types/src/client.rs
+++ b/types/src/client.rs
@@ -30,7 +30,8 @@ use futures_channel::{mpsc, oneshot};
 use futures_util::{future::FutureExt, sink::SinkExt, stream::StreamExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 /// Subscription kind
 #[derive(Debug)]
@@ -190,7 +191,7 @@ impl<Notif> Drop for Subscription<Notif> {
 /// Keep track of request IDs.
 pub struct RequestIdGuard {
 	// Current pending requests.
-	current_pending: AtomicUsize,
+	current_pending: Arc<()>,
 	/// Max concurrent pending requests allowed.
 	max_concurrent_requests: usize,
 	/// Get the next request ID.
@@ -200,52 +201,70 @@ pub struct RequestIdGuard {
 impl RequestIdGuard {
 	/// Create a new `RequestIdGuard` with the provided concurrency limit.
 	pub fn new(limit: usize) -> Self {
-		Self { current_pending: AtomicUsize::new(0), max_concurrent_requests: limit, current_id: AtomicU64::new(0) }
+		Self { current_pending: Arc::new(()), max_concurrent_requests: limit, current_id: AtomicU64::new(0) }
 	}
 
-	fn get_slot(&self) -> Result<(), Error> {
-		self.current_pending
-			.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
-				if val >= self.max_concurrent_requests {
-					None
-				} else {
-					Some(val + 1)
-				}
-			})
-			.map(|_| ())
-			.map_err(|_| Error::MaxSlotsExceeded)
+	fn get_slot(&self) -> Result<Arc<()>, Error> {
+		// Strong count is 1 at start, so that's why we use `>` and not `>=`.
+		if Arc::strong_count(&self.current_pending) > self.max_concurrent_requests {
+			Err(Error::MaxSlotsExceeded)
+		} else {
+			Ok(self.current_pending.clone())
+		}
 	}
 
 	/// Attempts to get the next request ID.
 	///
 	/// Fails if request limit has been exceeded.
-	pub fn next_request_id(&self) -> Result<u64, Error> {
-		self.get_slot()?;
+	pub fn next_request_id(&self) -> Result<RequestId<u64>, Error> {
+		let rc = self.get_slot()?;
 		let id = self.current_id.fetch_add(1, Ordering::SeqCst);
-		Ok(id)
+		Ok(RequestId { _rc: rc, id })
 	}
 
 	/// Attempts to get the `n` number next IDs that only counts as one request.
 	///
 	/// Fails if request limit has been exceeded.
-	pub fn next_request_ids(&self, len: usize) -> Result<Vec<u64>, Error> {
-		self.get_slot()?;
-		let mut batch = Vec::with_capacity(len);
+	pub fn next_request_ids(&self, len: usize) -> Result<RequestId<Vec<u64>>, Error> {
+		let rc = self.get_slot()?;
+		let mut ids = Vec::with_capacity(len);
 		for _ in 0..len {
-			batch.push(self.current_id.fetch_add(1, Ordering::SeqCst));
+			ids.push(self.current_id.fetch_add(1, Ordering::SeqCst));
 		}
-		Ok(batch)
+		Ok(RequestId { _rc: rc, id: ids })
 	}
+}
 
-	/// Decrease the currently pending counter by one (saturated at 0).
-	pub fn reclaim_request_id(&self) {
-		// NOTE we ignore the error here, since we are simply saturating at 0
-		let _ = self.current_pending.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
-			if val > 0 {
-				Some(val - 1)
-			} else {
-				None
-			}
-		});
+/// Reference counted request ID.
+#[derive(Debug)]
+pub struct RequestId<T> {
+	id: T,
+	/// Reference count decreased when dropped.
+	_rc: Arc<()>,
+}
+
+impl<T> RequestId<T> {
+	/// Get the actual ID.
+	pub fn inner(&self) -> &T {
+		&self.id
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::RequestIdGuard;
+
+	#[test]
+	fn request_id_guard_works() {
+		let guard = RequestIdGuard::new(2);
+		let _first = guard.next_request_id().unwrap();
+
+		{
+			let _second = guard.next_request_ids(13).unwrap();
+			assert!(guard.next_request_id().is_err());
+			// second dropped here.
+		}
+
+		assert!(guard.next_request_id().is_ok());
 	}
 }

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -301,8 +301,7 @@ impl Client for WsClient {
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		let req_id = self.id_guard.next_request_id()?;
 		let id = *req_id.inner();
-		let raw = serde_json::to_string(&RequestSer::new(Id::Number(id), method, params))
-			.map_err(Error::ParseError)?;
+		let raw = serde_json::to_string(&RequestSer::new(Id::Number(id), method, params)).map_err(Error::ParseError)?;
 		tracing::trace!("[frontend]: send request: {:?}", raw);
 
 		if self

--- a/ws-client/src/client.rs
+++ b/ws-client/src/client.rs
@@ -275,7 +275,7 @@ impl Client for WsClient {
 		// NOTE: we use this to guard against max number of concurrent requests.
 		let _req_id = self.id_guard.next_request_id()?;
 		let notif = NotificationSer::new(method, params);
-		let raw = serde_json::to_string(&notif).map_err(|e| Error::ParseError(e))?;
+		let raw = serde_json::to_string(&notif).map_err(Error::ParseError)?;
 		tracing::trace!("[frontend]: send notification: {:?}", raw);
 
 		let mut sender = self.to_back.clone();
@@ -302,7 +302,7 @@ impl Client for WsClient {
 		let req_id = self.id_guard.next_request_id()?;
 		let id = *req_id.inner();
 		let raw = serde_json::to_string(&RequestSer::new(Id::Number(id), method, params))
-			.map_err(|e| Error::ParseError(e))?;
+			.map_err(Error::ParseError)?;
 		tracing::trace!("[frontend]: send request: {:?}", raw);
 
 		if self
@@ -337,7 +337,7 @@ impl Client for WsClient {
 
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 
-		let raw = serde_json::to_string(&batches).map_err(|e| Error::ParseError(e))?;
+		let raw = serde_json::to_string(&batches).map_err(Error::ParseError)?;
 		tracing::trace!("[frontend]: send batch request: {:?}", raw);
 		if self
 			.to_back
@@ -385,7 +385,7 @@ impl SubscriptionClient for WsClient {
 
 		let ids = self.id_guard.next_request_ids(2)?;
 		let raw = serde_json::to_string(&RequestSer::new(Id::Number(ids.inner()[0]), subscribe_method, params))
-			.map_err(|e| Error::ParseError(e))?;
+			.map_err(Error::ParseError)?;
 
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		if self


### PR DESCRIPTION
The rationale behind this change is to reduce the technical debt, not to require us to remember to reclaim a request ID when a request was completed successful or not.