### PR TITLE
Allow awaiting on server handles

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -70,7 +70,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpc_ws_se
 
 /// Run jsonrpsee HTTP server for benchmarks.
 #[cfg(not(feature = "jsonrpc-crate"))]
-pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::http_server::HttpStopHandle) {
+pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::http_server::HttpServerHandle) {
 	use jsonrpsee::http_server::{HttpServerBuilder, RpcModule};
 
 	let server = HttpServerBuilder::default()
@@ -88,7 +88,7 @@ pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::
 
 /// Run jsonrpsee WebSocket server for benchmarks.
 #[cfg(not(feature = "jsonrpc-crate"))]
-pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::ws_server::WsStopHandle) {
+pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::ws_server::WsServerHandle) {
 	use jsonrpsee::ws_server::{RpcModule, WsServerBuilder};
 
 	let server = WsServerBuilder::default()

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -26,7 +26,7 @@
 
 use jsonrpsee::{
 	http_client::HttpClientBuilder,
-	http_server::{HttpServerBuilder, HttpStopHandle, RpcModule},
+	http_server::{HttpServerBuilder, HttpServerHandle, RpcModule},
 	rpc_params,
 	types::traits::Client,
 };
@@ -49,12 +49,12 @@ async fn main() -> anyhow::Result<()> {
 	Ok(())
 }
 
-async fn run_server() -> anyhow::Result<(SocketAddr, HttpStopHandle)> {
+async fn run_server() -> anyhow::Result<(SocketAddr, HttpServerHandle)> {
 	let server = HttpServerBuilder::default().build("127.0.0.1:0".parse()?)?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("lo"))?;
 
 	let addr = server.local_addr()?;
-	let stop_handle = server.start(module)?;
-	Ok((addr, stop_handle))
+	let server_handle = server.start(module)?;
+	Ok((addr, server_handle))
 }

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -28,7 +28,7 @@ use jsonrpsee::{
 	proc_macros::rpc,
 	types::{async_trait, error::Error, Subscription},
 	ws_client::WsClientBuilder,
-	ws_server::{SubscriptionSink, WsServerBuilder, WsStopHandle},
+	ws_server::{SubscriptionSink, WsServerBuilder, WsServerHandle},
 };
 use std::net::SocketAddr;
 
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
 	Ok(())
 }
 
