### PR TITLE
rpc module: add `call_and_subscribe`

### DIFF
--- a/http-server/src/response.rs
+++ b/http-server/src/response.rs
@@ -26,19 +26,15 @@
 
 //! Contains common builders for hyper responses.
 
-use crate::types::v2::{ErrorCode, Id, RpcError, TwoPointZero};
+use crate::types::v2::{ErrorCode, Id, RpcError};
 
 const JSON: &str = "application/json; charset=utf-8";
 const TEXT: &str = "text/plain";
 
 /// Create a response for json internal error.
 pub fn internal_error() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&RpcError {
-		jsonrpc: TwoPointZero,
-		error: ErrorCode::InternalError.into(),
-		id: Id::Null,
-	})
-	.expect("built from known-good data; qed");
+	let error = serde_json::to_string(&RpcError::new(ErrorCode::InternalError.into(), Id::Null))
+		.expect("built from known-good data; qed");
 
 	from_template(hyper::StatusCode::INTERNAL_SERVER_ERROR, error, JSON)
 }
@@ -77,21 +73,16 @@ pub fn invalid_allow_headers() -> hyper::Response<hyper::Body> {
 
 /// Create a json response for oversized requests (413)
 pub fn too_large() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&RpcError {
-		jsonrpc: TwoPointZero,
-		error: ErrorCode::OversizedRequest.into(),
-		id: Id::Null,
-	})
-	.expect("built from known-good data; qed");
+	let error = serde_json::to_string(&RpcError::new(ErrorCode::OversizedRequest.into(), Id::Null))
+		.expect("built from known-good data; qed");
 
 	from_template(hyper::StatusCode::PAYLOAD_TOO_LARGE, error, JSON)
 }
 
 /// Create a json response for empty or malformed requests (400)
 pub fn malformed() -> hyper::Response<hyper::Body> {
-	let error =
-		serde_json::to_string(&RpcError { jsonrpc: TwoPointZero, error: ErrorCode::ParseError.into(), id: Id::Null })
-			.expect("built from known-good data; qed");
+	let error = serde_json::to_string(&RpcError::new(ErrorCode::ParseError.into(), Id::Null))
+		.expect("built from known-good data; qed");
 
 	from_template(hyper::StatusCode::BAD_REQUEST, error, JSON)
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -70,3 +70,6 @@ pub mod __reexports {
 
 /// JSON-RPC result.
 pub type RpcResult<T> = std::result::Result<T, Error>;
+
+/// Empty `RpcParams` type;
+pub type EmptyParams = Vec<()>;

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
 }
 
 impl<'a> Request<'a> {
-	/// Create a new `Request`.
+	/// Create a new [`Request`].
 	pub fn new(method: Cow<'a, str>, params: Option<&'a RawValue>, id: Id<'a>) -> Self {
 		Self { jsonrpc: TwoPointZero, id, method, params }
 	}
@@ -79,7 +79,7 @@ pub struct Notification<'a, T> {
 }
 
 impl<'a, T> Notification<'a, T> {
-	/// Create a new `Notification`.
+	/// Create a new [`Notification`].
 	pub fn new(method: Cow<'a, str>, params: T) -> Self {
 		Self { jsonrpc: TwoPointZero, method, params }
 	}

--- a/types/src/v2/request.rs
+++ b/types/src/v2/request.rs
@@ -49,6 +49,13 @@ pub struct Request<'a> {
 	pub params: Option<&'a RawValue>,
 }
 
+impl<'a> Request<'a> {
+	/// Create a new `Request`.
+	pub fn new(method: Cow<'a, str>, params: Option<&'a RawValue>, id: Id<'a>) -> Self {
+		Self { jsonrpc: TwoPointZero, id, method, params }
+	}
+}
+
 /// JSON-RPC Invalid request as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct InvalidRequest<'a> {
@@ -69,6 +76,13 @@ pub struct Notification<'a, T> {
 	pub method: Cow<'a, str>,
 	/// Parameter values of the request.
 	pub params: T,
+}
+
+impl<'a, T> Notification<'a, T> {
+	/// Create a new `Notification`.
+	pub fn new(method: Cow<'a, str>, params: T) -> Self {
+		Self { jsonrpc: TwoPointZero, method, params }
+	}
 }
 
 /// Serializable [JSON-RPC object](https://www.jsonrpc.org/specification#request-object).

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -45,6 +45,13 @@ pub struct Response<'a, T> {
 	pub id: Id<'a>,
 }
 
