### PR TITLE
refactor(ws server): impl `IdProvider` for Box<T> 

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,9 @@ license = "MIT"
 anyhow = "1"
 arrayvec = "0.7.1"
 async-trait = "0.1"
-beef = { version = "0.5.1", features = ["impl_serde"] }
 async-channel = { version = "1.6", optional = true }
+beef = { version = "0.5.1", features = ["impl_serde"] }
+dyn-clonable = "0.9.0"
 thiserror = "1"
 futures-channel = { version = "0.3.14", default-features = false }
 futures-util = { version = "0.3.14", default-features = false, optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,6 @@ arrayvec = "0.7.1"
 async-trait = "0.1"
 async-channel = { version = "1.6", optional = true }
 beef = { version = "0.5.1", features = ["impl_serde"] }
-dyn-clonable = "0.9.0"
 thiserror = "1"
 futures-channel = { version = "0.3.14", default-features = false }
 futures-util = { version = "0.3.14", default-features = false, optional = true }

--- a/core/src/id_providers.rs
+++ b/core/src/id_providers.rs
@@ -31,7 +31,7 @@ use crate::traits::IdProvider;
 use jsonrpsee_types::SubscriptionId;
 
 /// Generates random integers as subscription ID.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RandomIntegerIdProvider;
 
 impl IdProvider for RandomIntegerIdProvider {
@@ -42,7 +42,7 @@ impl IdProvider for RandomIntegerIdProvider {
 }
 
 /// Generates random strings of length `len` as subscription ID.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RandomStringIdProvider {
 	len: usize,
 }
@@ -62,7 +62,7 @@ impl IdProvider for RandomStringIdProvider {
 }
 
 /// No-op implementation to be used for servers that don't support subscriptions.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NoopIdProvider;
 
 impl IdProvider for NoopIdProvider {

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -76,7 +76,7 @@ pub trait IdProvider: Send + Sync + std::fmt::Debug {
 	fn next_id(&self) -> SubscriptionId<'static>;
 }
 
-impl<T: IdProvider> IdProvider for Box<T> {
+impl<T: IdProvider + ?Sized> IdProvider for Box<T> {
 	fn next_id(&self) -> SubscriptionId<'static> {
 		(**self).next_id()
 	}

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -76,6 +76,11 @@ pub trait IdProvider: Send + Sync + std::fmt::Debug {
 	fn next_id(&self) -> SubscriptionId<'static>;
 }
 
+// Implement `IdProvider` for `Box<T>`
+//
+// It's not implemented for `&'_ T` because
+// of the required `'static lifetime`
+// Thus, `&dyn IdProvider` won't work.
 impl<T: IdProvider + ?Sized> IdProvider for Box<T> {
 	fn next_id(&self) -> SubscriptionId<'static> {
 		(**self).next_id()

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -71,8 +71,13 @@ tuple_impls! {
 }
 
 /// Trait to generate subscription IDs.
-#[dyn_clonable::clonable]
-pub trait IdProvider: Send + Sync + Clone + std::fmt::Debug {
+pub trait IdProvider: Send + Sync + std::fmt::Debug {
 	/// Returns the next ID for the subscription.
 	fn next_id(&self) -> SubscriptionId<'static>;
+}
+
+impl<T: IdProvider> IdProvider for Box<T> {
+	fn next_id(&self) -> SubscriptionId<'static> {
+		(**self).next_id()
+	}
 }

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -71,7 +71,8 @@ tuple_impls! {
 }
 
 /// Trait to generate subscription IDs.
-pub trait IdProvider: Send + Sync {
+#[dyn_clonable::clonable]
+pub trait IdProvider: Send + Sync + Clone + std::fmt::Debug {
 	/// Returns the next ID for the subscription.
 	fn next_id(&self) -> SubscriptionId<'static>;
 }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -27,6 +27,7 @@
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::future::{FutureDriver, ServerHandle, StopMonitor};
@@ -60,7 +61,7 @@ pub struct Server<M> {
 	stop_monitor: StopMonitor,
 	resources: Resources,
 	middleware: M,
-	id_provider: Box<dyn IdProvider>,
+	id_provider: Arc<dyn IdProvider>,
 }
 
 impl<M> std::fmt::Debug for Server<M> {
@@ -213,7 +214,7 @@ enum HandshakeResponse<'a, M> {
 		cfg: &'a Settings,
 		stop_monitor: &'a StopMonitor,
 		middleware: M,
-		id_provider: Box<dyn IdProvider>,
+		id_provider: Arc<dyn IdProvider>,
 	},
 }
 
@@ -288,7 +289,7 @@ async fn background_task(
 	max_request_body_size: u32,
 	stop_server: StopMonitor,
 	middleware: impl Middleware,
-	id_provider: Box<dyn IdProvider>,
+	id_provider: Arc<dyn IdProvider>,
 ) -> Result<(), Error> {
 	// And we can finally transition to a websocket background_task.
 	let mut builder = server.into_builder();
@@ -647,7 +648,7 @@ pub struct Builder<M = ()> {
 	settings: Settings,
 	resources: Resources,
 	middleware: M,
-	id_provider: Box<dyn IdProvider>,
+	id_provider: Arc<dyn IdProvider>,
 }
 
 impl<M> std::fmt::Debug for Builder<M> {
@@ -662,7 +663,7 @@ impl Default for Builder {
 			settings: Settings::default(),
 			resources: Resources::default(),
 			middleware: (),
-			id_provider: Box::new(RandomIntegerIdProvider),
+			id_provider: Arc::new(RandomIntegerIdProvider),
 		}
 	}
 }
@@ -818,8 +819,8 @@ impl<M> Builder<M> {
 	///
 	/// let builder = WsServerBuilder::default().set_id_provider(RandomStringIdProvider::new(16));
 	/// ```
-	pub fn set_id_provider(mut self, id_provider: Box<dyn IdProvider>) -> Self {
-		self.id_provider = id_provider;
+	pub fn set_id_provider<I: IdProvider + 'static>(mut self, id_provider: I) -> Self {
+		self.id_provider = Arc::new(id_provider);
 		self
 	}
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -70,6 +70,8 @@ impl<M> std::fmt::Debug for Server<M> {
 			.field("listener", &self.listener)
 			.field("cfg", &self.cfg)
 			.field("stop_monitor", &self.stop_monitor)
+			.field("id_provider", &self.id_provider)
+			.field("resources", &self.resources)
 			.finish()
 	}
 }
@@ -644,17 +646,12 @@ impl Default for Settings {
 }
 
 /// Builder to configure and create a JSON-RPC Websocket server
+#[derive(Debug)]
 pub struct Builder<M = ()> {
 	settings: Settings,
 	resources: Resources,
 	middleware: M,
 	id_provider: Arc<dyn IdProvider>,
-}
-
-impl<M> std::fmt::Debug for Builder<M> {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("Builder").field("settings", &self.settings).field("resources", &self.resources).finish()
-	}
 }
 
 impl Default for Builder {
@@ -810,6 +807,9 @@ impl<M> Builder<M> {
 	/// Configure custom `subscription ID` provider for the server to use
 	/// to when getting new subscription calls.
 	///
+	/// You may choose static dispatch or dynamic dispatch because
+	/// `IdProvider` is implemented for `Box<T>`.
+	///
 	/// Default: [`RandomIntegerIdProvider`].
 	///
 	/// # Examples
@@ -817,8 +817,13 @@ impl<M> Builder<M> {
 	/// ```rust
 	/// use jsonrpsee_ws_server::{WsServerBuilder, RandomStringIdProvider, IdProvider};
 	///
-	/// let builder = WsServerBuilder::default().set_id_provider(RandomStringIdProvider::new(16));
+	/// // static dispatch
+	/// let builder1 = WsServerBuilder::default().set_id_provider(RandomStringIdProvider::new(16));
+	///
+	/// // or dynamic dispatch
+	/// let builder2 = WsServerBuilder::default().set_id_provider(Box::new(RandomStringIdProvider::new(16)));
 	/// ```
+	///
 	pub fn set_id_provider<I: IdProvider + 'static>(mut self, id_provider: I) -> Self {
 		self.id_provider = Arc::new(id_provider);
 		self

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -631,7 +631,7 @@ async fn unsubscribe_wrong_sub_id_type() {
 }
 
 #[tokio::test]
-async fn custom_subscription_boxed_id_works() {
+async fn custom_boxed_subscription_id_works() {
 	#[derive(Debug, Clone)]
 	struct HardcodedSubscriptionId;
 

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -631,7 +631,7 @@ async fn unsubscribe_wrong_sub_id_type() {
 }
 
 #[tokio::test]
-async fn custom_subscription_id_works() {
+async fn custom_subscription_boxed_id_works() {
 	#[derive(Debug, Clone)]
 	struct HardcodedSubscriptionId;
 

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -632,6 +632,7 @@ async fn unsubscribe_wrong_sub_id_type() {
 
 #[tokio::test]
 async fn custom_subscription_id_works() {
+	#[derive(Debug, Clone)]
 	struct HardcodedSubscriptionId;
 
 	impl IdProvider for HardcodedSubscriptionId {
@@ -642,7 +643,7 @@ async fn custom_subscription_id_works() {
 
 	init_logger();
 	let server = WsServerBuilder::default()
-		.set_id_provider(HardcodedSubscriptionId)
+		.set_id_provider(Box::new(HardcodedSubscriptionId))
 		.build("127.0.0.1:0")
 		.with_default_timeout()
 		.await

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -631,7 +631,7 @@ async fn unsubscribe_wrong_sub_id_type() {
 }
 
 #[tokio::test]
-async fn custom_boxed_subscription_id_works() {
+async fn custom_subscription_id_works() {
 	#[derive(Debug, Clone)]
 	struct HardcodedSubscriptionId;
 
@@ -643,7 +643,7 @@ async fn custom_boxed_subscription_id_works() {
 
 	init_logger();
 	let server = WsServerBuilder::default()
-		.set_id_provider(Box::new(HardcodedSubscriptionId))
+		.set_id_provider(HardcodedSubscriptionId)
 		.build("127.0.0.1:0")
 		.with_default_timeout()
 		.await


### PR DESCRIPTION
Implement `IdProvider` for `Box<T>` to support `Box<dyn IdProvider>`, in addition I also added `std::fmt::Debug` to the IdProvider.

//cc @maciejhirsz 
I had a look how difficult it would be to make this purely static dispatch because currently we pass `dyn IdProvider` to the RpcModule if the call is a subscription,

Then we would have to add a type param on `Methods`, `RpcModule` and related types and the only user-facing would be the the `RpcModule` which is a bit annoying but it would kill the extra indirection's. The benefit of this is that we could get rid of the `Arc<dyn IdProvider>` to `I: IdProvider` and require `Clone` on IdProvider.