### PR TITLE
core: remove `Error::Request` variant

### DIFF
--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -147,7 +147,7 @@ impl ClientT for HttpClient {
 			Ok(response) => response,
 			Err(_) => {
 				let err: ErrorResponse = serde_json::from_slice(&body).map_err(Error::ParseError)?;
-				return Err(Error::Request(err.to_string()));
+				return Err(Error::Call(err.error.to_owned()));
 			}
 		};
 
@@ -186,7 +186,7 @@ impl ClientT for HttpClient {
 
 		let rps: Vec<Response<_>> =
 			serde_json::from_slice(&body).map_err(|_| match serde_json::from_slice::<ErrorResponse>(&body) {
-				Ok(e) => Error::Request(e.to_string()),
+				Ok(e) => Error::Call(e.error.to_owned()),
 				Err(e) => Error::ParseError(e),
 			})?;
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -147,7 +147,7 @@ impl ClientT for HttpClient {
 			Ok(response) => response,
 			Err(_) => {
 				let err: ErrorResponse = serde_json::from_slice(&body).map_err(Error::ParseError)?;
-				return Err(Error::Call(err.error.to_owned()));
+				return Err(Error::Call(err.error.to_call_error()));
 			}
 		};
 
@@ -186,7 +186,7 @@ impl ClientT for HttpClient {
 
 		let rps: Vec<Response<_>> =
 			serde_json::from_slice(&body).map_err(|_| match serde_json::from_slice::<ErrorResponse>(&body) {
-				Ok(e) => Error::Call(e.error.to_owned()),
+				Ok(e) => Error::Call(e.error.to_call_error()),
 				Err(e) => Error::ParseError(e),
 			})?;
 

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::types::error::{ErrorCode, ErrorObject, ErrorResponse};
+use crate::types::error::{ErrorCode, ErrorObject};
 use crate::types::ParamsSer;
 use crate::HttpClientBuilder;
 use jsonrpsee_core::client::{ClientT, IdKind};
@@ -33,6 +33,7 @@ use jsonrpsee_core::Error;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::Id;
 use jsonrpsee_test_utils::TimeoutFutureExt;
+use jsonrpsee_types::error::CallError;
 
 #[tokio::test]
 async fn method_call_works() {
@@ -97,34 +98,34 @@ async fn response_with_wrong_id() {
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::MethodNotFound.into());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_owned());
 }
 
 #[tokio::test]
 async fn response_parse_error() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::ParseError.into());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_owned());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::InvalidRequest.into());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_owned());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::InvalidParams.into());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_owned());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorCode::InternalError.into());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_owned());
 }
 
 #[tokio::test]
@@ -171,11 +172,10 @@ async fn run_request_with_response(response: String) -> Result<String, Error> {
 	client.request("say_hello", None).with_default_timeout().await.unwrap()
 }
 
-fn assert_jsonrpc_error_response(err: Error, exp: ErrorObject) {
+fn assert_jsonrpc_error_response(err: Error, exp: CallError) {
 	match &err {
-		Error::Request(e) => {
-			let this: ErrorResponse = serde_json::from_str(e).unwrap();
-			assert_eq!(this.error, exp);
+		Error::Call(e) => {
+			assert_eq!(e.to_string(), exp.to_string());
 		}
 		e => panic!("Expected error: \"{}\", got: {:?}", err, e),
 	};

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -98,34 +98,34 @@ async fn response_with_wrong_id() {
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_owned());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_call_error());
 }
 
 #[tokio::test]
 async fn response_parse_error() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_owned());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_call_error());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_owned());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_call_error());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_owned());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_call_error());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_owned());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_call_error());
 }
 
 #[tokio::test]

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -109,34 +109,34 @@ async fn response_with_wrong_id() {
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_owned());
+	assert_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_call_error());
 }
 
 #[tokio::test]
 async fn parse_error_works() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_owned());
+	assert_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_call_error());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_owned());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_call_error());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_owned());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_call_error());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_owned());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_call_error());
 }
 
 #[tokio::test]

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 #![cfg(test)]
-use crate::types::error::{ErrorCode, ErrorObject, ErrorResponse};
+use crate::types::error::{ErrorCode, ErrorObject};
 use crate::types::ParamsSer;
 use crate::WsClientBuilder;
 use jsonrpsee_core::client::{ClientT, SubscriptionClientT};
@@ -35,6 +35,7 @@ use jsonrpsee_core::Error;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::{Id, WebSocketTestServer};
 use jsonrpsee_test_utils::TimeoutFutureExt;
+use jsonrpsee_types::error::CallError;
 use serde_json::Value as JsonValue;
 
 #[tokio::test]
@@ -108,34 +109,34 @@ async fn response_with_wrong_id() {
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorCode::MethodNotFound.into());
+	assert_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_owned());
 }
 
 #[tokio::test]
 async fn parse_error_works() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorCode::ParseError.into());
+	assert_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_owned());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorCode::InvalidRequest.into());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_owned());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorCode::InvalidParams.into());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_owned());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorCode::InternalError.into());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_owned());
 }
 
 #[tokio::test]
@@ -282,11 +283,10 @@ async fn run_request_with_response(response: String) -> Result<String, Error> {
 	client.request("say_hello", None).with_default_timeout().await.unwrap()
 }
 
