### PR TITLE
benches: make jsonrpc crates optional

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,17 +7,17 @@ edition = "2018"
 license = "MIT"
 publish = false
 
-[dev-dependencies]
+[dependencies]
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
 futures-channel = "0.3.15"
 futures-util = "0.3.15"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
-jsonrpc-ws-server = "18.0.0"
-jsonrpc-http-server = "18.0.0"
-jsonrpc-pubsub = "18.0.0"
+jsonrpc-ws-server = { version = "18.0.0", optional = true }
+jsonrpc-http-server = { version = "18.0.0", optional = true }
+jsonrpc-pubsub = { version = "18.0.0", optional = true }
 num_cpus = "1"
 serde_json = "1"
-tokio = { version = "1.8", features = ["full"] }
+tokio = { version = "1.8", features = ["rt-multi-thread"] }
 
 [[bench]]
 name = "bench"
@@ -26,4 +26,4 @@ harness = false
 
 [features]
 # Run benchmarks against servers in https://github.com/paritytech/jsonrpc/
-jsonrpc-crate = []
+jsonrpc-crate = ["jsonrpc-ws-server", "jsonrpc-http-server", "jsonrpc-pubsub"]


### PR DESCRIPTION
Make the dependency tree smaller with the default bench dependencies.