### PR TITLE
Better error messages for method arguments ignored with a `_`

### DIFF
--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -71,9 +71,8 @@ impl RpcMethod {
 			None => quote!(),
 		};
 
-		let span = sig.span();
 		if blocking && sig.asyncness.is_some() {
-			return Err(syn::Error::new(span, "Blocking method must be synchronous"));
+			return Err(syn::Error::new(sig.span(), "Blocking method must be synchronous"));
 		}
 
 		let params: Vec<_> = sig
@@ -88,7 +87,7 @@ impl RpcMethod {
 						"Method argument names must be valid Rust identifiers; got `_` instead",
 					))),
 					_ => Some(Err(syn::Error::new(
-						span,
+						arg.span(),
 						format!("Unexpected method signature input; got {:?} ", *arg.pat),
 					))),
 				},

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -93,7 +93,7 @@ impl RpcMethod {
 					))),
 				},
 			})
-			.collect::<Result<Vec<_>, _>>()?;
+			.collect::<Result<_, _>>()?;
 
 		let returns = match sig.output {
 			syn::ReturnType::Default => None,

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -84,7 +84,7 @@ impl RpcMethod {
 				syn::FnArg::Typed(arg) => match *arg.pat {
 					syn::Pat::Ident(name) => Some(Ok((name, *arg.ty))),
 					syn::Pat::Wild(_) => Some(Err(syn::Error::new(
-						span,
+						arg.span(),
 						"Method argument names must be valid Rust identifiers; got `_` instead",
 					))),
 					_ => Some(Err(syn::Error::new(

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -85,7 +85,7 @@ impl RpcMethod {
 					syn::Pat::Ident(name) => Some(Ok((name, *arg.ty))),
 					syn::Pat::Wild(_) => Some(Err(syn::Error::new(
 						span,
-						"Method argument names must be a valid Rust identifiers; got `_` instead",
+						"Method argument names must be valid Rust identifiers; got `_` instead",
 					))),
 					_ => Some(Err(syn::Error::new(
 						span,

--- a/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.rs
+++ b/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.rs
@@ -1,0 +1,9 @@
+use jsonrpsee::proc_macros::rpc;
+
+#[rpc(server)]
+pub trait IgnoredArgument {
+	#[method(name = "a")]
+	async fn a(&self, _: Vec<u8>);
+}
+
+fn main() {}

--- a/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.stderr
@@ -1,0 +1,5 @@
+error: Method argument names must be a valid Rust identifiers; got `_` instead
+ --> $DIR/method_ignored_arguments.rs:6:2
+  |
+6 |     async fn a(&self, _: Vec<u8>);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.stderr
@@ -1,4 +1,4 @@
-error: Method argument names must be a valid Rust identifiers; got `_` instead
+error: Method argument names must be valid Rust identifiers; got `_` instead
  --> $DIR/method_ignored_arguments.rs:6:2
   |
 6 |     async fn a(&self, _: Vec<u8>);

--- a/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_ignored_arguments.stderr
@@ -1,5 +1,5 @@
 error: Method argument names must be valid Rust identifiers; got `_` instead
- --> $DIR/method_ignored_arguments.rs:6:2
+ --> $DIR/method_ignored_arguments.rs:6:20
   |
 6 |     async fn a(&self, _: Vec<u8>);
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                       ^^^^^^^^^^

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_name_conflict.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_name_conflict.rs
@@ -1,6 +1,6 @@
 use jsonrpsee::{proc_macros::rpc, types::RpcResult};
 
-// Associated items are forbidden.
+// Names must be unique.
 #[rpc(client, server)]
 pub trait MethodNameConflict {
 	#[method(name = "foo")]


### PR DESCRIPTION
Fixes #609
