### PR TITLE
feat: add  `SubscriptionSink::pipe_from_try_stream` to support streams that returns `Result`

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -179,7 +179,7 @@ impl SubscriptionClosed {
 
 /// A type to represent when a subscription gets closed
 /// by either the server or client side.
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub enum SubscriptionClosedReason {
 	/// The subscription was closed by calling the unsubscribe method.
 	Unsubscribed,

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -764,7 +764,7 @@ impl SubscriptionSink {
 	/// when items gets produced by the stream.
 	///
 	/// Returns `Ok(())` if the stream or connection was terminated.
-	/// Returns `Err(_)` if the underlying stream return an error or if an item from the stream could not be serialized.
+	/// Returns `Err(_)` if the underlying stream returns an error or if an item from the stream could not be serialized.
 	///
 	/// # Examples
 	///

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -288,7 +288,7 @@ pub(crate) mod visitor;
 ///         // as subscription responses.
 ///         fn sub_override_notif_method(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
 ///             tokio::spawn(async move {
-///                 let stream = futures_util::stream::iter(["one", "two", "three"]);
+///                 let stream = futures_util::stream::iter([Ok::<_, &str>("one"), Ok("two"), Ok("three")]);
 ///                 sink.pipe_from_stream(stream).await;
 ///             });
 ///

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -288,7 +288,7 @@ pub(crate) mod visitor;
 ///         // as subscription responses.
 ///         fn sub_override_notif_method(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
 ///             tokio::spawn(async move {
-///                 let stream = futures_util::stream::iter([Ok::<_, &str>("one"), Ok("two"), Ok("three")]);
+///                 let stream = futures_util::stream::iter(["one", "two", "three"]);
 ///                 sink.pipe_from_stream(stream).await;
 ///             });
 ///

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -399,7 +399,7 @@ async fn ws_server_cancels_stream_after_reset_conn() {
 	module
 		.register_subscription("subscribe_never_produce", "n", "unsubscribe_never_produce", |_, sink, mut tx| {
 			// create stream that doesn't produce items.
-			let stream = futures::stream::empty::<usize>();
+			let stream = futures::stream::empty::<usize>().map(|i| Ok::<_, Error>(i));
 			tokio::spawn(async move {
 				sink.pipe_from_stream(stream).await.unwrap();
 				let send_back = Arc::make_mut(&mut tx);
@@ -437,7 +437,8 @@ async fn ws_server_subscribe_with_stream() {
 		.register_subscription("subscribe_5_ints", "n", "unsubscribe_5_ints", |_, sink, _| {
 			tokio::spawn(async move {
 				let interval = interval(Duration::from_millis(50));
-				let stream = IntervalStream::new(interval).zip(futures::stream::iter(1..=5)).map(|(_, c)| c);
+				let stream =
+					IntervalStream::new(interval).zip(futures::stream::iter(1..=5)).map(|(_, c)| Ok::<_, Error>(c));
 
 				sink.pipe_from_stream(stream).await.unwrap();
 			});

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -459,7 +459,6 @@ async fn ws_server_cancels_sub_stream_after_err() {
 	let exp = SubscriptionClosed::new(SubscriptionClosedReason::Server(err.to_string()));
 	// The server closed down the subscription with the underlying error from the stream.
 	assert!(matches!(sub.next().await, Some(Err(Error::SubscriptionClosed(close_reason))) if close_reason == exp));
-	sub.next().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
The rationale for this is that it is more flexible for use cases when `Stream<Item = Result<T, Error>>`.

Take for example `tokio_stream::Broadcast` then one would have to something like:

```rust
   let stream = BroadcastStream::new(rx).take_while(|r| future::ready(r.is_ok())).filter_map(|r| future::ready(r.ok()));
```

Note, I realized that `pipe_from_stream` will work if Error: Serialize bound is satisfied but that's unlikely for the error types but I  added a comment about that