### PR TITLE
CI: try nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,32 @@ jobs:
           command: test
           args: --workspace
 
+  nextests:
+    name: Run nextests on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          version: 0.9
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Cargo nextest
+        run: cargo nextest run --workspace
+
   tests_macos:
     name: Run tests macos
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,30 +69,7 @@ jobs:
       - name: Cargo check all targets and features
         run: cargo hack check --workspace --each-feature --all-targets
 
-  tests:
-    name: Run tests Ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2.4.0
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v1.3.0
-
-      - name: Cargo test
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --workspace
-
-  nextests:
+  tests_ubuntu:
     name: Run nextests on Ubuntu
     runs-on: ubuntu-latest
     steps:
@@ -132,14 +109,17 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          version: 0.9
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --workspace
+      - name: Cargo nextest
+        run: cargo nextest run --workspace
 
   tests_windows:
     name: Run tests Windows
@@ -155,11 +135,14 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          version: 0.9
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --workspace
+      - name: Cargo nextest
+        run: cargo nextest run --workspace


### PR DESCRIPTION
An attempt to switch to [`cargo-nextest`](https://github.com/nextest-rs/nextest).

Note it [doesn't support doctests](https://github.com/nextest-rs/nextest/issues/16) so they should be run separately.
@dvdplm @niklasad1 could you suggest a good way of getting the list of doctests please?

---

Oh lovely.
So `nextest` with some cache (on the second run) performed like this
![image](https://user-images.githubusercontent.com/17856421/154104323-01d7dbea-d12a-4209-9621-67cb7b3f0af3.png)

instead of a regular `cargo test`
![image](https://user-images.githubusercontent.com/17856421/154104206-511a57f7-0bfd-4441-893b-3feeacd59a26.png)

it's worth mentioning though that without cache it takes another ~3m30s to install the tool. Thankfully, there's a cached [`cargo-install`](https://github.com/marketplace/actions/cargo-install).
![image](https://user-images.githubusercontent.com/17856421/154104604-5eed1994-9edc-4bc6-b438-3b612e9ab361.png)
