### PR TITLE
[ci] fix image in check-bench job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,10 +136,10 @@ benchmarks:
 
 check_bench:
   stage:                           check_benchmark
-  image:                           paritytech/benchmarks:latest
   variables:
     PROMETHEUS_URL:                "http://vm-longterm.parity-build.parity.io"
     TRESHOLD:                      20
+    CI_IMAGE:                      "paritytech/benchmarks:latest"
   <<:                              *kubernetes-env
   <<:                              *schedule-refs
   <<:                              *vault-secrets


### PR DESCRIPTION
`check_bench` didn't work because of misconfig. A wrong docker image was used because it is reassigned in `*kubernetes-env` step.