### PR TITLE
feat(rpc module): `stream API` for SubscriptionSink

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
 parking_lot = { version = "0.11", optional = true }
-tokio = { version = "1.8", features = ["rt", "macros"], optional = true }
+tokio = { version = "1.8", features = ["rt"], optional = true }
 
 [features]
 default = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
 parking_lot = { version = "0.11", optional = true }
-tokio = { version = "1.8", features = ["rt"], optional = true }
+tokio = { version = "1.8", features = ["rt", "macros"], optional = true }
 
 [features]
 default = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1"
 arrayvec = "0.7.1"
 async-trait = "0.1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
+async-channel = { version = "1.6", optional = true }
 thiserror = "1"
 futures-channel = { version = "0.3.14", default-features = false }
 futures-util = { version = "0.3.14", default-features = false, optional = true }
@@ -29,6 +30,7 @@ tokio = { version = "1.8", features = ["rt"], optional = true }
 default = []
 http-helpers = ["futures-util"]
 server = [
+	"async-channel",
 	"futures-util",
 	"rustc-hash",
 	"tracing",

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -92,26 +92,6 @@ pub struct MethodSink {
 	max_response_size: u32,
 }
 
-impl Sink<String> for MethodSink {
-	type Error = Error;
-
-	fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-		Pin::new(&mut self.tx).poll_ready(cx).map_err(Into::into)
-	}
-
-	fn start_send(mut self: Pin<&mut Self>, item: String) -> Result<(), Self::Error> {
-		Pin::new(&mut self.tx).start_send(item).map_err(Into::into)
-	}
-
-	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-		Pin::new(&mut self.tx).poll_flush(cx).map_err(Into::into)
-	}
-
-	fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-		Pin::new(&mut self.tx).poll_close(cx).map_err(Into::into)
-	}
-}
-
 impl MethodSink {
 	/// Create a new `MethodSink` with unlimited response size
 	pub fn new(tx: mpsc::UnboundedSender<String>) -> Self {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -776,15 +776,15 @@ impl SubscriptionSink {
 
 		loop {
 			match futures_util::future::select(item, close).await {
-				Either::Left((Some(i), c)) => {
-					match self.send(&i) {
+				Either::Left((Some(result), c)) => {
+					match self.send(&result) {
 						Ok(_) => (),
 						Err(Error::SubscriptionClosed(close_reason)) => {
 							self.close(&close_reason);
 							break Ok(());
 						}
 						Err(err) => {
-							tracing::warn!("Subscription got error: {:?} terminating task", err);
+							tracing::error!("subscription `{}` failed to send item got error: {:?}", self.method, err);
 							break Err(err);
 						}
 					};

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -772,7 +772,7 @@ impl SubscriptionSink {
 					item = stream.next();
 				}
 				// No messages should be sent over this channel
-				// if that's occur just continue.
+				// if that occurred just ignore and continue.
 				Either::Right((Some(_), i)) => {
 					item = i;
 					close = close_stream.next();

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -764,9 +764,9 @@ impl SubscriptionSink {
 			match futures_util::future::select(item, close).await {
 				Either::Left((Some(i), c)) => {
 					match self.send(&i) {
-						Ok => (),
-						Err(Error::SubscriptionClosed(_)) => return Ok(()),
-						err => return err,
+						Ok(_) => (),
+						Err(Error::SubscriptionClosed(_)) => break Ok(()),
+						Err(err) => break Err(err),
 					};
 					close = c;
 					item = stream.next();
@@ -778,7 +778,7 @@ impl SubscriptionSink {
 					close = close_stream.next();
 				}
 				// Stream or connection has been terminated.
-				Either::Right((None, _)) | Either::Left((None, _)) => return Ok(()),
+				Either::Right((None, _)) | Either::Left((None, _)) => break Ok(()),
 			}
 		}
 	}

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -62,7 +62,6 @@ pub type ConnectionId = usize;
 /// Raw RPC response.
 pub type RawRpcResponse = (String, mpsc::UnboundedReceiver<String>, mpsc::UnboundedSender<String>);
 /// Connection state for stateful protocols such as WebSocket
-/// This is used to keep track whether the connection has been closed.
 pub type MaybeConnState<'a> = Option<ConnState<'a>>;
 
 /// Data for stateful connections.

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -821,8 +821,15 @@ impl SubscriptionSink {
 						break;
 					}
 				},
-				// "close" only returns None when connection closed.
-				_ = rx.next() => break,
+				v = rx.next() => {
+					if let Some(_) = v {
+						// No messages should be sent over this channel.
+						()
+					} else {
+						// Channel dropped by the server.
+						break;
+					}
+				},
 				else => break,
 			}
 		}

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -751,7 +751,7 @@ impl SubscriptionSink {
 	/// Returns `Ok(())` if the stream or connection was terminated.
 	/// Returns `Err(_)` if one of the items couldn't be serialized.
 	///
-	pub async fn read_stream_and_send<S, T>(mut self, mut stream: S) -> Result<(), Error>
+	pub async fn streamify<S, T>(mut self, mut stream: S) -> Result<(), Error>
 	where
 		S: Stream<Item = T> + Unpin,
 		T: Serialize,

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -364,7 +364,7 @@ impl Methods {
 		Ok((resp, rx))
 	}
 
-	/// Wrapper over [`Methods::execute`] to execute a callback.
+	/// Execute a callback.
 	async fn inner_call(&self, req: Request<'_>) -> RawRpcResponse {
 		let (tx, mut rx) = mpsc::unbounded();
 		let sink = MethodSink::new(tx);
@@ -374,7 +374,7 @@ impl Methods {
 		let params = Params::new(req.params.map(|params| params.get()));
 
 		let _result = match self.method(&req.method).map(|c| &c.callback) {
-			None => todo!(),
+			None => sink.send_error(req.id, ErrorCode::MethodNotFound.into()),
 			Some(MethodKind::Sync(cb)) => (cb)(id, params, &sink),
 			Some(MethodKind::Async(cb)) => (cb)(id.into_owned(), params.into_owned(), sink, 0, None).await,
 			Some(MethodKind::Subscription(cb)) => {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -761,11 +761,11 @@ impl SubscriptionSink {
 	/// let mut m = RpcModule::new(());
 	/// m.register_subscription("sub", "_", "unsub", |params, mut sink, _| {
 	///     let stream = futures_util::stream::iter(vec![1_u32, 2, 3]);
-	///     tokio::spawn(sink.consume_and_streamify(stream));
+	///     tokio::spawn(sink.pipe_from_stream(stream));
 	///     Ok(())
 	/// });
 	/// ```
-	pub async fn consume_and_streamify<S, T>(mut self, mut stream: S) -> Result<(), Error>
+	pub async fn pipe_from_stream<S, T>(mut self, mut stream: S) -> Result<(), Error>
 	where
 		S: Stream<Item = T> + Unpin,
 		T: Serialize,

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -785,7 +785,7 @@ impl SubscriptionSink {
 						}
 						Err(err) => {
 							tracing::warn!("Subscription got error: {:?} terminating task", err);
-							break Err(err)
+							break Err(err);
 						}
 					};
 					close = c;

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -40,7 +40,6 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Error as HyperError, Method};
 use jsonrpsee_core::error::{Error, GenericTransportError};
 use jsonrpsee_core::http_helpers::{self, read_body};
-use jsonrpsee_core::id_providers::NoopIdProvider;
 use jsonrpsee_core::middleware::Middleware;
 use jsonrpsee_core::server::helpers::{collect_batch_response, prepare_error, MethodSink};
 use jsonrpsee_core::server::resource_limiting::Resources;
@@ -457,7 +456,7 @@ async fn process_validated_request(
 			middleware.on_call(req.method.as_ref());
 
 			// NOTE: we don't need to track connection id on HTTP, so using hardcoded 0 here.
-			match methods.execute_with_resources(&sink, None, req, 0, &resources, &NoopIdProvider) {
+			match methods.execute_with_resources(&sink, None, req, &resources) {
 				Ok((name, MethodResult::Sync(success))) => {
 					middleware.on_result(name, success, request_start);
 				}
@@ -483,7 +482,7 @@ async fn process_validated_request(
 			let middleware = &middleware;
 
 			join_all(batch.into_iter().filter_map(move |req| {
-				match methods.execute_with_resources(&sink, None, req, 0, &resources, &NoopIdProvider) {
+				match methods.execute_with_resources(&sink, None, req, &resources) {
 					Ok((name, MethodResult::Sync(success))) => {
 						middleware.on_result(name, success, request_start);
 						None

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -497,15 +497,12 @@ async fn process_validated_request(
 				},
 			};
 			middleware.on_result(&req.method, result, request_start);
-		// TODO: shouldn't `on_response` be called here?!
-		// middleware.on_response(request_start);
 		} else if let Ok(_req) = serde_json::from_slice::<Notif>(&body) {
 			return Ok::<_, HyperError>(response::ok_response("".into()));
 		} else {
 			let (id, code) = prepare_error(&body);
 			sink.send_error(id, code.into());
 		}
-
 	// Batch of requests or notifications
 	} else if let Ok(batch) = serde_json::from_slice::<Vec<Request>>(&body) {
 		if !batch.is_empty() {

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -335,7 +335,7 @@ impl<M: Middleware> Server<M> {
 								middleware.on_call(req.method.as_ref());
 
 								// NOTE: we don't need to track connection id on HTTP, so using hardcoded 0 here.
-								match methods.execute_with_resources(&sink, req, 0, &resources, &NoopIdProvider) {
+								match methods.execute_with_resources(&sink, None, req, 0, &resources, &NoopIdProvider) {
 									Ok((name, MethodResult::Sync(success))) => {
 										middleware.on_result(name, success, request_start);
 									}
@@ -363,6 +363,7 @@ impl<M: Middleware> Server<M> {
 								join_all(batch.into_iter().filter_map(
 									move |req| match methods.execute_with_resources(
 										&sink,
+										None,
 										req,
 										0,
 										&resources,

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -85,7 +85,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 		.register_subscription("subscribe_noop", "subscribe_noop", "unsubscribe_noop", |_, mut sink, _| {
 			std::thread::spawn(move || {
 				std::thread::sleep(Duration::from_secs(1));
-				sink.close("Server closed the stream because it was lazy")
+				sink.close_with_custom_message("Server closed the stream because it was lazy")
 			});
 			Ok(())
 		})

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -375,7 +375,7 @@ async fn ws_server_cancels_stream_after_reset_conn() {
 			// create stream that doesn't produce items.
 			let stream = futures::stream::empty::<usize>();
 			tokio::spawn(async move {
-				sink.consume_and_streamify(stream).await.unwrap();
+				sink.pipe_from_stream(stream).await.unwrap();
 				let send_back = Arc::make_mut(&mut tx);
 				send_back.feed(()).await.unwrap();
 			});

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -375,7 +375,7 @@ async fn ws_server_cancels_stream_after_reset_conn() {
 			// create stream that doesn't produce items.
 			let stream = futures::stream::empty::<usize>();
 			tokio::spawn(async move {
-				sink.add_stream(stream).await;
+				sink.read_stream_and_send(stream).await.unwrap();
 				let send_back = Arc::make_mut(&mut tx);
 				send_back.feed(()).await.unwrap();
 			});

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -360,6 +360,44 @@ async fn ws_server_should_stop_subscription_after_client_drop() {
 }
 
 #[tokio::test]
+async fn ws_server_cancel_stream_after_reset_conn() {
+	use futures::{channel::mpsc, SinkExt, StreamExt};
+	use jsonrpsee::{ws_server::WsServerBuilder, RpcModule};
+
+	let server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+	let server_url = format!("ws://{}", server.local_addr().unwrap());
+
+	let (tx, mut rx) = mpsc::channel(1);
+	let mut module = RpcModule::new(tx);
+
+	module
+		.register_subscription("subscribe_never_produce", "n", "unsubscribe_never_produce", |_, sink, mut tx| {
+			// create stream that doesn't produce items.
+			let stream = futures::stream::empty::<usize>();
+			tokio::spawn(async move {
+				sink.add_stream(stream).await;
+				let send_back = Arc::make_mut(&mut tx);
+				send_back.feed(()).await.unwrap();
+			});
+			Ok(())
+		})
+		.unwrap();
+
+	server.start(module).unwrap();
+
+	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
+	let _sub1: Subscription<usize> =
+		client.subscribe("subscribe_never_produce", None, "unsubscribe_never_produce").await.unwrap();
+	let _sub2: Subscription<usize> =
+		client.subscribe("subscribe_never_produce", None, "unsubscribe_never_produce").await.unwrap();
+
+	// terminate connection.
+	drop(client);
+	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");
+	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");
+}
+
+#[tokio::test]
 async fn ws_batch_works() {
 	let server_addr = websocket_server().await;
 	let server_url = format!("ws://{}", server_addr);

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -375,7 +375,7 @@ async fn ws_server_cancels_stream_after_reset_conn() {
 			// create stream that doesn't produce items.
 			let stream = futures::stream::empty::<usize>();
 			tokio::spawn(async move {
-				sink.read_stream_and_send(stream).await.unwrap();
+				sink.streamify(stream).await.unwrap();
 				let send_back = Arc::make_mut(&mut tx);
 				send_back.feed(()).await.unwrap();
 			});

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -360,7 +360,7 @@ async fn ws_server_should_stop_subscription_after_client_drop() {
 }
 
 #[tokio::test]
-async fn ws_server_cancel_stream_after_reset_conn() {
+async fn ws_server_cancels_stream_after_reset_conn() {
 	use futures::{channel::mpsc, SinkExt, StreamExt};
 	use jsonrpsee::{ws_server::WsServerBuilder, RpcModule};
 

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -375,7 +375,7 @@ async fn ws_server_cancels_stream_after_reset_conn() {
 			// create stream that doesn't produce items.
 			let stream = futures::stream::empty::<usize>();
 			tokio::spawn(async move {
-				sink.streamify(stream).await.unwrap();
+				sink.consume_and_streamify(stream).await.unwrap();
 				let send_back = Arc::make_mut(&mut tx);
 				send_back.feed(()).await.unwrap();
 			});

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -239,8 +239,8 @@ async fn close_test_subscribing_without_server() {
 	// close the subscription to ensure it doesn't return any items.
 	my_sub.close();
 
-	// in this case, the unsubscribe method was not called and will be treated as the
-	// connetion was closed.
+	// In this case, the unsubscribe method was not called and
+	// it will be treated as the connection was closed.
 	let exp = SubscriptionClosed::new(SubscriptionClosedReason::ConnectionReset);
 	assert!(
 		matches!(my_sub.next::<String>().await, Some(Err(Error::SubscriptionClosed(close_reason))) if close_reason == exp)

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-server"
 
 [dependencies]
+async-channel = "1.6.1"
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
 jsonrpsee-types = { path = "../types", version = "0.7.0" }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -316,11 +316,13 @@ async fn background_task(
 				break;
 			}
 		}
-		// terminate connection.
+
+		// Terminate connection and send close message.
 		let _ = sender.close().await;
-		// NOTE(niklasad1): when the receiver is dropped no further requests or subscriptions
-		// will be possible.
-		drop(conn_tx);
+
+		// Force `conn_tx` to this async block and close it down
+		// when the connection closes to be on safe side.
+		conn_tx.close();
 	});
 
 	// Buffer for incoming data.

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -411,7 +411,7 @@ async fn background_task(
 
 									let fut = async move {
 										let result = (callback)(id, params, sink, conn_id, Some(guard)).await;
-										middleware.on_result(&name, result, request_start);
+										middleware.on_result(name, result, request_start);
 										middleware.on_response(request_start);
 									};
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/jsonrpsee/issues/627

This PR introduces a new API for the `SubscriptionSink` to add a stream to send items over the subscription when "new items" get produced, if the connection gets closed it will terminate the task because it has additional channel linked to actual connection.