### PR TITLE
Periodically wake `DriverSelect` so we can poll whether or not `stop` had been called.

### DIFF
--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -142,7 +142,7 @@ impl RpcDescription {
 
 	fn encode_params(
 		&self,
-		params: &Vec<(syn::PatIdent, syn::Type)>,
+		params: &[(syn::PatIdent, syn::Type)],
 		param_kind: &ParamKind,
 		signature: &syn::TraitItemMethod,
 	) -> TokenStream2 {

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -81,7 +81,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 		.register_subscription("subscribe_noop", "unsubscribe_noop", |_, mut sink, _| {
 			std::thread::spawn(move || {
 				std::thread::sleep(Duration::from_secs(1));
-				sink.close("Server closed the stream because it was lazy".into())
+				sink.close("Server closed the stream because it was lazy")
 			});
 			Ok(())
 		})

--- a/tests/tests/resource_limiting.rs
+++ b/tests/tests/resource_limiting.rs
@@ -160,8 +160,6 @@ async fn run_tests_on_ws_server(server_addr: SocketAddr, server_handle: WsServer
 	assert!(pass_mem.is_ok());
 	assert_server_busy(fail_mem);
 
-	// Client being active prevents the server from shutting down?!
-	drop(client);
 	server_handle.stop().unwrap().await;
 }
 

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -17,7 +17,7 @@ jsonrpsee-utils = { path = "../utils", version = "0.4.1", features = ["server"] 
 tracing = "0.1"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
-tokio = { version = "1", features = ["net", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.6", features = ["compat"] }
 
 [dev-dependencies]

--- a/ws-server/src/future.rs
+++ b/ws-server/src/future.rs
@@ -36,6 +36,10 @@ use std::sync::{
 	Arc, Weak,
 };
 use std::task::{Context, Poll};
+use tokio::time::{self, Duration, Interval};
+
+/// Polling for server stop monitor interval in milliseconds.
+const POLLING_HEARTBEAT: u64 = 1000;
 
 /// This is a flexible collection of futures that need to be driven to completion
 /// alongside some other future, such as connection handlers that need to be
@@ -45,11 +49,16 @@ use std::task::{Context, Poll};
 /// `select_with` providing some other future, the result of which you need.
 pub(crate) struct FutureDriver<F> {
 	futures: Vec<F>,
+	heartbeat: Interval,
 }
 
 impl<F> Default for FutureDriver<F> {
 	fn default() -> Self {
-		FutureDriver { futures: Vec::new() }
+		let mut heartbeat = time::interval(Duration::from_millis(POLLING_HEARTBEAT));
+
+		heartbeat.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+		FutureDriver { futures: Vec::new(), heartbeat }
 	}
 }
 
@@ -92,6 +101,12 @@ where
 			}
 		}
 	}
+
+	fn poll_heartbeat(&mut self, cx: &mut Context) {
+		// We don't care about the ticks of the heartbeat, it's here only
+		// to periodically wake the `Waker` on `cx`.
+		let _ = self.heartbeat.poll_tick(cx);
+	}
 }
 
 impl<F> Future for FutureDriver<F>
@@ -132,6 +147,7 @@ where
 		let this = Pin::into_inner(self);
 
 		this.driver.drive(cx);
+		this.driver.poll_heartbeat(cx);
 
 		this.selector.poll_unpin(cx)
 	}

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -133,7 +133,7 @@ impl Server {
 	}
 }
 
-/// This is a glorified select listening to new messages, while also checking the `stop_receiver` signal.
+/// This is a glorified select listening for new messages, while also checking the `stop_receiver` signal.
 struct Monitored<'a, F> {
 	future: F,
 	stop_monitor: &'a StopMonitor,
@@ -305,13 +305,13 @@ async fn background_task(
 			if let Err(err) = method_executors.select_with(Monitored::new(receive, &stop_server)).await {
 				match err {
 					MonitoredError::Selector(SokettoError::Closed) => {
-						tracing::debug!("Remote peer terminated the connection: {}", conn_id);
+						tracing::debug!("WS transport error: remote peer terminated the connection: {}", conn_id);
 						tx.close_channel();
 						return Ok(());
 					}
 					MonitoredError::Selector(SokettoError::MessageTooLarge { current, maximum }) => {
 						tracing::warn!(
-							"WS transport error: message is too big error ({} bytes, max is {})",
+							"WS transport error: outgoing message is too big error ({} bytes, max is {})",
 							current,
 							maximum
 						);


### PR DESCRIPTION
Fixes #549. This is all pretty esoteric, but TL;DR is:

+ The loop in the per-connection background task has been reworked to more closely resemble the loop in accepting incoming connections, making sure we check the `StopMonitor` every time the driver has been polled.
+ Added an `Interval` internally in `FutureDriver`, which is only polled in the `DriverSelect` instances. It effectively triggers a forced poll every second, which checks the stop flag, which will shut down all loops.

The tests are now properly terminating without having to drop the client (with a 1s delay):

```
$ cargo test --test resource_limiting
   Compiling jsonrpsee-integration-tests v0.4.1 (/home/maciej/rust/jsonrpsee/tests)
    Finished test [unoptimized + debuginfo] target(s) in 2.94s
     Running tests/resource_limiting.rs (target/debug/deps/resource_limiting-17aaec4a6e8ab5eb)

running 4 tests
test http_server_with_macro_module ... ok
test http_server_with_manual_module ... ok
test ws_server_with_manual_module ... ok
test ws_server_with_macro_module ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
``` 