-fn assert_error_response(err: Error, exp: ErrorObject) {
+fn assert_error_response(err: Error, exp: CallError) {
 	match &err {
-		Error::Request(e) => {
-			let this: ErrorResponse = serde_json::from_str(e).unwrap();
-			assert_eq!(this.error, exp);
+		Error::Call(e) => {
+			assert_eq!(e.to_string(), exp.to_string());
 		}
 		e => panic!("Expected error: \"{}\", got: {:?}", err, e),
 	};

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -212,12 +212,12 @@ pub(crate) fn process_error_response(manager: &mut RequestManager, err: ErrorRes
 	match manager.request_status(&id) {
 		RequestStatus::PendingMethodCall => {
 			let send_back = manager.complete_pending_call(id).expect("State checked above; qed");
-			let _ = send_back.map(|s| s.send(Err(Error::Call(err.error.to_owned()))));
+			let _ = send_back.map(|s| s.send(Err(Error::Call(err.error.to_call_error()))));
 			Ok(())
 		}
 		RequestStatus::PendingSubscription => {
 			let (_, send_back, _) = manager.complete_pending_subscription(id).expect("State checked above; qed");
-			let _ = send_back.send(Err(Error::Call(err.error.to_owned())));
+			let _ = send_back.send(Err(Error::Call(err.error.to_call_error())));
 			Ok(())
 		}
 		_ => Err(Error::InvalidRequestId),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -56,14 +56,11 @@ impl From<anyhow::Error> for Error {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Error that occurs when a call failed.
-	#[error("Server call failed: {0}")]
+	#[error("JSON-RPC call failed: {0}")]
 	Call(#[from] CallError),
 	/// Networking error or error on the low-level protocol layer.
 	#[error("Networking or low-level protocol error: {0}")]
 	Transport(#[source] anyhow::Error),
-	/// JSON-RPC request error.
-	#[error("JSON-RPC request error: {0:?}")]
-	Request(String),
 	/// Frontend/backend channel error.
 	#[error("Frontend/backend channel error: {0}")]
 	Internal(#[from] futures_channel::mpsc::SendError),

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -338,7 +338,7 @@ impl Methods {
 		}
 
 		if let Ok(err) = serde_json::from_str::<ErrorResponse>(&resp) {
-			return Err(Error::Call(err.error.to_owned()));
+			return Err(Error::Call(err.error.to_call_error()));
 		}
 
 		unreachable!("Invalid JSON-RPC response is not possible using jsonrpsee; this is bug please file an issue");

--- a/tests/tests/resource_limiting.rs
+++ b/tests/tests/resource_limiting.rs
@@ -32,6 +32,7 @@ use jsonrpsee::core::Error;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
 use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::types::error::CallError;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::ws_server::{WsServerBuilder, WsServerHandle};
 use jsonrpsee::RpcModule;
@@ -117,11 +118,9 @@ async fn http_server(module: RpcModule<()>) -> Result<(SocketAddr, HttpServerHan
 
 fn assert_server_busy(fail: Result<String, Error>) {
 	match fail {
-		Err(Error::Request(msg)) => {
-			let err: serde_json::Value = serde_json::from_str(&msg).unwrap();
-
-			assert_eq!(err["error"]["code"], -32604);
-			assert_eq!(err["error"]["message"], "Server is busy, try again later");
+		Err(Error::Call(CallError::Custom { code, message, data: _ })) => {
+			assert_eq!(code, -32604);
+			assert_eq!(message, "Server is busy, try again later");
 		}
 		fail => panic!("Expected error, got: {:?}", fail),
 	}

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -80,8 +80,8 @@ impl<'a> ErrorObject<'a> {
 		Self { code, message: code.message().into(), data }
 	}
 
-	/// Create an owned ErrorObject.
-	pub fn to_owned(self) -> CallError {
+	/// Create an owned ErrorObject via [`CallError`]
+	pub fn to_call_error(self) -> CallError {
 		CallError::Custom {
 			code: self.code.code(),
 			data: self.data.map(|d| d.to_owned()),

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -79,6 +79,15 @@ impl<'a> ErrorObject<'a> {
 	pub fn new(code: ErrorCode, data: Option<&'a RawValue>) -> ErrorObject<'a> {
 		Self { code, message: code.message().into(), data }
 	}
+
+	/// Create an owned ErrorObject.
+	pub fn to_owned(self) -> CallError {
+		CallError::Custom {
+			code: self.code.code(),
+			data: self.data.map(|d| d.to_owned()),
+			message: self.message.into_owned(),
+		}
+	}
 }
 
 impl<'a> From<ErrorCode> for ErrorObject<'a> {

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -613,7 +613,7 @@ impl AllowedValue {
 			if !list.iter().any(|o| o.as_bytes() == value) {
 				let error = format!("{} denied: {}", header, String::from_utf8_lossy(value));
 				tracing::warn!("{}", error);
-				return Err(Error::Request(error));
+				return Err(Error::Custom(error));
 			}
 		}
 


### PR DESCRIPTION
`Error::Call` is redundant to `Error::Request` and was only used in the client to return the String representation of a `JSON-RPC response object` but it doesn't make sense to have when I realized that `RawValue` has the `into_owned API` that I missed ty @gregdhill 

Closing https://github.com/paritytech/jsonrpsee/issues/715