### PR TITLE
fix(ws client): expose tls feature.

### DIFF
--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -19,3 +19,7 @@ env_logger = "0.9"
 jsonrpsee-test-utils = { path = "../../test-utils" }
 tokio = { version = "1", features = ["macros"] }
 serde_json = "1"
+
+[features]
+tls = ["jsonrpsee-client-transport/tls"]
+default = ["tls"]


### PR DESCRIPTION
The TLS feature was missing which this fixes and enables it by default.