### PR TITLE
feat(client): support request id as Strings.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -61,7 +61,7 @@ pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
 		b.iter(|| {
 			let params = &[1_u64.into(), 2_u32.into()];
 			let params = ParamsSer::ArrayRef(params);
-			let request = RequestSer::new(Id::Number(0), "say_hello", Some(params));
+			let request = RequestSer::new(&Id::Number(0), "say_hello", Some(params));
 			v2_serialize(request);
 		})
 	});
@@ -69,7 +69,7 @@ pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
 	crit.bench_function("jsonrpsee_types_v2_vec", |b| {
 		b.iter(|| {
 			let params = ParamsSer::Array(vec![1_u64.into(), 2_u32.into()]);
-			let request = RequestSer::new(Id::Number(0), "say_hello", Some(params));
+			let request = RequestSer::new(&Id::Number(0), "say_hello", Some(params));
 			v2_serialize(request);
 		})
 	});

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -130,7 +130,7 @@ impl ClientT for HttpClient {
 	{
 		let guard = self.id_manager.next_request_id()?;
 		let id = guard.inner();
-		let request = RequestSer::new(id.clone(), method, params);
+		let request = RequestSer::new(&id, method, params);
 
 		let fut = self.transport.send_and_read_body(serde_json::to_string(&request).map_err(Error::ParseError)?);
 		let body = match tokio::time::timeout(self.request_timeout, fut).await {
@@ -171,7 +171,7 @@ impl ClientT for HttpClient {
 		let ids: Vec<Id> = guard.inner();
 
 		for (pos, (method, params)) in batch.into_iter().enumerate() {
-			batch_request.push(RequestSer::new(ids[pos].clone(), method, params));
+			batch_request.push(RequestSer::new(&ids[pos], method, params));
 			ordered_requests.push(ids[pos].clone());
 			request_set.insert(ids[pos].clone(), pos);
 		}

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 use crate::transport::HttpTransportClient;
 use crate::types::{ErrorResponse, Id, NotificationSer, ParamsSer, RequestSer, Response};
 use async_trait::async_trait;
-use jsonrpsee_core::client::{CertificateStore, ClientT, RequestIdManager, Subscription, SubscriptionClientT};
+use jsonrpsee_core::client::{CertificateStore, ClientT, IdKind, RequestIdManager, Subscription, SubscriptionClientT};
 use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 use rustc_hash::FxHashMap;
 use serde::de::DeserializeOwned;
@@ -42,6 +42,7 @@ pub struct HttpClientBuilder {
 	request_timeout: Duration,
 	max_concurrent_requests: usize,
 	certificate_store: CertificateStore,
+	id_kind: IdKind,
 }
 
 impl HttpClientBuilder {
@@ -69,6 +70,12 @@ impl HttpClientBuilder {
 		self
 	}
 
+	/// Configure the format of the request object id.
+	pub fn id_format(mut self, id_kind: IdKind) -> Self {
+		self.id_kind = id_kind;
+		self
+	}
+
 	/// Build the HTTP client with target to connect to.
 	pub fn build(self, target: impl AsRef<str>) -> Result<HttpClient, Error> {
 		let transport = HttpTransportClient::new(target, self.max_request_body_size, self.certificate_store)
@@ -77,6 +84,7 @@ impl HttpClientBuilder {
 			transport,
 			id_manager: Arc::new(RequestIdManager::new(self.max_concurrent_requests)),
 			request_timeout: self.request_timeout,
+			id_kind: self.id_kind,
 		})
 	}
 }
@@ -88,6 +96,7 @@ impl Default for HttpClientBuilder {
 			request_timeout: Duration::from_secs(60),
 			max_concurrent_requests: 256,
 			certificate_store: CertificateStore::Native,
+			id_kind: IdKind::Number,
 		}
 	}
 }
@@ -101,6 +110,8 @@ pub struct HttpClient {
 	request_timeout: Duration,
 	/// Request ID manager.
 	id_manager: Arc<RequestIdManager>,
+	/// Configure the format of the request object id.
+	id_kind: IdKind,
 }
 
 #[async_trait]
@@ -120,8 +131,15 @@ impl ClientT for HttpClient {
 	where
 		R: DeserializeOwned,
 	{
-		let id = self.id_manager.next_request_id()?;
-		let request = RequestSer::new(Id::Number(*id.inner()), method, params);
+		let guard = self.id_manager.next_request_id()?;
+		let id = *guard.inner();
+
+		let id = match self.id_kind {
+			IdKind::Number => Id::Number(id),
+			IdKind::String => Id::Str(format!("{}", id).into()),
+		};
+
+		let request = RequestSer::new(id.clone(), method, params);
 
 		let fut = self.transport.send_and_read_body(serde_json::to_string(&request).map_err(Error::ParseError)?);
 		let body = match tokio::time::timeout(self.request_timeout, fut).await {
@@ -142,9 +160,7 @@ impl ClientT for HttpClient {
 			}
 		};
 
-		let response_id = response.id.as_number().copied().ok_or(Error::InvalidRequestId)?;
-
-		if response_id == *id.inner() {
+		if response.id == id {
 			Ok(response.result)
 		} else {
 			Err(Error::InvalidRequestId)
@@ -160,11 +176,21 @@ impl ClientT for HttpClient {
 		let mut ordered_requests = Vec::with_capacity(batch.len());
 		let mut request_set = FxHashMap::with_capacity_and_hasher(batch.len(), Default::default());
 
-		let ids = self.id_manager.next_request_ids(batch.len())?;
+		let guard = self.id_manager.next_request_ids(batch.len())?;
+
+		let ids: Vec<Id> = guard
+			.inner()
+			.into_iter()
+			.map(|&id| match self.id_kind {
+				IdKind::Number => Id::Number(id),
+				IdKind::String => Id::Str(format!("{}", id).into()),
+			})
+			.collect();
+
 		for (pos, (method, params)) in batch.into_iter().enumerate() {
-			batch_request.push(RequestSer::new(Id::Number(ids.inner()[pos]), method, params));
-			ordered_requests.push(ids.inner()[pos]);
-			request_set.insert(ids.inner()[pos], pos);
+			batch_request.push(RequestSer::new(ids[pos].clone(), method, params));
+			ordered_requests.push(ids[pos].clone());
+			request_set.insert(ids[pos].clone(), pos);
 		}
 
 		let fut = self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
@@ -184,8 +210,7 @@ impl ClientT for HttpClient {
 		// NOTE: `R::default` is placeholder and will be replaced in loop below.
 		let mut responses = vec![R::default(); ordered_requests.len()];
 		for rp in rps {
-			let response_id = rp.id.as_number().copied().ok_or(Error::InvalidRequestId)?;
-			let pos = match request_set.get(&response_id) {
+			let pos = match request_set.get(&rp.id) {
 				Some(pos) => *pos,
 				None => return Err(Error::InvalidRequestId),
 			};

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -70,7 +70,7 @@ impl HttpClientBuilder {
 		self
 	}
 
-	/// Configure the format of the request object id.
+	/// Configure the data type of the request object ID (default is number).
 	pub fn id_format(mut self, id_kind: IdKind) -> Self {
 		self.id_kind = id_kind;
 		self

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -45,7 +45,7 @@ async fn method_call_works() {
 }
 
 #[tokio::test]
-async fn method_call_with_wrong_id() {
+async fn method_call_with_wrong_id_kind() {
 	let exp = "id as string";
 	let server_addr =
 		http_server_with_hardcoded_response(ok_response(exp.into(), Id::Num(0))).with_default_timeout().await.unwrap();

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -145,7 +145,7 @@ impl<'a> WsClientBuilder<'a> {
 		self
 	}
 
-	/// See documentation [`ClientBuilder::id_format`] (default is Number).
+	/// See documentation for [`ClientBuilder::id_format`] (default is Number).
 	pub fn id_format(mut self, kind: IdKind) -> Self {
 		self.id_kind = kind;
 		self

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -43,7 +43,7 @@ pub use jsonrpsee_types as types;
 use std::time::Duration;
 
 use jsonrpsee_client_transport::ws::{Header, InvalidUri, Uri, WsTransportClientBuilder};
-use jsonrpsee_core::client::{CertificateStore, ClientBuilder};
+use jsonrpsee_core::client::{CertificateStore, ClientBuilder, IdKind};
 use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 
 /// Builder for [`WsClient`].
@@ -77,6 +77,7 @@ pub struct WsClientBuilder<'a> {
 	max_concurrent_requests: usize,
 	max_notifs_per_subscription: usize,
 	max_redirections: usize,
+	id_kind: IdKind,
 }
 
 impl<'a> Default for WsClientBuilder<'a> {
@@ -90,6 +91,7 @@ impl<'a> Default for WsClientBuilder<'a> {
 			max_concurrent_requests: 256,
 			max_notifs_per_subscription: 1024,
 			max_redirections: 5,
+			id_kind: IdKind::Number,
 		}
 	}
 }
@@ -143,6 +145,12 @@ impl<'a> WsClientBuilder<'a> {
 		self
 	}
 
+	/// See documentation [`ClientBuilder::id_format`] (default is Number).
+	pub fn id_format(mut self, kind: IdKind) -> Self {
+		self.id_kind = kind;
+		self
+	}
+
 	/// Build the client with specified URL to connect to.
 	/// You must provide the port number in the URL.
 	///
@@ -165,6 +173,7 @@ impl<'a> WsClientBuilder<'a> {
 			.max_notifs_per_subscription(self.max_notifs_per_subscription)
 			.request_timeout(self.request_timeout)
 			.max_concurrent_requests(self.max_concurrent_requests)
+			.id_format(self.id_kind)
 			.build(sender, receiver))
 	}
 }

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -48,7 +48,7 @@ async fn method_call_works() {
 }
 
 #[tokio::test]
-async fn method_call_with_wrong_id() {
+async fn method_call_with_wrong_id_kind() {
 	let exp = "id as string";
 	let server = WebSocketTestServer::with_hardcoded_response(
 		"127.0.0.1:0".parse().unwrap(),

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -198,7 +198,7 @@ pub(crate) fn build_unsubscribe_message(
 	let sub_id_slice: &[JsonValue] = &[sub_id.into()];
 	// TODO: https://github.com/paritytech/jsonrpsee/issues/275
 	let params = ParamsSer::ArrayRef(sub_id_slice);
-	let raw = serde_json::to_string(&RequestSer::new(unsub_req_id.clone(), &unsub, Some(params))).ok()?;
+	let raw = serde_json::to_string(&RequestSer::new(&unsub_req_id, &unsub, Some(params))).ok()?;
 	Some(RequestMessage { raw, id: unsub_req_id, send_back: None })
 }
 

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -45,8 +45,8 @@ pub(crate) fn process_batch_response(manager: &mut RequestManager, rps: Vec<Resp
 	let mut rps_unordered: Vec<_> = Vec::with_capacity(rps.len());
 
 	for rp in rps {
-		let id = rp.id.as_number().copied().ok_or(Error::InvalidRequestId)?;
-		digest.push(id);
+		let id = rp.id.into_owned();
+		digest.push(id.clone());
 		rps_unordered.push((id, rp.result));
 	}
 
@@ -131,7 +131,7 @@ pub(crate) fn process_single_response(
 	response: Response<JsonValue>,
 	max_capacity_per_subscription: usize,
 ) -> Result<Option<RequestMessage>, Error> {
-	let response_id = response.id.as_number().copied().ok_or(Error::InvalidRequestId)?;
+	let response_id = response.id.into_owned();
 	match manager.request_status(&response_id) {
 		RequestStatus::PendingMethodCall => {
 			let send_back_oneshot = match manager.complete_pending_call(response_id) {
@@ -144,7 +144,7 @@ pub(crate) fn process_single_response(
 		}
 		RequestStatus::PendingSubscription => {
 			let (unsub_id, send_back_oneshot, unsubscribe_method) =
-				manager.complete_pending_subscription(response_id).ok_or(Error::InvalidRequestId)?;
+				manager.complete_pending_subscription(response_id.clone()).ok_or(Error::InvalidRequestId)?;
 
 			let sub_id: Result<SubscriptionId, _> = response.result.try_into();
 			let sub_id = match sub_id {
@@ -157,7 +157,7 @@ pub(crate) fn process_single_response(
 
 			let (subscribe_tx, subscribe_rx) = mpsc::channel(max_capacity_per_subscription);
 			if manager
-				.insert_subscription(response_id, unsub_id, sub_id.clone(), subscribe_tx, unsubscribe_method)
+				.insert_subscription(response_id.clone(), unsub_id, sub_id.clone(), subscribe_tx, unsubscribe_method)
 				.is_ok()
 			{
 				match send_back_oneshot.send(Ok((subscribe_rx, sub_id.clone()))) {
@@ -191,14 +191,14 @@ pub(crate) async fn stop_subscription(
 /// Builds an unsubscription message.
 pub(crate) fn build_unsubscribe_message(
 	manager: &mut RequestManager,
-	sub_req_id: u64,
+	sub_req_id: Id<'static>,
 	sub_id: SubscriptionId<'static>,
 ) -> Option<RequestMessage> {
 	let (unsub_req_id, _, unsub, sub_id) = manager.remove_subscription(sub_req_id, sub_id)?;
 	let sub_id_slice: &[JsonValue] = &[sub_id.into()];
 	// TODO: https://github.com/paritytech/jsonrpsee/issues/275
 	let params = ParamsSer::ArrayRef(sub_id_slice);
-	let raw = serde_json::to_string(&RequestSer::new(Id::Number(unsub_req_id), &unsub, Some(params))).ok()?;
+	let raw = serde_json::to_string(&RequestSer::new(unsub_req_id.clone(), &unsub, Some(params))).ok()?;
 	Some(RequestMessage { raw, id: unsub_req_id, send_back: None })
 }
 
@@ -207,7 +207,7 @@ pub(crate) fn build_unsubscribe_message(
 /// Returns `Ok` if the response was successfully sent.
 /// Returns `Err(_)` if the response ID was not found.
 pub(crate) fn process_error_response(manager: &mut RequestManager, err: ErrorResponse) -> Result<(), Error> {
-	let id = err.id.as_number().copied().ok_or(Error::InvalidRequestId)?;
+	let id = err.id.clone().into_owned();
 	match manager.request_status(&id) {
 		RequestStatus::PendingMethodCall => {
 			let send_back = manager.complete_pending_call(id).expect("State checked above; qed");

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -207,7 +207,7 @@ impl ClientT for Client {
 		let guard = self.id_manager.next_request_id()?;
 		let id = guard.inner();
 
-		let raw = serde_json::to_string(&RequestSer::new(id.clone(), method, params)).map_err(Error::ParseError)?;
+		let raw = serde_json::to_string(&RequestSer::new(&id, method, params)).map_err(Error::ParseError)?;
 		tracing::trace!("[frontend]: send request: {:?}", raw);
 
 		if self
@@ -238,7 +238,7 @@ impl ClientT for Client {
 		let mut batches = Vec::with_capacity(batch.len());
 
 		for (idx, (method, params)) in batch.into_iter().enumerate() {
-			batches.push(RequestSer::new(batch_ids[idx].clone(), method, params));
+			batches.push(RequestSer::new(&batch_ids[idx], method, params));
 		}
 
 		let (send_back_tx, send_back_rx) = oneshot::channel();
@@ -293,8 +293,8 @@ impl SubscriptionClientT for Client {
 
 		let ids: Vec<Id> = guard.inner();
 
-		let raw = serde_json::to_string(&RequestSer::new(ids[0].clone(), subscribe_method, params))
-			.map_err(Error::ParseError)?;
+		let raw =
+			serde_json::to_string(&RequestSer::new(&ids[0], subscribe_method, params)).map_err(Error::ParseError)?;
 
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		if self

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -291,7 +291,7 @@ impl SubscriptionClientT for Client {
 
 		let guard = self.id_manager.next_request_ids(2)?;
 
-		let ids: Vec<Id> = guard.inner();
+		let mut ids: Vec<Id> = guard.inner();
 
 		let raw =
 			serde_json::to_string(&RequestSer::new(&ids[0], subscribe_method, params)).map_err(Error::ParseError)?;
@@ -302,8 +302,8 @@ impl SubscriptionClientT for Client {
 			.clone()
 			.send(FrontToBack::Subscribe(SubscriptionMessage {
 				raw,
-				subscribe_id: ids[0].clone(),
-				unsubscribe_id: ids[1].clone(),
+				subscribe_id: ids.swap_remove(0),
+				unsubscribe_id: ids.swap_remove(0),
 				unsubscribe_method: unsubscribe_method.to_owned(),
 				send_back: send_back_tx,
 			}))

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -37,7 +37,7 @@ use futures_channel::{mpsc, oneshot};
 use futures_util::future::FutureExt;
 use futures_util::sink::SinkExt;
 use futures_util::stream::{Stream, StreamExt};
-use jsonrpsee_types::{ParamsSer, SubscriptionId};
+use jsonrpsee_types::{Id, ParamsSer, SubscriptionId};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -210,7 +210,7 @@ pub struct BatchMessage {
 	/// Serialized batch request.
 	pub raw: String,
 	/// Request IDs.
-	pub ids: Vec<u64>,
+	pub ids: Vec<Id<'static>>,
 	/// One-shot channel over which we send back the result of this request.
 	pub send_back: oneshot::Sender<Result<Vec<JsonValue>, Error>>,
 }
@@ -221,7 +221,7 @@ pub struct RequestMessage {
 	/// Serialized message.
 	pub raw: String,
 	/// Request ID.
-	pub id: u64,
+	pub id: Id<'static>,
 	/// One-shot channel over which we send back the result of this request.
 	pub send_back: Option<oneshot::Sender<Result<JsonValue, Error>>>,
 }
@@ -232,9 +232,9 @@ pub struct SubscriptionMessage {
 	/// Serialized message.
 	pub raw: String,
 	/// Request ID of the subscribe message.
-	pub subscribe_id: u64,
+	pub subscribe_id: Id<'static>,
 	/// Request ID of the unsubscribe message.
-	pub unsubscribe_id: u64,
+	pub unsubscribe_id: Id<'static>,
 	/// Method to use to unsubscribe later. Used if the channel unexpectedly closes.
 	pub unsubscribe_method: String,
 	/// If the subscription succeeds, we return a [`mpsc::Receiver`] that will receive notifications.
@@ -397,6 +397,15 @@ pub enum CertificateStore {
 	Native,
 	/// Use WebPKI's certificate store
 	WebPki,
+}
+
+/// JSON-RPC request object id format.
+#[derive(Debug, Copy, Clone)]
+pub enum IdKind {
+	/// String.
+	String,
+	/// Number.
+	Number,
 }
 
 #[cfg(test)]

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -335,12 +335,14 @@ pub struct RequestIdManager {
 	max_concurrent_requests: usize,
 	/// Get the next request ID.
 	current_id: AtomicU64,
+	/// Request ID type.
+	id_kind: IdKind,
 }
 
 impl RequestIdManager {
 	/// Create a new `RequestIdGuard` with the provided concurrency limit.
-	pub fn new(limit: usize) -> Self {
-		Self { current_pending: Arc::new(()), max_concurrent_requests: limit, current_id: AtomicU64::new(0) }
+	pub fn new(limit: usize, id_kind: IdKind) -> Self {
+		Self { current_pending: Arc::new(()), max_concurrent_requests: limit, current_id: AtomicU64::new(0), id_kind }
 	}
 
 	fn get_slot(&self) -> Result<Arc<()>, Error> {
@@ -355,20 +357,21 @@ impl RequestIdManager {
 	/// Attempts to get the next request ID.
 	///
 	/// Fails if request limit has been exceeded.
-	pub fn next_request_id(&self) -> Result<RequestIdGuard<u64>, Error> {
+	pub fn next_request_id(&self) -> Result<RequestIdGuard<Id<'static>>, Error> {
 		let rc = self.get_slot()?;
-		let id = self.current_id.fetch_add(1, Ordering::SeqCst);
+		let id = self.id_kind.into_id(self.current_id.fetch_add(1, Ordering::SeqCst));
 		Ok(RequestIdGuard { _rc: rc, id })
 	}
 
 	/// Attempts to get the `n` number next IDs that only counts as one request.
 	///
 	/// Fails if request limit has been exceeded.
-	pub fn next_request_ids(&self, len: usize) -> Result<RequestIdGuard<Vec<u64>>, Error> {
+	pub fn next_request_ids(&self, len: usize) -> Result<RequestIdGuard<Vec<Id<'static>>>, Error> {
 		let rc = self.get_slot()?;
 		let mut ids = Vec::with_capacity(len);
 		for _ in 0..len {
-			ids.push(self.current_id.fetch_add(1, Ordering::SeqCst));
+			let id = self.id_kind.into_id(self.current_id.fetch_add(1, Ordering::SeqCst));
+			ids.push(id);
 		}
 		Ok(RequestIdGuard { _rc: rc, id: ids })
 	}
@@ -376,16 +379,16 @@ impl RequestIdManager {
 
 /// Reference counted request ID.
 #[derive(Debug)]
-pub struct RequestIdGuard<T> {
+pub struct RequestIdGuard<T: Clone> {
 	id: T,
 	/// Reference count decreased when dropped.
 	_rc: Arc<()>,
 }
 
-impl<T> RequestIdGuard<T> {
-	/// Get the actual ID.
-	pub fn inner(&self) -> &T {
-		&self.id
+impl<T: Clone> RequestIdGuard<T> {
+	/// Get the actual ID or IDs.
+	pub fn inner(&self) -> T {
+		self.id.clone()
 	}
 }
 
@@ -399,7 +402,7 @@ pub enum CertificateStore {
 	WebPki,
 }
 
-/// JSON-RPC request object id format.
+/// JSON-RPC request object id data type.
 #[derive(Debug, Copy, Clone)]
 pub enum IdKind {
 	/// String.
@@ -408,13 +411,22 @@ pub enum IdKind {
 	Number,
 }
 
+impl IdKind {
+	fn into_id(self, id: u64) -> Id<'static> {
+		match self {
+			IdKind::Number => Id::Number(id),
+			IdKind::String => Id::Str(format!("{}", id).into()),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
-	use super::RequestIdManager;
+	use super::{IdKind, RequestIdManager};
 
 	#[test]
 	fn request_id_guard_works() {
-		let manager = RequestIdManager::new(2);
+		let manager = RequestIdManager::new(2, IdKind::Number);
 		let _first = manager.next_request_id().unwrap();
 
 		{

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use helpers::{http_server, http_server_with_access_control, websocket_server, websocket_server_with_subscription};
-use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
+use jsonrpsee::core::client::{ClientT, IdKind, Subscription, SubscriptionClientT};
 use jsonrpsee::core::error::SubscriptionClosedReason;
 use jsonrpsee::core::{Error, JsonValue};
 use jsonrpsee::http_client::HttpClientBuilder;
@@ -81,10 +81,28 @@ async fn ws_method_call_works() {
 }
 
 #[tokio::test]
+async fn ws_method_call_str_id_works() {
+	let server_addr = websocket_server().await;
+	let server_url = format!("ws://{}", server_addr);
+	let client = WsClientBuilder::default().id_format(IdKind::String).build(&server_url).await.unwrap();
+	let response: String = client.request("say_hello", None).await.unwrap();
+	assert_eq!(&response, "hello");
+}
+
+#[tokio::test]
 async fn http_method_call_works() {
 	let (server_addr, _handle) = http_server().await;
 	let uri = format!("http://{}", server_addr);
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
+	let response: String = client.request("say_hello", None).await.unwrap();
+	assert_eq!(&response, "hello");
+}
+
+#[tokio::test]
+async fn http_method_call_str_id_works() {
+	let (server_addr, _handle) = http_server().await;
+	let uri = format!("http://{}", server_addr);
+	let client = HttpClientBuilder::default().id_format(IdKind::String).build(&uri).unwrap();
 	let response: String = client.request("say_hello", None).await.unwrap();
 	assert_eq!(&response, "hello");
 }

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -350,7 +350,7 @@ impl<'a> SubscriptionId<'a> {
 }
 
 /// Request Id
-#[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize, PartialOrd, Ord)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum Id<'a> {

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -91,7 +91,7 @@ pub struct RequestSer<'a> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Request ID
-	pub id: Id<'a>,
+	pub id: &'a Id<'a>,
 	/// Name of the method to be invoked.
 	// NOTE: as this type only implements serialize
 	// `#[serde(borrow)]` and `Cow<'a, str>` is not needed.
@@ -103,7 +103,7 @@ pub struct RequestSer<'a> {
 
 impl<'a> RequestSer<'a> {
 	/// Create a new serializable JSON-RPC request.
-	pub fn new(id: Id<'a>, method: &'a str, params: Option<ParamsSer<'a>>) -> Self {
+	pub fn new(id: &'a Id<'a>, method: &'a str, params: Option<ParamsSer<'a>>) -> Self {
 		Self { jsonrpc: TwoPointZero, id, method, params }
 	}
 }
@@ -213,16 +213,16 @@ mod test {
 			// With all fields set.
 			(
 				r#"{"jsonrpc":"2.0","id":1,"method":"subtract","params":[42,23]}"#,
-				Some(id.clone()),
+				Some(&id),
 				Some(params.clone()),
 				method,
 			),
 			// Escaped method name.
-			(r#"{"jsonrpc":"2.0","id":1,"method":"\"m"}"#, Some(id.clone()), None, "\"m"),
+			(r#"{"jsonrpc":"2.0","id":1,"method":"\"m"}"#, Some(&id), None, "\"m"),
 			// Without ID field.
 			(r#"{"jsonrpc":"2.0","id":null,"method":"subtract","params":[42,23]}"#, None, Some(params), method),
 			// Without params field
-			(r#"{"jsonrpc":"2.0","id":1,"method":"subtract"}"#, Some(id), None, method),
+			(r#"{"jsonrpc":"2.0","id":1,"method":"subtract"}"#, Some(&id), None, method),
 			// Without params and ID.
 			(r#"{"jsonrpc":"2.0","id":null,"method":"subtract"}"#, None, None, method),
 		];
@@ -231,7 +231,7 @@ mod test {
 			let request = serde_json::to_string(&RequestSer {
 				jsonrpc: TwoPointZero,
 				method,
-				id: id.unwrap_or(Id::Null),
+				id: id.unwrap_or(&Id::Null),
 				params,
 			})
 			.unwrap();


### PR DESCRIPTION
Supersedes #644

It makes it possible to configure the clients to generate `request object ID` as a strings instead of numbers, I did the most simple way and converting the `numeric ID` to strings from the `RequestIdManager`. 

We might want to use some more optimized `itoa` instead of format in future or generate random IDs.

However, `numeric ids` is still default because it avoids some allocations.

The rationale behind this is that some `JSON-RPC servers` suffers from the issue where they can't decode `Id` as numbers because of the `serde-json arbritary-precision` bug, so this is a workaround for that.

//cc @whalelephant I think this should be what you need right? 