### PR TITLE
Arrow syntax for overwrites

### DIFF
--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -27,7 +27,7 @@
 //! Declaration of the JSON RPC generator procedural macros.
 
 use crate::{
-	attributes::{optional, parse_param_kind, Aliases, Argument, AttributeMeta, MissingArgument, ParamKind, Resource},
+	attributes::{optional, parse_param_kind, Aliases, Argument, AttributeMeta, MissingArgument, NameMapping, ParamKind, Resource},
 	helpers::extract_doc_comments,
 };
 
@@ -110,15 +110,13 @@ pub struct RpcSubscription {
 
 impl RpcSubscription {
 	pub fn from_item(attr: syn::Attribute, mut sub: syn::TraitItemMethod) -> syn::Result<Self> {
-		let [aliases, item, name, param_kind, unsubscribe_aliases, override_notif_method] = AttributeMeta::parse(attr)?
-			.retain(["aliases", "item", "name", "param_kind", "unsubscribe_aliases", "override_notif_method"])?;
+		let [aliases, item, name, param_kind, unsubscribe_aliases] = AttributeMeta::parse(attr)?
+			.retain(["aliases", "item", "name", "param_kind", "unsubscribe_aliases"])?;
 
 		let aliases = parse_aliases(aliases)?;
-		let name = name?.string()?;
-		let override_notif_method = match override_notif_method {
-			Ok(arg) => Some(arg.string()?),
-			Err(_) => None,
-		};
+		let map = name?.value::<NameMapping>()?;
+		let name = map.name;
+		let override_notif_method = map.mapped;
 		let item = item?.value()?;
 		let param_kind = parse_param_kind(param_kind)?;
 		let unsubscribe_aliases = parse_aliases(unsubscribe_aliases)?;

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -33,7 +33,7 @@ pub trait Rpc {
 	fn sub_with_params(&self, val: u32) -> RpcResult<()>;
 
 	// This will send notifications to the client with `method=subscribe_override`
-	#[subscription(name = "subscribe_method", override_notif_method = "subscribe_override", item = u32)]
+	#[subscription(name = "subscribe_method" => "subscribe_override", item = u32)]
 	fn sub_with_override_notif_method(&self) -> RpcResult<()>;
 }
 


### PR DESCRIPTION
Only applied to `name = ...`, but you could use `NameMapping` (feel free to name it something better) in aliases via `Bracketed<NameMapping>`.