### PR TITLE
Proc mac support map param

### DIFF
--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -43,7 +43,7 @@ pub(crate) struct Argument {
 #[derive(Debug, Clone)]
 pub enum ParamFormat {
 	Array,
-	Map
+	Map,
 }
 
 #[derive(Debug, Clone)]
@@ -198,8 +198,8 @@ where
 
 pub(crate) fn parse_param_format(arg: Result<Argument, MissingArgument>) -> ParamFormat {
 	match optional(arg, Argument::string).unwrap().as_deref() {
-			None | Some("array") => ParamFormat::Array,
-			Some("map") => ParamFormat::Map,
-			err => panic!("param_format must be either `map` or `array`, got {:?}", err)
+		None | Some("array") => ParamFormat::Array,
+		Some("map") => ParamFormat::Map,
+		err => panic!("param_format must be either `map` or `array`, got {:?}", err),
 	}
 }

--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -41,6 +41,12 @@ pub(crate) struct Argument {
 }
 
 #[derive(Debug, Clone)]
+pub enum ParamFormat {
+	Array,
+	Map
+}
+
+#[derive(Debug, Clone)]
 pub struct Resource {
 	pub name: syn::LitStr,
 	pub assign: Token![=],
@@ -188,4 +194,12 @@ where
 	F: Fn(Argument) -> syn::Result<T>,
 {
 	arg.ok().map(transform).transpose()
+}
+
+pub(crate) fn parse_param_format(arg: Result<Argument, MissingArgument>) -> ParamFormat {
+	match optional(arg, Argument::string).unwrap().as_deref() {
+			None | Some("array") => ParamFormat::Array,
+			Some("map") => ParamFormat::Map,
+			err => panic!("param_format must be either `map` or `array`, got {:?}", err)
+	}
 }

--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -196,10 +196,13 @@ where
 	arg.ok().map(transform).transpose()
 }
 
-pub(crate) fn parse_param_kind(arg: Result<Argument, MissingArgument>) -> ParamKind {
-	match optional(arg, Argument::string).unwrap().as_deref() {
-		None | Some("array") => ParamKind::Array,
-		Some("map") => ParamKind::Map,
-		err => panic!("param_kind must be either `map` or `array`, got {:?}", err),
+pub(crate) fn parse_param_kind(arg: Result<Argument, MissingArgument>) -> syn::Result<ParamKind> {
+	let kind: Option<syn::Ident> = optional(arg, Argument::value)?;
+
+	match kind {
+		None => Ok(ParamKind::Array),
+		Some(ident) if ident == "array" => Ok(ParamKind::Array),
+		Some(ident) if ident == "map" => Ok(ParamKind::Map),
+		ident => Err(Error::new(ident.span(), "param_kind must be either `map` or `array`")),
 	}
 }

--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -41,7 +41,7 @@ pub(crate) struct Argument {
 }
 
 #[derive(Debug, Clone)]
-pub enum ParamFormat {
+pub enum ParamKind {
 	Array,
 	Map,
 }
@@ -196,10 +196,10 @@ where
 	arg.ok().map(transform).transpose()
 }
 
-pub(crate) fn parse_param_format(arg: Result<Argument, MissingArgument>) -> ParamFormat {
+pub(crate) fn parse_param_kind(arg: Result<Argument, MissingArgument>) -> ParamKind {
 	match optional(arg, Argument::string).unwrap().as_deref() {
-		None | Some("array") => ParamFormat::Array,
-		Some("map") => ParamFormat::Map,
-		err => panic!("param_format must be either `map` or `array`, got {:?}", err),
+		None | Some("array") => ParamKind::Array,
+		Some("map") => ParamKind::Map,
+		err => panic!("param_kind must be either `map` or `array`, got {:?}", err),
 	}
 }

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -164,6 +164,7 @@ pub(crate) mod visitor;
 /// - `name` (mandatory): name of the RPC method. Does not have to be the same as the Rust method name.
 /// - `aliases`: list of name aliases for the RPC method as a comma separated string.
 /// - `blocking`: when set method execution will always spawn on a dedicated thread. Only usable with non-`async` methods.
+/// - `param_kind`: kind of structure to use for parameter passing. Can be "array" or "map", defaults to "array".
 ///
 /// **Method requirements:**
 ///
@@ -180,6 +181,7 @@ pub(crate) mod visitor;
 /// - `name` (mandatory): name of the RPC method. Does not have to be the same as the Rust method name.
 /// - `unsub` (mandatory): name of the RPC method to unsubscribe from the subscription. Must not be the same as `name`.
 /// - `item` (mandatory): type of items yielded by the subscription. Note that it must be the type, not string.
+/// - `param_kind`: kind of structure to use for parameter passing. Can be "array" or "map", defaults to "array".
 ///
 /// **Method requirements:**
 ///

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -96,7 +96,7 @@ impl RpcDescription {
 
 		// Encoded parameters for the request.
 		let parameters = self.encode_params(&method.params, &method.param_kind, &method.signature);
-				// Doc-comment to be associated with the method.
+		// Doc-comment to be associated with the method.
 		let docs = &method.docs;
 
 		let method = quote! {

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -23,7 +23,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-
+use crate::attributes::ParamFormat;
 use crate::helpers::generate_where_clause;
 use crate::rpc_macro::{RpcDescription, RpcMethod, RpcSubscription};
 use proc_macro2::TokenStream as TokenStream2;
@@ -100,8 +100,8 @@ impl RpcDescription {
 			let params = method.params.iter().map(|(param, _param_type)| {
 				quote! { #serde_json::to_value(&#param)? }
 			});
-			match method.param_format.as_deref() {
-				Some("map") => {
+			match method.param_format {
+				ParamFormat::Map => {
 					// Extract parameter names.
 					let param_names = extract_param_names(&method.signature.sig);
 					// Combine parameter names and values into tuples.
@@ -120,12 +120,11 @@ impl RpcDescription {
 							)
 					}
 				}
-				Some("array") => {
+				ParamFormat::Array => {
 					quote! {
 						Some(vec![ #(#params),* ].into())
 					}
 				}
-				_ => panic!(""), // FIXME
 			}
 		} else {
 			quote! { None }
@@ -167,8 +166,8 @@ impl RpcDescription {
 			let params = sub.params.iter().map(|(param, _param_type)| {
 				quote! { #serde_json::to_value(&#param)? }
 			});
-			match sub.param_format.as_deref() {
-				Some("map") => {
+			match sub.param_format {
+				ParamFormat::Map => {
 					// Extract parameter names.
 					let param_names = extract_param_names(&sub.signature.sig);
 					// Combine parameter names and values into tuples.
@@ -187,12 +186,11 @@ impl RpcDescription {
 							)
 					}
 				}
-				Some("array") => {
+				ParamFormat::Array => {
 					quote! {
 						Some(vec![ #(#params),* ].into())
 					}
 				}
-				_ => panic!(""), // FIXME
 			}
 		} else {
 			quote! { None }

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -152,6 +152,7 @@ impl RpcDescription {
 					},
 					_ => None,
 				});
+				// Combine parameter names and values into tuples.
 				let params = param_names.zip(params).map(|pair| {
 					let key = pair.0;
 					let value = pair.1;
@@ -161,7 +162,7 @@ impl RpcDescription {
 				quote! {
 					Some(#jsonrpsee::types::v2::ParamsSer::Map(
 							std::collections::BTreeMap::<&str, #jsonrpsee::types::JsonValue>::from(
-								vec![#(#params),*].into()
+								[#(#params),*]
 								)
 							)
 						)

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -159,7 +159,12 @@ impl RpcDescription {
 				});
 				let jsonrpsee = self.jsonrpsee_client_path.as_ref().unwrap();
 				quote! {
-					Some(#jsonrpsee::types::v2::ParamsSer::Map(std::collections::BTreeMap::<&str, #jsonrpsee::types::JsonValue>::from(vec![#(#params),*].into())))
+					Some(#jsonrpsee::types::v2::ParamsSer::Map(
+							std::collections::BTreeMap::<&str, #jsonrpsee::types::JsonValue>::from(
+								vec![#(#params),*].into()
+								)
+							)
+						)
 				}
 			} else {
 				quote! {

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -100,28 +100,32 @@ impl RpcDescription {
 			let params = method.params.iter().map(|(param, _param_type)| {
 				quote! { #serde_json::to_value(&#param)? }
 			});
-			if method.param_format == "map" {
-				// Extract parameter names.
-				let param_names = extract_param_names(&method.signature.sig);
-				// Combine parameter names and values into tuples.
-				let params = param_names.iter().zip(params).map(|pair| {
-					let key = pair.0;
-					let value = pair.1;
-					quote! { (#key, #value) }
-				});
-				let jsonrpsee = self.jsonrpsee_client_path.as_ref().unwrap();
-				quote! {
-					Some(#jsonrpsee::types::v2::ParamsSer::Map(
-							std::collections::BTreeMap::<&str, #jsonrpsee::types::JsonValue>::from(
-								[#(#params),*]
+			match method.param_format.as_deref() {
+				Some("map") => {
+					// Extract parameter names.
+					let param_names = extract_param_names(&method.signature.sig);
+					// Combine parameter names and values into tuples.
+					let params = param_names.iter().zip(params).map(|pair| {
+						let key = pair.0;
+						let value = pair.1;
+						quote! { (#key, #value) }
+					});
+					let jsonrpsee = self.jsonrpsee_client_path.as_ref().unwrap();
+					quote! {
+						Some(#jsonrpsee::types::v2::ParamsSer::Map(
+								std::collections::BTreeMap::<&str, #jsonrpsee::types::JsonValue>::from(
+									[#(#params),*]
+									)
 								)
 							)
-						)
+					}
 				}
-			} else {
-				quote! {
-					Some(vec![ #(#params),* ].into())
+				Some("array") => {
+					quote! {
+						Some(vec![ #(#params),* ].into())
+					}
 				}
+				_ => panic!(""), // FIXME
 			}
 		} else {
 			quote! { None }
@@ -163,28 +167,32 @@ impl RpcDescription {
 			let params = sub.params.iter().map(|(param, _param_type)| {
 				quote! { #serde_json::to_value(&#param)? }
 			});
-			if sub.param_format == "map" {
-				// Extract parameter names.
-				let param_names = extract_param_names(&sub.signature.sig);
-				// Combine parameter names and values into tuples.
-				let params = param_names.iter().zip(params).map(|pair| {
-					let key = pair.0;
-					let value = pair.1;
-					quote! { (#key, #value) }
-				});
-				let jsonrpsee = self.jsonrpsee_client_path.as_ref().unwrap();
-				quote! {
-					Some(#jsonrpsee::types::v2::ParamsSer::Map(
-							std::collections::BTreeMap::<&str, #jsonrpsee::types::JsonValue>::from(
-								[#(#params),*]
+			match sub.param_format.as_deref() {
+				Some("map") => {
+					// Extract parameter names.
+					let param_names = extract_param_names(&sub.signature.sig);
+					// Combine parameter names and values into tuples.
+					let params = param_names.iter().zip(params).map(|pair| {
+						let key = pair.0;
+						let value = pair.1;
+						quote! { (#key, #value) }
+					});
+					let jsonrpsee = self.jsonrpsee_client_path.as_ref().unwrap();
+					quote! {
+						Some(#jsonrpsee::types::v2::ParamsSer::Map(
+								std::collections::BTreeMap::<&str, #jsonrpsee::types::JsonValue>::from(
+									[#(#params),*]
+									)
 								)
 							)
-						)
+					}
 				}
-			} else {
-				quote! {
-					Some(vec![ #(#params),* ].into())
+				Some("array") => {
+					quote! {
+						Some(vec![ #(#params),* ].into())
+					}
 				}
+				_ => panic!(""), // FIXME
 			}
 		} else {
 			quote! { None }
@@ -204,11 +212,14 @@ impl RpcDescription {
 }
 
 fn extract_param_names(sig: &syn::Signature) -> Vec<String> {
-	sig.inputs.iter().filter_map(|param| match param {
-		FnArg::Typed(PatType { pat, .. }) => match &**pat {
-			Pat::Ident(PatIdent { ident, .. }) => Some(ident.to_string()),
+	sig.inputs
+		.iter()
+		.filter_map(|param| match param {
+			FnArg::Typed(PatType { pat, .. }) => match &**pat {
+				Pat::Ident(PatIdent { ident, .. }) => Some(ident.to_string()),
+				_ => None,
+			},
 			_ => None,
-		},
-		_ => None,
-	}).collect()
+		})
+		.collect()
 }

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -27,7 +27,7 @@
 //! Declaration of the JSON RPC generator procedural macros.
 
 use crate::{
-	attributes::{optional, Argument, AttributeMeta, MissingArgument, Resource},
+	attributes::{optional, parse_param_format, Argument, AttributeMeta, MissingArgument, ParamFormat, Resource},
 	helpers::extract_doc_comments,
 };
 
@@ -42,7 +42,7 @@ pub struct RpcMethod {
 	pub blocking: bool,
 	pub docs: TokenStream2,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
-	pub param_format: Option<String>,
+	pub param_format: ParamFormat,
 	pub returns: Option<syn::Type>,
 	pub signature: syn::TraitItemMethod,
 	pub aliases: Vec<String>,
@@ -57,7 +57,7 @@ impl RpcMethod {
 		let aliases = parse_aliases(aliases)?;
 		let blocking = optional(blocking, Argument::flag)?.is_some();
 		let name = name?.string()?;
-		let param_format = optional(param_format, Argument::string)?.or(Some("array".into()));
+		let param_format = parse_param_format(param_format);
 		let resources = optional(resources, Argument::group)?.unwrap_or_default();
 
 		let sig = method.sig.clone();
@@ -97,7 +97,7 @@ pub struct RpcSubscription {
 	pub docs: TokenStream2,
 	pub unsubscribe: String,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
-	pub param_format: Option<String>,
+	pub param_format: ParamFormat,
 	pub item: syn::Type,
 	pub signature: syn::TraitItemMethod,
 	pub aliases: Vec<String>,
@@ -112,7 +112,7 @@ impl RpcSubscription {
 		let aliases = parse_aliases(aliases)?;
 		let name = name?.string()?;
 		let item = item?.value()?;
-		let param_format = optional(param_format, Argument::string)?.or(Some("array".into()));
+		let param_format = parse_param_format(param_format);
 		let unsubscribe_aliases = parse_aliases(unsubscribe_aliases)?;
 
 		let sig = sub.sig.clone();

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -95,6 +95,7 @@ pub struct RpcSubscription {
 	pub docs: TokenStream2,
 	pub unsubscribe: String,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
+	pub param_format: String,
 	pub item: syn::Type,
 	pub signature: syn::TraitItemMethod,
 	pub aliases: Vec<String>,
@@ -103,12 +104,16 @@ pub struct RpcSubscription {
 
 impl RpcSubscription {
 	pub fn from_item(attr: syn::Attribute, mut sub: syn::TraitItemMethod) -> syn::Result<Self> {
-		let [aliases, item, name, unsubscribe_aliases] =
-			AttributeMeta::parse(attr)?.retain(["aliases", "item", "name", "unsubscribe_aliases"])?;
+		let [aliases, item, name, param_format, unsubscribe_aliases] =
+			AttributeMeta::parse(attr)?.retain(["aliases", "item", "name", "param_format", "unsubscribe_aliases"])?;
 
 		let aliases = parse_aliases(aliases)?;
 		let name = name?.string()?;
 		let item = item?.value()?;
+		let param_format = match param_format {
+			Ok(param_format) => param_format.string()?,
+			Err(_) => String::from("array"),
+		};
 		let unsubscribe_aliases = parse_aliases(unsubscribe_aliases)?;
 
 		let sig = sub.sig.clone();
@@ -130,7 +135,7 @@ impl RpcSubscription {
 		// We've analyzed attributes and don't need them anymore.
 		sub.attrs.clear();
 
-		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, item, signature: sub, aliases, docs })
+		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, param_format, item, signature: sub, aliases, docs })
 	}
 }
 

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -27,7 +27,7 @@
 //! Declaration of the JSON RPC generator procedural macros.
 
 use crate::{
-	attributes::{optional, parse_param_format, Argument, AttributeMeta, MissingArgument, ParamFormat, Resource},
+	attributes::{optional, parse_param_kind, Argument, AttributeMeta, MissingArgument, ParamKind, Resource},
 	helpers::extract_doc_comments,
 };
 
@@ -42,7 +42,7 @@ pub struct RpcMethod {
 	pub blocking: bool,
 	pub docs: TokenStream2,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
-	pub param_format: ParamFormat,
+	pub param_kind: ParamKind,
 	pub returns: Option<syn::Type>,
 	pub signature: syn::TraitItemMethod,
 	pub aliases: Vec<String>,
@@ -51,13 +51,13 @@ pub struct RpcMethod {
 
 impl RpcMethod {
 	pub fn from_item(attr: Attribute, mut method: syn::TraitItemMethod) -> syn::Result<Self> {
-		let [aliases, blocking, name, param_format, resources] =
-			AttributeMeta::parse(attr)?.retain(["aliases", "blocking", "name", "param_format", "resources"])?;
+		let [aliases, blocking, name, param_kind, resources] =
+			AttributeMeta::parse(attr)?.retain(["aliases", "blocking", "name", "param_kind", "resources"])?;
 
 		let aliases = parse_aliases(aliases)?;
 		let blocking = optional(blocking, Argument::flag)?.is_some();
 		let name = name?.string()?;
-		let param_format = parse_param_format(param_format);
+		let param_kind = parse_param_kind(param_kind);
 		let resources = optional(resources, Argument::group)?.unwrap_or_default();
 
 		let sig = method.sig.clone();
@@ -87,7 +87,7 @@ impl RpcMethod {
 		// We've analyzed attributes and don't need them anymore.
 		method.attrs.clear();
 
-		Ok(Self { aliases, blocking, name, params, param_format, returns, signature: method, docs, resources })
+		Ok(Self { aliases, blocking, name, params, param_kind, returns, signature: method, docs, resources })
 	}
 }
 
@@ -97,7 +97,7 @@ pub struct RpcSubscription {
 	pub docs: TokenStream2,
 	pub unsubscribe: String,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
-	pub param_format: ParamFormat,
+	pub param_kind: ParamKind,
 	pub item: syn::Type,
 	pub signature: syn::TraitItemMethod,
 	pub aliases: Vec<String>,
@@ -106,13 +106,13 @@ pub struct RpcSubscription {
 
 impl RpcSubscription {
 	pub fn from_item(attr: syn::Attribute, mut sub: syn::TraitItemMethod) -> syn::Result<Self> {
-		let [aliases, item, name, param_format, unsubscribe_aliases] =
-			AttributeMeta::parse(attr)?.retain(["aliases", "item", "name", "param_format", "unsubscribe_aliases"])?;
+		let [aliases, item, name, param_kind, unsubscribe_aliases] =
+			AttributeMeta::parse(attr)?.retain(["aliases", "item", "name", "param_kind", "unsubscribe_aliases"])?;
 
 		let aliases = parse_aliases(aliases)?;
 		let name = name?.string()?;
 		let item = item?.value()?;
-		let param_format = parse_param_format(param_format);
+		let param_kind = parse_param_kind(param_kind);
 		let unsubscribe_aliases = parse_aliases(unsubscribe_aliases)?;
 
 		let sig = sub.sig.clone();
@@ -134,7 +134,7 @@ impl RpcSubscription {
 		// We've analyzed attributes and don't need them anymore.
 		sub.attrs.clear();
 
-		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, param_format, item, signature: sub, aliases, docs })
+		Ok(Self { name, unsubscribe, unsubscribe_aliases, params, param_kind, item, signature: sub, aliases, docs })
 	}
 }
 

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -57,7 +57,7 @@ impl RpcMethod {
 		let aliases = parse_aliases(aliases)?;
 		let blocking = optional(blocking, Argument::flag)?.is_some();
 		let name = name?.string()?;
-		let param_kind = parse_param_kind(param_kind);
+		let param_kind = parse_param_kind(param_kind)?;
 		let resources = optional(resources, Argument::group)?.unwrap_or_default();
 
 		let sig = method.sig.clone();
@@ -112,7 +112,7 @@ impl RpcSubscription {
 		let aliases = parse_aliases(aliases)?;
 		let name = name?.string()?;
 		let item = item?.value()?;
-		let param_kind = parse_param_kind(param_kind);
+		let param_kind = parse_param_kind(param_kind)?;
 		let unsubscribe_aliases = parse_aliases(unsubscribe_aliases)?;
 
 		let sig = sub.sig.clone();

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -42,7 +42,7 @@ pub struct RpcMethod {
 	pub blocking: bool,
 	pub docs: TokenStream2,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
-	pub param_format: String,
+	pub param_format: Option<String>,
 	pub returns: Option<syn::Type>,
 	pub signature: syn::TraitItemMethod,
 	pub aliases: Vec<String>,
@@ -57,10 +57,7 @@ impl RpcMethod {
 		let aliases = parse_aliases(aliases)?;
 		let blocking = optional(blocking, Argument::flag)?.is_some();
 		let name = name?.string()?;
-		let param_format = match param_format {
-			Ok(param_format) => param_format.string()?,
-			Err(_) => String::from("array"),
-		};
+		let param_format = optional(param_format, Argument::string)?.or(Some("array".into()));
 		let resources = optional(resources, Argument::group)?.unwrap_or_default();
 
 		let sig = method.sig.clone();
@@ -100,7 +97,7 @@ pub struct RpcSubscription {
 	pub docs: TokenStream2,
 	pub unsubscribe: String,
 	pub params: Vec<(syn::PatIdent, syn::Type)>,
-	pub param_format: String,
+	pub param_format: Option<String>,
 	pub item: syn::Type,
 	pub signature: syn::TraitItemMethod,
 	pub aliases: Vec<String>,
@@ -115,10 +112,7 @@ impl RpcSubscription {
 		let aliases = parse_aliases(aliases)?;
 		let name = name?.string()?;
 		let item = item?.value()?;
-		let param_format = match param_format {
-			Ok(param_format) => param_format.string()?,
-			Err(_) => String::from("array"),
-		};
+		let param_format = optional(param_format, Argument::string)?.or(Some("array".into()));
 		let unsubscribe_aliases = parse_aliases(unsubscribe_aliases)?;
 
 		let sig = sub.sig.clone();

--- a/proc-macros/tests/ui/correct/param_format.rs
+++ b/proc-macros/tests/ui/correct/param_format.rs
@@ -1,0 +1,63 @@
+use jsonrpsee::{
+	proc_macros::rpc,
+	types::{async_trait, RpcResult},
+	ws_client::*,
+	ws_server::WsServerBuilder,
+};
+
+use std::net::SocketAddr;
+
+#[rpc(client, server, namespace = "foo")]
+pub trait Rpc {
+	#[method(name="method_with_array_param", param_format="array")]
+	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
+
+	#[method(name="method_with_map_param", param_format="map")]
+	async fn method_with_map_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
+
+	#[method(name="method_with_default_param")]
+	async fn method_with_default_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
+}
+
+pub struct RpcServerImpl;
+
+#[async_trait]
+impl RpcServer for RpcServerImpl {
+	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
+		assert_eq!(param_a, 0);
+		assert_eq!(&param_b, "a");
+		Ok(42u16)
+	}
+
+	async fn method_with_map_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
+		assert_eq!(param_a, 0);
+		assert_eq!(&param_b, "a");
+		Ok(42u16)
+	}
+
+	async fn method_with_default_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
+		assert_eq!(param_a, 0);
+		assert_eq!(&param_b, "a");
+		Ok(42u16)
+	}
+}
+
+pub async fn websocket_server() -> SocketAddr {
+	let server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+	let addr = server.local_addr().unwrap();
+
+	server.start(RpcServerImpl.into_rpc()).unwrap();
+
+	addr
+}
+
+#[tokio::main]
+async fn main() {
+	let server_addr = websocket_server().await;
+	let server_url = format!("ws://{}", server_addr);
+	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
+
+	assert_eq!(client.method_with_array_param(0, "a".into()).await.unwrap(), 42);
+	assert_eq!(client.method_with_map_param(0, "a".into()).await.unwrap(), 42);
+	assert_eq!(client.method_with_array_param(0, "a".into()).await.unwrap(), 42);
+}

--- a/proc-macros/tests/ui/correct/param_kind.rs
+++ b/proc-macros/tests/ui/correct/param_kind.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 
 #[rpc(client, server, namespace = "foo")]
 pub trait Rpc {
-	#[method(name="method_with_array_param", param_kind="array")]
+	#[method(name = "method_with_array_param", param_kind = array)]
 	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name="method_with_map_param", param_kind="map")]

--- a/proc-macros/tests/ui/correct/param_kind.rs
+++ b/proc-macros/tests/ui/correct/param_kind.rs
@@ -9,10 +9,10 @@ use std::net::SocketAddr;
 
 #[rpc(client, server, namespace = "foo")]
 pub trait Rpc {
-	#[method(name="method_with_array_param", param_format="array")]
+	#[method(name="method_with_array_param", param_kind="array")]
 	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
-	#[method(name="method_with_map_param", param_format="map")]
+	#[method(name="method_with_map_param", param_kind="map")]
 	async fn method_with_map_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name="method_with_default_param")]
@@ -59,5 +59,5 @@ async fn main() {
 
 	assert_eq!(client.method_with_array_param(0, "a".into()).await.unwrap(), 42);
 	assert_eq!(client.method_with_map_param(0, "a".into()).await.unwrap(), 42);
-	assert_eq!(client.method_with_array_param(0, "a".into()).await.unwrap(), 42);
+	assert_eq!(client.method_with_default_param(0, "a".into()).await.unwrap(), 42);
 }

--- a/proc-macros/tests/ui/correct/param_kind.rs
+++ b/proc-macros/tests/ui/correct/param_kind.rs
@@ -12,7 +12,7 @@ pub trait Rpc {
 	#[method(name = "method_with_array_param", param_kind = array)]
 	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
-	#[method(name="method_with_map_param", param_kind="map")]
+	#[method(name="method_with_map_param", param_kind= map)]
 	async fn method_with_map_param(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name="method_with_default_param")]

--- a/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
@@ -1,4 +1,4 @@
-error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `param_format`, `resources`
+error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `param_kind`, `resources`
  --> tests/ui/incorrect/method/method_unexpected_field.rs:6:25
   |
 6 |     #[method(name = "foo", magic = false)]

--- a/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
@@ -1,5 +1,5 @@
-error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `resources`
- --> $DIR/method_unexpected_field.rs:6:25
+error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `param_format`, `resources`
+ --> tests/ui/incorrect/method/method_unexpected_field.rs:6:25
   |
 6 |     #[method(name = "foo", magic = false)]
   |                            ^^^^^

--- a/proc-macros/tests/ui/incorrect/sub/sub_unsupported_field.stderr
+++ b/proc-macros/tests/ui/incorrect/sub/sub_unsupported_field.stderr
@@ -1,4 +1,4 @@
-error: Unknown argument `magic`, expected one of: `aliases`, `item`, `name`, `param_format`, `unsubscribe_aliases`
+error: Unknown argument `magic`, expected one of: `aliases`, `item`, `name`, `param_kind`, `unsubscribe_aliases`
  --> tests/ui/incorrect/sub/sub_unsupported_field.rs:6:42
   |
 6 |     #[subscription(name = "sub", item = u8, magic = true)]

--- a/proc-macros/tests/ui/incorrect/sub/sub_unsupported_field.stderr
+++ b/proc-macros/tests/ui/incorrect/sub/sub_unsupported_field.stderr
@@ -1,5 +1,5 @@
-error: Unknown argument `magic`, expected one of: `aliases`, `item`, `name`, `unsubscribe_aliases`
- --> $DIR/sub_unsupported_field.rs:6:42
+error: Unknown argument `magic`, expected one of: `aliases`, `item`, `name`, `param_format`, `unsubscribe_aliases`
+ --> tests/ui/incorrect/sub/sub_unsupported_field.rs:6:42
   |
 6 |     #[subscription(name = "sub", item = u8, magic = true)]
   |                                             ^^^^^


### PR DESCRIPTION
This is my MR for #538.

- Added `param_format` parameter to the `method` and `subscription` attributes. It takes a string parameter, `"map"`to make the macro generate a function that sends the parameters as a map, everything else will fall back to the default `"array"`. I'm not too happy with the fact that it is a string, so if anybody has an alternative, be my friend :) 

- Updated `render_method` and `render_sub` to generate the necessary code. There's an additional function that extracts the parameter names from the function signature

I wasn't sure how / if you test your macros, so I didn't do anything related to unit test, but I can confirm that the code is generated correctly and works, judging from how it interacts with json_rpc APIs.

Looking forward to your comments :)