### PR TITLE
Array syntax aliases

### DIFF
--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -53,6 +53,10 @@ pub struct Resource {
 	pub value: syn::LitInt,
 }
 
+pub struct Aliases {
+	pub list: Punctuated<syn::LitStr, Token![,]>,
+}
+
 impl Parse for Argument {
 	fn parse(input: ParseStream) -> syn::Result<Self> {
 		let label = input.parse()?;
@@ -84,6 +88,18 @@ impl Parse for Argument {
 impl Parse for Resource {
 	fn parse(input: ParseStream) -> syn::Result<Self> {
 		Ok(Resource { name: input.parse()?, assign: input.parse()?, value: input.parse()? })
+	}
+}
+
+impl Parse for Aliases {
+	fn parse(input: ParseStream) -> syn::Result<Self> {
+		let content;
+
+		syn::bracketed!(content in input);
+
+		let list = content.parse_terminated(Parse::parse)?;
+
+		Ok(Aliases { list })
 	}
 }
 

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -205,8 +205,7 @@ impl RpcDescription {
 					.aliases
 					.iter()
 					.map(|alias| {
-						let alias = alias.trim().to_string();
-						check_name(&alias, rust_method_name.span());
+						check_name(alias, rust_method_name.span());
 						handle_register_result(quote! {
 							rpc.register_alias(#alias, #rpc_name)
 						})
@@ -229,8 +228,7 @@ impl RpcDescription {
 					.aliases
 					.iter()
 					.map(|alias| {
-						let alias = alias.trim().to_string();
-						check_name(&alias, rust_method_name.span());
+						check_name(alias, rust_method_name.span());
 						handle_register_result(quote! {
 							rpc.register_alias(#alias, #sub_name)
 						})
@@ -240,8 +238,7 @@ impl RpcDescription {
 					.unsubscribe_aliases
 					.iter()
 					.map(|alias| {
-						let alias = alias.trim().to_string();
-						check_name(&alias, rust_method_name.span());
+						check_name(alias, rust_method_name.span());
 						handle_register_result(quote! {
 							rpc.register_alias(#alias, #unsub_name)
 						})

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -31,9 +31,9 @@ use crate::{
 	helpers::extract_doc_comments,
 };
 
-use std::borrow::Cow;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use std::borrow::Cow;
 use syn::spanned::Spanned;
 use syn::{punctuated::Punctuated, Attribute, Token};
 

--- a/proc-macros/tests/ui/correct/alias_doesnt_use_namespace.rs
+++ b/proc-macros/tests/ui/correct/alias_doesnt_use_namespace.rs
@@ -3,10 +3,10 @@ use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 #[rpc(client, server, namespace = "myapi")]
 pub trait Rpc {
 	/// Alias doesn't use the namespace so not duplicated.
-	#[method(name = "getTemp", aliases = "getTemp")]
+	#[method(name = "getTemp", aliases = ["getTemp"])]
 	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
-	#[subscription(name = "getFood", item = String, aliases = "getFood", unsubscribe_aliases = "unsubscribegetFood")]
+	#[subscription(name = "getFood", item = String, aliases = ["getFood"], unsubscribe_aliases = ["unsubscribegetFood"])]
 	fn sub(&self) -> RpcResult<()>;
 }
 

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 
 #[rpc(client, server, namespace = "foo")]
 pub trait Rpc {
-	#[method(name = "foo", aliases = "fooAlias, Other")]
+	#[method(name = "foo", aliases = ["fooAlias", "Other"])]
 	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name = "optional_params")]
@@ -29,7 +29,7 @@ pub trait Rpc {
 	#[subscription(name = "sub", item = String)]
 	fn sub(&self) -> RpcResult<()>;
 
-	#[subscription(name = "echo", aliases = "ECHO", item = u32, unsubscribe_aliases = "NotInterested, listenNoMore")]
+	#[subscription(name = "echo", aliases = ["ECHO"], item = u32, unsubscribe_aliases = ["NotInterested", "listenNoMore"])]
 	fn sub_with_params(&self, val: u32) -> RpcResult<()>;
 }
 

--- a/proc-macros/tests/ui/correct/parse_angle_brackets.rs
+++ b/proc-macros/tests/ui/correct/parse_angle_brackets.rs
@@ -5,8 +5,8 @@ fn main() {
 	pub trait Rpc {
 		#[subscription(
 			name = "submitAndWatchExtrinsic",
-			aliases = "author_extrinsicUpdate",
-			unsubscribe_aliases = "author_unwatchExtrinsic",
+			aliases = ["author_extrinsicUpdate"],
+			unsubscribe_aliases = ["author_unwatchExtrinsic"],
 			// Arguments are being parsed the nearest comma,
 			// angle braces need to be accounted for manually.
 			item = TransactionStatus<Hash, BlockHash>,

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_conflicting_alias.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_conflicting_alias.rs
@@ -2,7 +2,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::RpcResult;
 #[rpc(client, server)]
 pub trait DuplicatedAlias {
-	#[method(name = "foo", aliases = "foo_dup, foo_dup")]
+	#[method(name = "foo", aliases = ["foo_dup", "foo_dup"])]
 	async fn async_method(&self) -> RpcResult<u8>;
 }
 

--- a/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.rs
+++ b/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.rs
@@ -2,7 +2,7 @@ use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 
 #[rpc(client, server)]
 pub trait DuplicatedSubAlias {
-	#[subscription(name = "alias", item = String, aliases = "hello_is_goodbye", unsubscribe_aliases = "hello_is_goodbye")]
+	#[subscription(name = "alias", item = String, aliases = ["hello_is_goodbye"], unsubscribe_aliases = ["hello_is_goodbye"])]
 	fn async_method(&self) -> RpcResult<()>;
 }
 

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -49,7 +49,7 @@ mod rpc_impl {
 		#[subscription(name = "sub", item = String)]
 		fn sub(&self) -> RpcResult<()>;
 
-		#[subscription(name = "echo", aliases = "alias_echo", item = u32)]
+		#[subscription(name = "echo", aliases = ["alias_echo"], item = u32)]
 		fn sub_with_params(&self, val: u32) -> RpcResult<()>;
 
 		#[method(name = "params")]


### PR DESCRIPTION
This change requires aliases to be defined using array syntax instead of a string we have to split and separate by commas. I've removed all `trim`s in proc macro code, meaning method names are taken verbatim as-is without any magic.