### PR TITLE
feat(http server): add new builder APIs `build_from_tcp` and `build_from_hyper`

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -78,7 +78,9 @@ pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::
 		.max_request_body_size(u32::MAX)
 		.custom_tokio_runtime(handle)
 		.build("127.0.0.1:0")
+		.await
 		.unwrap();
+
 	let mut module = RpcModule::new(());
 	module.register_method(SYNC_METHOD_NAME, |_, _| Ok("lo")).unwrap();
 	module.register_async_method(ASYNC_METHOD_NAME, |_, _| async { Ok("lo") }).unwrap();

--- a/examples/cors_server.rs
+++ b/examples/cors_server.rs
@@ -67,7 +67,8 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<(SocketAddr, HttpServerHandle)> {
 	let acl = AccessControlBuilder::new().allow_all_headers().allow_all_origins().allow_all_hosts().build();
 
-	let server = HttpServerBuilder::default().set_access_control(acl).build("127.0.0.1:0".parse::<SocketAddr>()?)?;
+	let server =
+		HttpServerBuilder::default().set_access_control(acl).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
 
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| {

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<(SocketAddr, HttpServerHandle)> {
-	let server = HttpServerBuilder::default().build("127.0.0.1:0".parse::<SocketAddr>()?)?;
+	let server = HttpServerBuilder::default().build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("lo"))?;
 

--- a/examples/middleware_http.rs
+++ b/examples/middleware_http.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<(SocketAddr, HttpServerHandle)> {
-	let server = HttpServerBuilder::new().set_middleware(Timings).build("127.0.0.1:0")?;
+	let server = HttpServerBuilder::new().set_middleware(Timings).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("lo"))?;
 	let addr = server.local_addr()?;

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -19,7 +19,6 @@ globset = "0.4"
 lazy_static = "1.4"
 tracing = "0.1"
 serde_json = "1"
-socket2 = "0.4"
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros"] }
 unicase = "2.6.0"
 
@@ -27,3 +26,4 @@ unicase = "2.6.0"
 env_logger = "0.9.0"
 jsonrpsee-test-utils = { path = "../test-utils" }
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
+socket2 = "0.4"

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -43,9 +43,7 @@ pub use access_control::{
 };
 pub use jsonrpsee_core::server::rpc_module::RpcModule;
 pub use jsonrpsee_types as types;
-pub use server::{
-	Builder as HttpServerBuilder, HyperTcpConfig, Server as HttpServer, ServerHandle as HttpServerHandle,
-};
+pub use server::{Builder as HttpServerBuilder, Server as HttpServer, ServerHandle as HttpServerHandle};
 pub use tracing;
 
 #[cfg(test)]

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -43,7 +43,9 @@ pub use access_control::{
 };
 pub use jsonrpsee_core::server::rpc_module::RpcModule;
 pub use jsonrpsee_types as types;
-pub use server::{Builder as HttpServerBuilder, Server as HttpServer, ServerHandle as HttpServerHandle};
+pub use server::{
+	Builder as HttpServerBuilder, HyperTcpConfig, Server as HttpServer, ServerHandle as HttpServerHandle,
+};
 pub use tracing;
 
 #[cfg(test)]

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -180,7 +180,7 @@ impl<M> Builder<M> {
 	///
 	///   socket.listen(4096).unwrap();
 	///
-	///   // hyper does some settings on the provided socket, ensure that nothing breaks the our settings.
+	///   // hyper does some settings on the provided socket, ensure that nothing breaks our "expected settings".
 	///   let hyper_cfg = HyperTcpConfig { sleep_on_accept_errors: true, keepalive_timeout: Some(Duration::from_secs(1)), no_delay: true };
 	///
 	///   let server = HttpServerBuilder::new().build_from_tcp(socket, hyper_cfg).unwrap();

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -159,7 +159,7 @@ impl<M> Builder<M> {
 	/// Finalizes the configuration of the server with customized TCP settings on the socket and on hyper.
 	///
 	/// ```rust
-	/// use jsonrpsee_http_server::{HttpServerBuilder, HyperTcpConfig};
+	/// use jsonrpsee_http_server::HttpServerBuilder;
 	/// use socket2::{Domain, Socket, Type};
 	///
 	/// #[tokio::main]
@@ -202,7 +202,7 @@ impl<M> Builder<M> {
 	}
 
 	/// Finalizes the configuration of the server with customized TCP settings on the socket.
-	/// Note, that [`hyper`] might overwrite some of the TCP settings on socket
+	/// Note, that [`hyper`] might overwrite some of the TCP settings on the socket
 	/// if you want full-control of socket settings use [`Builder::build_from_hyper`] instead.
 	///
 	/// ```rust

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -178,9 +178,9 @@ impl<M> Builder<M> {
 	///
 	///   let listener = hyper::Server::from_tcp(socket.into())
 	///     .unwrap()
-	///		.tcp_sleep_on_accept_errors(true)
-	///		.tcp_keepalive(None)
-	///		.tcp_nodelay(true);
+	///     .tcp_sleep_on_accept_errors(true)
+	///     .tcp_keepalive(None)
+	///     .tcp_nodelay(true);
 	///
 	///   let server = HttpServerBuilder::new().build_from_hyper(listener, addr).unwrap();
 	/// }

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -29,7 +29,6 @@ use std::future::Future;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
 
 use crate::response::{internal_error, malformed};
 use crate::{response, AccessControl};
@@ -203,9 +202,11 @@ impl<M> Builder<M> {
 	}
 
 	/// Finalizes the configuration of the server with customized TCP settings on the socket.
+	/// Note, that [`hyper`] might overwrite some of the TCP settings on socket
+	/// if you want full-control of socket settings use [`Builder::build_from_hyper`] instead.
 	///
 	/// ```rust
-	/// use jsonrpsee_http_server::{HttpServerBuilder, HyperTcpConfig};
+	/// use jsonrpsee_http_server::HttpServerBuilder;
 	/// use socket2::{Domain, Socket, Type};
 	/// use std::time::Duration;
 	///
@@ -274,24 +275,6 @@ impl<M> Builder<M> {
 			middleware: self.middleware,
 		})
 	}
-}
-
-/// [`hyper`] does some TCP settings on the socket by default, this type provides a way
-/// to configure it.
-///
-/// This type mimics configurations provided by [`hyper::server::conn::AddrIncoming`].
-#[derive(Debug, Copy, Clone)]
-pub struct HyperTcpConfig {
-	/// Set whether to sleep on accepts errors.
-	pub sleep_on_accept_errors: bool,
-	/// Set whether TCP keepalive messages are enabled on accepted connections.
-	///
-	/// If `None` is specified, keepalive is disabled, otherwise the duration
-	/// specified will be the time to remain idle before sending TCP keepalive
-	/// probes.
-	pub keepalive_timeout: Option<Duration>,
-	/// Set the value of `TCP_NODELAY` option for accepted connections.
-	pub no_delay: bool,
 }
 
 /// Handle used to run or stop the server.

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -161,6 +161,7 @@ impl<M> Builder<M> {
 	/// ```rust
 	/// use jsonrpsee_http_server::HttpServerBuilder;
 	/// use socket2::{Domain, Socket, Type};
+	/// use std::net::TcpListener;
 	///
 	/// #[tokio::main]
 	/// async fn main() {
@@ -173,9 +174,12 @@ impl<M> Builder<M> {
 	///   socket.bind(&address).unwrap();
 	///   socket.listen(4096).unwrap();
 	///
+	///   let listener: TcpListener = socket.into();
+	///   let local_addr = listener.local_addr().ok();
+	///
 	///   // hyper does some settings on the provided socket, ensure that nothing breaks our "expected settings".
 	///
-	///   let listener = hyper::Server::from_tcp(socket.into())
+	///   let listener = hyper::Server::from_tcp(listener)
 	///     .unwrap()
 	///     .tcp_sleep_on_accept_errors(true)
 	///     .tcp_keepalive(None)

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -182,10 +182,10 @@ impl<M> Builder<M> {
 	///
 	///   socket.listen(4096).unwrap();
 	///
-	///   let server = HttpServerBuilder::new().build_from_tcp(socket).await.unwrap();
+	///   let server = HttpServerBuilder::new().build_from_tcp(socket).unwrap();
 	/// }
 	/// ```
-	pub async fn build_from_tcp(self, listener: impl Into<StdTcpListener>) -> Result<Server<M>, Error> {
+	pub fn build_from_tcp(self, listener: impl Into<StdTcpListener>) -> Result<Server<M>, Error> {
 		let listener = listener.into();
 		let local_addr = listener.local_addr().ok();
 		let listener = hyper::Server::from_tcp(listener)?.tcp_nodelay(true);

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -244,7 +244,7 @@ impl<M> Builder<M> {
 /// [`hyper`] does some TCP settings on the socket by default, this type provides a way
 /// to configure it.
 ///
-/// This type mimics configurations provided by [`hyper::server::AddrIncoming`].
+/// This type mimics configurations provided by [`hyper::server::conn::AddrIncoming`].
 #[derive(Debug, Copy, Clone)]
 pub struct HyperTcpConfig {
 	/// Set whether to sleep on accepts errors.

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -38,7 +38,7 @@ use jsonrpsee_test_utils::TimeoutFutureExt;
 use serde_json::Value as JsonValue;
 
 async fn server() -> (SocketAddr, ServerHandle) {
-	let server = HttpServerBuilder::default().build("127.0.0.1:0").unwrap();
+	let server = HttpServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let ctx = TestContext;
 	let mut module = RpcModule::new(ctx);
 	let addr = server.local_addr().unwrap();
@@ -410,7 +410,7 @@ async fn run_forever() {
 async fn can_set_the_max_request_body_size() {
 	let addr = "127.0.0.1:0";
 	// Rejects all requests larger than 100 bytes
-	let server = HttpServerBuilder::default().max_request_body_size(100).build(addr).unwrap();
+	let server = HttpServerBuilder::default().max_request_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx| Ok("a".repeat(100))).unwrap();
 	let addr = server.local_addr().unwrap();
@@ -434,7 +434,7 @@ async fn can_set_the_max_request_body_size() {
 async fn can_set_the_max_response_size() {
 	let addr = "127.0.0.1:0";
 	// Set the max response size to 100 bytes
-	let server = HttpServerBuilder::default().max_response_body_size(100).build(addr).unwrap();
+	let server = HttpServerBuilder::default().max_response_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx| Ok("a".repeat(101))).unwrap();
 	let addr = server.local_addr().unwrap();

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -121,7 +121,7 @@ pub async fn http_server() -> (SocketAddr, HttpServerHandle) {
 }
 
 pub async fn http_server_with_access_control(acl: AccessControl) -> (SocketAddr, HttpServerHandle) {
-	let server = HttpServerBuilder::default().set_access_control(acl).build("127.0.0.1:0").unwrap();
+	let server = HttpServerBuilder::default().set_access_control(acl).build("127.0.0.1:0").await.unwrap();
 	let mut module = RpcModule::new(());
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| Ok("hello")).unwrap();

--- a/tests/tests/middleware.rs
+++ b/tests/tests/middleware.rs
@@ -126,7 +126,8 @@ async fn http_server(module: RpcModule<()>, counter: Counter) -> Result<(SocketA
 		.register_resource("CPU", 6, 2)?
 		.register_resource("MEM", 10, 1)?
 		.set_middleware(counter)
-		.build("127.0.0.1:0")?;
+		.build("127.0.0.1:0")
+		.await?;
 
 	let addr = server.local_addr()?;
 	let handle = server.start(module)?;

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -308,7 +308,7 @@ async fn multiple_blocking_calls_overlap() {
 
 #[tokio::test]
 async fn subscriptions_do_not_work_for_http_servers() {
-	let htserver = HttpServerBuilder::default().build("127.0.0.1:0").unwrap();
+	let htserver = HttpServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = htserver.local_addr().unwrap();
 	let htserver_url = format!("http://{}", addr);
 	let _handle = htserver.start(RpcServerImpl.into_rpc()).unwrap();

--- a/tests/tests/resource_limiting.rs
+++ b/tests/tests/resource_limiting.rs
@@ -107,7 +107,8 @@ async fn http_server(module: RpcModule<()>) -> Result<(SocketAddr, HttpServerHan
 	let server = HttpServerBuilder::default()
 		.register_resource("CPU", 6, 2)?
 		.register_resource("MEM", 10, 1)?
-		.build("127.0.0.1:0")?;
+		.build("127.0.0.1:0")
+		.await?;
 
 	let addr = server.local_addr()?;
 	let handle = server.start(module)?;


### PR DESCRIPTION
Before the HTTP server configured the socket explictly but this PR changes to use `tokio::net::TcpListener` similar to what the `WsServer does`

In addition this PR adds another API for users to provide their own TcpListener, see the inline example I added with socket2.

Example:


 ```rust
	/// use jsonrpsee_http_server::HttpServerBuilder;
	/// use socket2::{Domain, Socket, Type};
	///
	/// #[tokio::main]
	/// async fn main() {
	///   let addr = "127.0.0.1:0".parse().unwrap();
	///   let domain = Domain::for_address(addr);
	///   let socket = Socket::new(domain, Type::STREAM, None).unwrap();
	///   socket.set_nodelay(true).unwrap();
	///   socket.set_reuse_address(true).unwrap();
	///   socket.set_nonblocking(true).unwrap();
	///   socket.set_keepalive(true).unwrap();
	///
	///   let address = addr.into();
	///   socket.bind(&address).unwrap();
	///
	///   socket.listen(4096).unwrap();
	///
	///   let server = HttpServerBuilder::new().build_from_tcp(socket).await.unwrap();
	/// }
	/// ```

```
