### PR TITLE
perf: use async_lock instead of parking_lot

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 anyhow = "1"
 arrayvec = "0.7.1"
 async-trait = "0.1"
+async-lock = { version = "2.4.0", optional = true }
 beef = { version = "0.5.1", features = ["impl_serde"] }
 thiserror = "1"
 futures-channel = { version = "0.3.14", default-features = false }
@@ -29,6 +30,7 @@ tokio = { version = "1.8", optional = true }
 default = []
 http-helpers = ["futures-util"]
 server = [
+	"async-lock",
 	"futures-util",
 	"rustc-hash",
 	"tracing",

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -180,10 +180,10 @@ impl MethodCallback {
 
 	/// Attempt to claim resources prior to executing a method. On success returns a guard that releases
 	/// claimed resources when dropped.
-	pub fn claim(&self, name: &str, resources: &Resources) -> Result<ResourceGuard, Error> {
+	pub async fn claim(&self, name: &str, resources: &Resources) -> Result<ResourceGuard, Error> {
 		match self.resources {
 			MethodResources::Uninitialized(_) => Err(Error::UninitializedMethod(name.into())),
-			MethodResources::Initialized(units) => resources.claim(units),
+			MethodResources::Initialized(units) => resources.claim(units).await,
 		}
 	}
 

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-http-server"
 
 [dependencies]
+async-lock = "2.4.0"
 hyper = { version = "0.14.10", features = ["server", "http1", "http2", "tcp"] }
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false }

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-server"
 
 [dependencies]
+async-lock = "2.4.0"
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
 jsonrpsee-types = { path = "../types", version = "0.9.0" }


### PR DESCRIPTION
`parkint_lot` uses a blocking mutex, i.e. if the lock cannot be obtained immediately, the whole thread is put on hold.
It is a bad practice to use a "classic" mutex in the context of an asynchronous executor like tokio for example.
The threads of the tokio threadpool dedicated to the execution of async tasks must never be put on hold by the operating system, it is up to tokio to manage this directly.
The `parkint_lot` mutex yields to the operating system, while the `async_lock` mutex yields to the chosen asynchronous executor (usually tokio).

There are other asynchronous implementations of mutexes, I chose async_lock because it is the most proven and "light" (it does not impose a particular asynchronous executor to the user).

I left parking_lot at the level of opening subscriptions, because it requires a more complex refactoring, and it is less impacting for the performances (there are in practice much more requests than openings of subscriptions).
But it would be nice to migrate also the opening of subscriptions in a next PR. 