+impl<'a, T> Response<'a, T> {
+	/// Create a new `Response`.
+	pub fn new(result: T, id: Id<'a>) -> Response<'a, T> {
+		Response { jsonrpc: TwoPointZero, result, id }
+	}
+}
+
 /// Return value for subscriptions.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SubscriptionPayload<T> {

--- a/types/src/v2/response.rs
+++ b/types/src/v2/response.rs
@@ -46,7 +46,7 @@ pub struct Response<'a, T> {
 }
 
 impl<'a, T> Response<'a, T> {
-	/// Create a new `Response`.
+	/// Create a new [`Response`].
 	pub fn new(result: T, id: Id<'a>) -> Response<'a, T> {
 		Response { jsonrpc: TwoPointZero, result, id }
 	}

--- a/utils/src/server/helpers.rs
+++ b/utils/src/server/helpers.rs
@@ -31,7 +31,7 @@ use jsonrpsee_types::to_json_raw_value;
 use jsonrpsee_types::v2::error::{OVERSIZED_RESPONSE_CODE, OVERSIZED_RESPONSE_MSG};
 use jsonrpsee_types::v2::{
 	error::{CALL_EXECUTION_FAILED_CODE, UNKNOWN_ERROR_CODE},
-	ErrorCode, ErrorObject, Id, InvalidRequest, Response, RpcError, TwoPointZero,
+	ErrorCode, ErrorObject, Id, InvalidRequest, Response, RpcError,
 };
 use serde::Serialize;
 
@@ -106,8 +106,7 @@ impl MethodSink {
 	pub fn send_response(&self, id: Id, result: impl Serialize) -> bool {
 		let mut writer = BoundedWriter::new(self.max_response_size as usize);
 
-		let json = match serde_json::to_writer(&mut writer, &Response { jsonrpc: TwoPointZero, id: id.clone(), result })
-		{
+		let json = match serde_json::to_writer(&mut writer, &Response::new(result, id.clone())) {
 			Ok(_) => {
 				// Safety - serde_json does not emit invalid UTF-8.
 				unsafe { String::from_utf8_unchecked(writer.into_bytes()) }
@@ -139,7 +138,7 @@ impl MethodSink {
 
 	/// Send a JSON-RPC error to the client
 	pub fn send_error(&self, id: Id, error: ErrorObject) -> bool {
-		let json = match serde_json::to_string(&RpcError { jsonrpc: TwoPointZero, error, id }) {
+		let json = match serde_json::to_string(&RpcError::new(error, id)) {
 			Ok(json) => json,
 			Err(err) => {
 				tracing::error!("Error serializing error message: {:?}", err);
@@ -214,16 +213,14 @@ pub async fn collect_batch_response(rx: mpsc::UnboundedReceiver<String>) -> Stri
 
 #[cfg(test)]
 mod tests {
-	use super::{BoundedWriter, Id, Response, TwoPointZero};
+	use super::{BoundedWriter, Id, Response};
 
 	#[test]
 	fn bounded_serializer_work() {
 		let mut writer = BoundedWriter::new(100);
 		let result = "success";
 
-		assert!(
-			serde_json::to_writer(&mut writer, &Response { jsonrpc: TwoPointZero, id: Id::Number(1), result }).is_ok()
-		);
+		assert!(serde_json::to_writer(&mut writer, &Response::new(result, Id::Number(1))).is_ok());
 		assert_eq!(String::from_utf8(writer.into_bytes()).unwrap(), r#"{"jsonrpc":"2.0","result":"success","id":1}"#);
 	}
 

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -369,7 +369,15 @@ impl Methods {
 		rx.next().await
 	}
 
-	/// Perform a method call and receive further subscriptions.
+	/// Perform a "in memory JSON-RPC method call" and receive further subscriptions.
+	/// This is useful if you want to support both `method calls` and `subscriptions`
+	/// in the same API.
+	///
+	/// There are better variants than this method if you only want
+	/// method calls or subscriptions.
+	///
+	/// See [`RpcModule::test_subscription`] and [`RpcModule::call_with`] for
+	/// for further documentation.
 	///
 	/// Returns a response to actual method call and a stream to process
 	/// futher subscriptions if a subcription was registered on the call.
@@ -386,7 +394,7 @@ impl Methods {
 	///
 	///     let mut module = RpcModule::new(());
 	///     module.register_subscription("hi", "hi", "goodbye", |_, mut sink, _| {
-	///     sink.send(&"one answer").unwrap();
+	///         sink.send(&"one answer").unwrap();
 	///         Ok(())
 	///     }).unwrap();
 	///     let (resp, mut stream) = module.call_and_subscribe("hi", EmptyParams::new()).await.unwrap();

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -376,7 +376,7 @@ impl Methods {
 	/// There are better variants than this method if you only want
 	/// method calls or subscriptions.
 	///
-	/// See [`RpcModule::test_subscription`] and [`RpcModule::call_with`] for
+	/// See [`Methods::test_subscription`] and [`Methods::call_with`] for
 	/// for further documentation.
 	///
 	/// Returns a response to the actual method call and a stream to process

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -374,7 +374,7 @@ impl Methods {
 	/// in the same API.
 	///
 	/// There are better variants than this method if you only want
-	/// method calls or subscriptions.
+	/// method calls or only subscriptions.
 	///
 	/// See [`Methods::test_subscription`] and [`Methods::call_with`] for
 	/// for further documentation.

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -371,8 +371,8 @@ impl Methods {
 
 	/// Perform a method call and receive further subscriptions.
 	///
-	/// Returns a response to actual method call and a stream to process
-	/// futher subscriptions if a subcription was registered on the call.
+	/// Returns a response to the actual method call and a stream to process
+	/// further notifications if a subscription was registered by the call.
 	///
 	/// ```
 	/// #[tokio::main]

--- a/utils/src/server/rpc_module.rs
+++ b/utils/src/server/rpc_module.rs
@@ -380,7 +380,7 @@ impl Methods {
 	/// for further documentation.
 	///
 	/// Returns a response to the actual method call and a stream to process
-	/// further notifications if a subscription was registered by the call.
+	/// for further notifications if a subscription was registered by the call.
 	///
 	/// ```
 	/// #[tokio::main]


### PR DESCRIPTION
Needed to support `in memory queries` in substrate with "optional subscriptions`, [example here](https://github.com/paritytech/substrate/blob/3e96b8ec9c863422889245e73516551cc56127c5/client/service/src/lib.rs#L88-#L99)

This might be useful elsewhere too but I think we should refactor this in `v0.7` many similar functions there now.

It won't work unless we expose `receiver` of the stream which this does.