-async fn run_server() -> anyhow::Result<(SocketAddr, WsStopHandle)> {
+async fn run_server() -> anyhow::Result<(SocketAddr, WsServerHandle)> {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 
 	let addr = server.local_addr()?;

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -43,7 +43,7 @@ pub use access_control::{
 };
 pub use jsonrpsee_types as types;
 pub use jsonrpsee_utils::server::rpc_module::RpcModule;
-pub use server::{Builder as HttpServerBuilder, Server as HttpServer, StopHandle as HttpStopHandle};
+pub use server::{Builder as HttpServerBuilder, Server as HttpServer, ServerHandle as HttpServerHandle};
 
 #[cfg(test)]
 mod tests;

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -391,8 +391,8 @@ async fn run_forever() {
 
 	let _ = env_logger::try_init();
 	let (_addr, server_handle) = server().with_default_timeout().await.unwrap();
-	// Timed out.
-	server_handle.with_timeout(TIMEOUT).await.unwrap_err();
+
+	assert!(matches!(server_handle.with_timeout(TIMEOUT).await, Err(_timeout_err)));
 
 	let (_addr, server_handle) = server().await;
 	server_handle.handle.as_ref().unwrap().abort();

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -27,16 +27,17 @@
 #![cfg(test)]
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use crate::types::error::{CallError, Error};
-use crate::{server::StopHandle, HttpServerBuilder, RpcModule};
+use crate::{server::ServerHandle, HttpServerBuilder, RpcModule};
 
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::{Id, StatusCode, TestContext};
 use jsonrpsee_test_utils::TimeoutFutureExt;
 use serde_json::Value as JsonValue;
 
-async fn server() -> (SocketAddr, StopHandle) {
+async fn server() -> (SocketAddr, ServerHandle) {
 	let server = HttpServerBuilder::default().build("127.0.0.1:0".parse().unwrap()).unwrap();
 	let ctx = TestContext;
 	let mut module = RpcModule::new(ctx);
@@ -78,8 +79,8 @@ async fn server() -> (SocketAddr, StopHandle) {
 		})
 		.unwrap();
 
-	let stop_handle = server.start(module).unwrap();
-	(addr, stop_handle)
+	let server_handle = server.start(module).unwrap();
+	(addr, server_handle)
 }
 
 #[tokio::test]
@@ -380,6 +381,27 @@ async fn can_register_modules() {
 #[tokio::test]
 async fn stop_works() {
 	let _ = env_logger::try_init();
-	let (_addr, stop_handle) = server().with_default_timeout().await.unwrap();
-	assert!(matches!(stop_handle.stop().unwrap().await, Ok(_)));
+	let (_addr, server_handle) = server().with_default_timeout().await.unwrap();
+	assert!(matches!(server_handle.stop().unwrap().await, Ok(_)));
+}
+
+#[tokio::test]
+async fn run_forever() {
+	const TIMEOUT: Duration = Duration::from_millis(200);
+
+	let _ = env_logger::try_init();
+	let (_addr, server_handle) = server().with_default_timeout().await.unwrap();
+	// Timed out.
+	server_handle.with_timeout(TIMEOUT).await.unwrap_err();
+
+	let (_addr, server_handle) = server().await;
+	server_handle.handle.as_ref().unwrap().abort();
+
+	// Cancelled task is still considered to be finished without errors.
+	// A subject to change.
+	server_handle.with_timeout(TIMEOUT).await.unwrap();
+
+	let (_addr, mut server_handle) = server().with_default_timeout().await.unwrap();
+	server_handle.handle.take();
+	server_handle.with_timeout(TIMEOUT).await.unwrap();
 }

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -25,15 +25,15 @@
 // DEALINGS IN THE SOFTWARE.
 
 use jsonrpsee::{
-	http_server::{HttpServerBuilder, HttpStopHandle},
+	http_server::{HttpServerBuilder, HttpServerHandle},
 	types::Error,
-	ws_server::{WsServerBuilder, WsStopHandle},
+	ws_server::{WsServerBuilder, WsServerHandle},
 	RpcModule,
 };
 use std::net::SocketAddr;
 use std::time::Duration;
 
-pub async fn websocket_server_with_subscription() -> (SocketAddr, WsStopHandle) {
+pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle) {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 
 	let mut module = RpcModule::new(());
@@ -88,9 +88,9 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsStopHandle) 
 		.unwrap();
 
 	let addr = server.local_addr().unwrap();
-	let stop_handle = server.start(module).unwrap();
+	let server_handle = server.start(module).unwrap();
 
-	(addr, stop_handle)
+	(addr, server_handle)
 }
 
 pub async fn websocket_server() -> SocketAddr {
@@ -112,7 +112,7 @@ pub async fn websocket_server() -> SocketAddr {
 	addr
 }
 
-pub async fn http_server() -> (SocketAddr, HttpStopHandle) {
+pub async fn http_server() -> (SocketAddr, HttpServerHandle) {
 	let server = HttpServerBuilder::default().build("127.0.0.1:0".parse().unwrap()).unwrap();
 	let mut module = RpcModule::new(());
 	let addr = server.local_addr().unwrap();

--- a/ws-server/src/lib.rs
+++ b/ws-server/src/lib.rs
@@ -38,7 +38,7 @@ mod server;
 #[cfg(test)]
 mod tests;
 
-pub use future::{ShutdownWaiter as WsShutdownWaiter, StopHandle as WsStopHandle};
+pub use future::{ServerHandle as WsServerHandle, ShutdownWaiter as WsShutdownWaiter};
 pub use jsonrpsee_types as types;
 pub use jsonrpsee_utils::server::rpc_module::{RpcModule, SubscriptionSink};
 pub use server::{Builder as WsServerBuilder, Server as WsServer};

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -29,7 +29,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::future::{FutureDriver, StopHandle, StopMonitor};
+use crate::future::{FutureDriver, ServerHandle, StopMonitor};
 use crate::types::{
 	error::Error,
 	v2::{ErrorCode, Id, Request},
@@ -66,14 +66,14 @@ impl Server {
 	}
 
 	/// Returns the handle to stop the running server.
-	pub fn stop_handle(&self) -> StopHandle {
+	pub fn server_handle(&self) -> ServerHandle {
 		self.stop_monitor.handle()
 	}
 
 	/// Start responding to connections requests. This will run on the tokio runtime until the server is stopped.
-	pub fn start(mut self, methods: impl Into<Methods>) -> Result<StopHandle, Error> {
+	pub fn start(mut self, methods: impl Into<Methods>) -> Result<ServerHandle, Error> {
 		let methods = methods.into().initialize_resources(&self.resources)?;
-		let handle = self.stop_handle();
+		let handle = self.server_handle();
 
 		match self.cfg.tokio_runtime.take() {
 			Some(rt) => rt.spawn(self.start_inner(methods)),

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -27,14 +27,16 @@
 #![cfg(test)]
 
 use crate::types::error::{CallError, Error};
-use crate::{future::StopHandle, RpcModule, WsServerBuilder};
+use crate::{future::ServerHandle, RpcModule, WsServerBuilder};
 use anyhow::anyhow;
+use futures_util::future::join;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::{Id, TestContext, WebSocketTestClient, WebSocketTestError};
 use jsonrpsee_test_utils::TimeoutFutureExt;
 use serde_json::Value as JsonValue;
 use std::fmt;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 /// Applications can/should provide their own error.
 #[derive(Debug)]
@@ -58,7 +60,7 @@ async fn server() -> SocketAddr {
 ///     other: `invalid_params` (always returns `CallError::InvalidParams`), `call_fail` (always returns
 /// 			`CallError::Failed`), `sleep_for` Returns the address together with handles for server future
 ///				and server stop.
-async fn server_with_handles() -> (SocketAddr, StopHandle) {
+async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut module = RpcModule::new(());
 	module
@@ -105,8 +107,8 @@ async fn server_with_handles() -> (SocketAddr, StopHandle) {
 
 	let addr = server.local_addr().unwrap();
 
-	let stop_handle = server.start(module).unwrap();
-	(addr, stop_handle)
+	let server_handle = server.start(module).unwrap();
+	(addr, server_handle)
 }
 
 /// Run server with user provided context.
@@ -538,12 +540,27 @@ async fn can_register_modules() {
 #[tokio::test]
 async fn stop_works() {
 	let _ = env_logger::try_init();
-	let (_addr, stop_handle) = server_with_handles().with_default_timeout().await.unwrap();
-	stop_handle.clone().stop().unwrap().with_default_timeout().await.unwrap();
+	let (_addr, server_handle) = server_with_handles().with_default_timeout().await.unwrap();
+	server_handle.clone().stop().unwrap().with_default_timeout().await.unwrap();
 
 	// After that we should be able to wait for task handle to finish.
 	// First `unwrap` is timeout, second is `JoinHandle`'s one.
 
 	// After server was stopped, attempt to stop it again should result in an error.
-	assert!(matches!(stop_handle.stop(), Err(Error::AlreadyStopped)));
+	assert!(matches!(server_handle.stop(), Err(Error::AlreadyStopped)));
+}
+
+#[tokio::test]
+async fn run_forever() {
+	const TIMEOUT: Duration = Duration::from_millis(200);
+
+	let _ = env_logger::try_init();
+	let (_addr, server_handle) = server_with_handles().with_default_timeout().await.unwrap();
+	// Timed out.
+	server_handle.with_timeout(TIMEOUT).await.unwrap_err();
+
+	let (_addr, server_handle) = server_with_handles().with_default_timeout().await.unwrap();
+
+	// Send the shutdown request from one handle and await the server on the second one.
+	join(server_handle.clone().stop().unwrap(), server_handle).with_timeout(TIMEOUT).await.unwrap();
 }

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -556,8 +556,8 @@ async fn run_forever() {
 
 	let _ = env_logger::try_init();
 	let (_addr, server_handle) = server_with_handles().with_default_timeout().await.unwrap();
-	// Timed out.
-	server_handle.with_timeout(TIMEOUT).await.unwrap_err();
+
+	assert!(matches!(server_handle.with_timeout(TIMEOUT).await, Err(_timeout_err)));
 
 	let (_addr, server_handle) = server_with_handles().with_default_timeout().await.unwrap();
 


### PR DESCRIPTION
* Rename both `HttpStopHandle` and `WsStopHandle` to  `HttpServerHandle` and `WsServerHandle` respectively
* Implement `Future` for both allowing to do
```rust
let (addr, handle) = server.start(rpc).unwrap();
handle.await
```
to run the server forever.

The interfaces for HTTP and WS are slightly different in the sense that the latter handle can be cloned. This can be easily implemented via channels for HTTP but that's a subject for different PR and was not introduced here.

Resolves #547