### PR TITLE
Replace async-channel

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 anyhow = "1"
 arrayvec = "0.7.1"
 async-trait = "0.1"
-async-channel = { version = "1.6", optional = true }
 beef = { version = "0.5.1", features = ["impl_serde"] }
 thiserror = "1"
 futures-channel = { version = "0.3.14", default-features = false }
@@ -30,7 +29,6 @@ tokio = { version = "1.8", features = ["rt", "sync"], optional = true }
 default = []
 http-helpers = ["futures-util"]
 server = [
-	"async-channel",
 	"futures-util",
 	"rustc-hash",
 	"tracing",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 anyhow = "1"
 arrayvec = "0.7.1"
 async-trait = "0.1"
-async-channel = { version = "1.6", optional = true }
 beef = { version = "0.5.1", features = ["impl_serde"] }
 thiserror = "1"
 futures-channel = { version = "0.3.14", default-features = false }
@@ -24,26 +23,27 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
 parking_lot = { version = "0.12", optional = true }
-tokio = { version = "1.8", features = ["rt", "sync"], optional = true }
+tokio = { version = "1.8", optional = true }
 
 [features]
 default = []
 http-helpers = ["futures-util"]
 server = [
-	"async-channel",
 	"futures-util",
 	"rustc-hash",
 	"tracing",
 	"parking_lot",
 	"rand",
-	"tokio",
+	"tokio/rt",
+	"tokio/sync",
 ]
 client = ["futures-util"]
 async-client = [
 	"client",
 	"rustc-hash",
-	"tokio/sync",
 	"tokio/macros",
+	"tokio/rt",
+	"tokio/sync",
 	"tokio/time",
 	"tracing"
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
 parking_lot = { version = "0.12", optional = true }
-tokio = { version = "1.8", features = ["rt"], optional = true }
+tokio = { version = "1.8", features = ["rt", "sync"], optional = true }
 
 [features]
 default = []

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -904,7 +904,9 @@ impl Subscription {
 	/// Close the subscription channel.
 	pub fn close(&mut self) {
 		tracing::trace!("[Subscription::close] Notifying");
-		self.close_notify.take().and_then(|n| {
+if let Some(n) = self.close_notify.take() { 
+     n.notify_one() 
+}
 			n.notify_one();
 			None::<Arc<Notify>>
 		});

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -377,7 +377,6 @@ impl Methods {
 		let sink = MethodSink::new(tx_sink);
 		let id = req.id.clone();
 		let params = Params::new(req.params.map(|params| params.get()));
-		// TODO: (dp) pretty annoying having to do this for all `inner_call`s. We only need it for subscriptions yeah?
 		let notify = Arc::new(Notify::new());
 
 		let _result = match self.method(&req.method).map(|c| &c.callback) {
@@ -904,12 +903,9 @@ impl Subscription {
 	/// Close the subscription channel.
 	pub fn close(&mut self) {
 		tracing::trace!("[Subscription::close] Notifying");
-if let Some(n) = self.close_notify.take() { 
-     n.notify_one() 
-}
-			n.notify_one();
-			None::<Arc<Notify>>
-		});
+		if let Some(n) = self.close_notify.take() {
+			n.notify_one()
+		}
 	}
 	/// Get the subscription ID
 	pub fn subscription_id(&self) -> &RpcSubscriptionId {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -820,7 +820,7 @@ impl SubscriptionSink {
 		} else {
 			tracing::warn!("[SubscriptionSink::pipe_from_stream] We're closed.");
 			// TODO: (dp) Is this right? Should return `Err`?
-			return Ok(())
+			return Ok(());
 		}
 	}
 

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -66,9 +66,9 @@ pub type ConnectionId = usize;
 
 /// Raw response from an RPC
 /// A 3-tuple containing:
-/// 	- Call result as a `String`,
-/// 	- a [`mpsc::UnboundedReceiver<String>`] to receive future subscription results
-/// 	- a [`tokio::sync::Notify`] to allow subscribers to notify their [`SubscriptionSink`] when they disconnect.
+///   - Call result as a `String`,
+///   - a [`mpsc::UnboundedReceiver<String>`] to receive future subscription results
+///   - a [`tokio::sync::Notify`] to allow subscribers to notify their [`SubscriptionSink`] when they disconnect.
 pub type RawRpcResponse = (String, mpsc::UnboundedReceiver<String>, Arc<Notify>);
 
 /// Helper struct to manage subscriptions.

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -793,7 +793,6 @@ impl SubscriptionSink {
 			let closed_fut = close_notify.notified();
 			pin_mut!(closed_fut);
 			loop {
-				// match futures_util::future::select(item, Box::pin(close_notify.notified())).await {
 				match futures_util::future::select(stream_item, closed_fut).await {
 					// The app sent us a value to send back to the subscribers
 					Either::Left((Some(result), next_closed_fut)) => {
@@ -821,7 +820,7 @@ impl SubscriptionSink {
 			}
 		} else {
 			// The sink is closed.
-			return Ok(());
+			Ok(())
 		}
 	}
 

--- a/proc-macros/tests/ui.rs
+++ b/proc-macros/tests/ui.rs
@@ -5,14 +5,12 @@
 //! Use with `TRYBUILD=overwrite` after updating codebase (see `trybuild` docs for more details on that)
 //! to automatically regenerate `stderr` files, but don't forget to check that new files make sense.
 
-#[ignore = "reason"]
 #[test]
 fn ui_pass() {
 	let t = trybuild::TestCases::new();
 	t.pass("tests/ui/correct/*.rs");
 }
 
-#[ignore = "reason"]
 #[test]
 fn ui_fail() {
 	let t = trybuild::TestCases::new();

--- a/proc-macros/tests/ui.rs
+++ b/proc-macros/tests/ui.rs
@@ -5,12 +5,14 @@
 //! Use with `TRYBUILD=overwrite` after updating codebase (see `trybuild` docs for more details on that)
 //! to automatically regenerate `stderr` files, but don't forget to check that new files make sense.
 
+#[ignore = "reason"]
 #[test]
 fn ui_pass() {
 	let t = trybuild::TestCases::new();
 	t.pass("tests/ui/correct/*.rs");
 }
 
+#[ignore = "reason"]
 #[test]
 fn ui_fail() {
 	let t = trybuild::TestCases::new();

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,3 +17,4 @@ tracing = "0.1"
 serde = "1"
 serde_json = "1"
 hyper = { version = "0.14", features = ["http1", "client"] }
+tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,3 +18,4 @@ serde = "1"
 serde_json = "1"
 hyper = { version = "0.14", features = ["http1", "client"] }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
+tokio-stream = "0.1"

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -419,7 +419,7 @@ async fn ws_server_cancels_stream_after_reset_conn() {
 	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");
 	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");
 }
-
+// TODO: (dp) Finish this test: check that dropping one subscriber doesn't halt the stream etc
 #[tokio::test]
 async fn ws_server_subscribe_with_stream() {
 	tracing_subscriber::FmtSubscriber::builder()

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -422,14 +422,9 @@ async fn ws_server_cancels_stream_after_reset_conn() {
 	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");
 	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");
 }
-// TODO: (dp) Finish this test: check that dropping one subscriber doesn't halt the stream etc
+
 #[tokio::test]
 async fn ws_server_subscribe_with_stream() {
-	tracing_subscriber::FmtSubscriber::builder()
-		.with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-		.try_init()
-		.expect("setting default subscriber failed");
-
 	use futures::{channel::mpsc, SinkExt, StreamExt};
 	use jsonrpsee::{ws_server::WsServerBuilder, RpcModule};
 

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -468,7 +468,7 @@ async fn ws_server_subscribe_with_stream() {
 	// Sub1 is still in business
 	assert_eq!(sub1.next().await.unwrap().unwrap(), 3);
 
-	// We expect the stream to run five times and should be getting 5 values on `rx`.
+	// We expect two subscription streams complete to and should be getting 2 values on `rx`.
 	// We've read three, so two more expected and then the channel is closed.
 	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");
 	assert_eq!(Some(()), rx.next().await, "subscription stream should be terminated after the client was dropped");

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -451,8 +451,10 @@ async fn ws_server_subscribe_with_stream() {
 	server.start(module).unwrap();
 
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let mut sub1: Subscription<usize> = client.subscribe("subscribe_10_ints", None, "unsubscribe_10_ints").await.unwrap();
-	let mut sub2: Subscription<usize> = client.subscribe("subscribe_10_ints", None, "unsubscribe_10_ints").await.unwrap();
+	let mut sub1: Subscription<usize> =
+		client.subscribe("subscribe_10_ints", None, "unsubscribe_10_ints").await.unwrap();
+	let mut sub2: Subscription<usize> =
+		client.subscribe("subscribe_10_ints", None, "unsubscribe_10_ints").await.unwrap();
 	tracing::info!("[test] Subscribed");
 	let r = sub1.next().await;
 	tracing::debug!("[test] sub1 next: {r:?}");

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -441,7 +441,9 @@ async fn ws_server_subscribe_with_stream() {
 			use futures::task::Poll;
 			let mut int_counter = 1usize;
 			let stream = futures::stream::poll_fn(move |_| -> Poll<Option<usize>> {
-				if int_counter == 10 { return Poll::Ready(None); }
+				if int_counter == 10 {
+					return Poll::Ready(None);
+				}
 				std::thread::sleep(Duration::from_millis(100));
 				let out = Poll::Ready(Some(int_counter));
 				int_counter += 1;

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-server"
 
 [dependencies]
-async-channel = "1.6.1"
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
 jsonrpsee-types = { path = "../types", version = "0.9.0" }

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -473,7 +473,6 @@ async fn background_task(
 				let id_provider = id_provider.clone();
 				let close_notify2 = close_notify.clone();
 
-				// let conn_rx2 = conn_rx.clone();
 				let fut = async move {
 					// Batch responses must be sent back as a single message so we read the results from each
 					// request in the batch and read the results off of a new channel, `rx_batch`, and then send the

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -49,6 +49,7 @@ use soketto::connection::Error as SokettoError;
 use soketto::handshake::{server::Response, Server as SokettoServer};
 use soketto::Sender;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio::sync::Notify;
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
 /// Default maximum connections allowed.
@@ -298,7 +299,9 @@ async fn background_task(
 	builder.set_max_message_size(max_request_body_size as usize);
 	let (mut sender, mut receiver) = builder.finish();
 	let (tx, mut rx) = mpsc::unbounded::<String>();
-	let (conn_tx, conn_rx) = async_channel::unbounded();
+	// let (conn_tx, conn_rx) = async_channel::unbounded();
+	let close_notify = Arc::new(Notify::new());
+	let close_notify_server_stop = close_notify.clone();
 
 	let stop_server2 = stop_server.clone();
 	let sink = MethodSink::new_with_limit(tx, max_request_body_size);
@@ -324,7 +327,8 @@ async fn background_task(
 
 		// Force `conn_tx` to this async block and close it down
 		// when the connection closes to be on safe side.
-		conn_tx.close();
+		// conn_tx.close();
+		close_notify_server_stop.notify_one();
 	});
 
 	// Buffer for incoming data.
@@ -433,8 +437,11 @@ async fn background_task(
 							},
 							MethodKind::Subscription(callback) => match method.claim(&req.method, &resources) {
 								Ok(guard) => {
+									// let close_notify = Arc::new(Notify::new());
+									let cn = close_notify.clone();
 									let conn_state =
-										ConnState { conn_id, close: conn_rx.clone(), id_provider: &*id_provider };
+										ConnState { conn_id, close_notify: cn, id_provider: &*id_provider };
+									// ConnState { conn_id, close_notify: conn_rx.clone(), id_provider: &*id_provider };
 
 									let result = callback(id, params, &sink, conn_state);
 									middleware.on_result(name, result, request_start);
@@ -466,8 +473,9 @@ async fn background_task(
 				let methods = &methods;
 				let sink = sink.clone();
 				let id_provider = id_provider.clone();
+				let close_notify2 = close_notify.clone();
 
-				let conn_rx2 = conn_rx.clone();
+				// let conn_rx2 = conn_rx.clone();
 				let fut = async move {
 					// Batch responses must be sent back as a single message so we read the results from each
 					// request in the batch and read the results off of a new channel, `rx_batch`, and then send the
@@ -533,9 +541,10 @@ async fn background_task(
 										MethodKind::Subscription(callback) => {
 											match method_callback.claim(&req.method, resources) {
 												Ok(guard) => {
+													let cn = close_notify2.clone();
 													let conn_state = ConnState {
 														conn_id,
-														close: conn_rx2.clone(),
+														close_notify: cn,
 														id_provider: &*id_provider,
 													};
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -437,11 +437,9 @@ async fn background_task(
 							},
 							MethodKind::Subscription(callback) => match method.claim(&req.method, &resources) {
 								Ok(guard) => {
-									// let close_notify = Arc::new(Notify::new());
 									let cn = close_notify.clone();
 									let conn_state =
 										ConnState { conn_id, close_notify: cn, id_provider: &*id_provider };
-									// ConnState { conn_id, close_notify: conn_rx.clone(), id_provider: &*id_provider };
 
 									let result = callback(id, params, &sink, conn_state);
 									middleware.on_result(name, result, request_start);
@@ -541,10 +539,10 @@ async fn background_task(
 										MethodKind::Subscription(callback) => {
 											match method_callback.claim(&req.method, resources) {
 												Ok(guard) => {
-													let cn = close_notify2.clone();
+													let close_notify = close_notify2.clone();
 													let conn_state = ConnState {
 														conn_id,
-														close_notify: cn,
+														close_notify,
 														id_provider: &*id_provider,
 													};
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -299,7 +299,6 @@ async fn background_task(
 	builder.set_max_message_size(max_request_body_size as usize);
 	let (mut sender, mut receiver) = builder.finish();
 	let (tx, mut rx) = mpsc::unbounded::<String>();
-	// let (conn_tx, conn_rx) = async_channel::unbounded();
 	let close_notify = Arc::new(Notify::new());
 	let close_notify_server_stop = close_notify.clone();
 
@@ -327,7 +326,6 @@ async fn background_task(
 
 		// Force `conn_tx` to this async block and close it down
 		// when the connection closes to be on safe side.
-		// conn_tx.close();
 		close_notify_server_stop.notify_one();
 	});
 

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -540,11 +540,8 @@ async fn background_task(
 											match method_callback.claim(&req.method, resources) {
 												Ok(guard) => {
 													let close_notify = close_notify2.clone();
-													let conn_state = ConnState {
-														conn_id,
-														close_notify,
-														id_provider: &*id_provider,
-													};
+													let conn_state =
+														ConnState { conn_id, close_notify, id_provider: &*id_provider };
 
 													let result = callback(id, params, &sink_batch, conn_state);
 													middleware.on_result(&req.method, result, request_start);


### PR DESCRIPTION
Replace `async-channel` with `tokio::sync::Notify` to use a dependency less and (possibly?) be a bit faster by using a lighter primitive (maybe?). The problem the `async-channel` is solving is: how does the `SubscriptionSink` know about rude subscribers that leaves without calling `unsubscribe_*`? Using a full-on channel for this might be overkill and this is an attempt at fixing that.

Fixes https://github.com/paritytech/jsonrpsee/issues/691


