### PR TITLE
fix(ws client): improve error message bad URL

### DIFF
--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -286,7 +286,7 @@ impl<'a> WsTransportClientBuilder<'a> {
 							Ok(uri) => {
 								// Absolute URI.
 								if uri.scheme().is_some() {
-									let uri: Target = uri.try_into().map_err(|e| {
+									let target: Target = uri.try_into().map_err(|e| {
 										tracing::error!("Redirection failed: {:?}", e);
 										e
 									})?;

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -438,10 +438,11 @@ impl TryFrom<Uri> for Target {
 			#[cfg(feature = "tls")]
 			Some("wss") => Mode::Tls,
 			invalid_scheme => {
+				let scheme = invalid_scheme.unwrap_or("no scheme");
 				#[cfg(feature = "tls")]
-				let err = format!("{:?} not supported, expects 'ws' or 'wss'", invalid_scheme);
+				let err = format!("`{}` not supported, expects 'ws' or 'wss'", scheme);
 				#[cfg(not(feature = "tls"))]
-				let err = format!("{:?} not supported, expects 'ws' ('wss' requires the tls feature)", invalid_scheme);
+				let err = format!("`{}` not supported, expects 'ws' ('wss' requires the tls feature)", scheme);
 				return Err(WsHandshakeError::Url(err.into()));
 			}
 		};

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -286,7 +286,7 @@ impl<'a> WsTransportClientBuilder<'a> {
 							Ok(uri) => {
 								// Absolute URI.
 								if uri.scheme().is_some() {
-									let target: Target = uri.try_into().map_err(|e| {
+									target = uri.try_into().map_err(|e| {
 										tracing::error!("Redirection failed: {:?}", e);
 										e
 									})?;


### PR DESCRIPTION
Fixes/improves the error message when a bad URL is detected

Partly addresses https://github.com/paritytech/jsonrpsee/issues/638 to print an error when an absolute URI 
in a redirection couldn't be parsed as a WS target.