### PR TITLE
refactor(log): downgrade send errors to `warn`

### DIFF
--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -134,7 +134,7 @@ impl MethodSink {
 		};
 
 		if let Err(err) = self.tx.unbounded_send(json) {
-			tracing::error!("Error sending response to the client: {:?}", err);
+			tracing::warn!("Error sending response {:?}", err);
 			false
 		} else {
 			true
@@ -153,7 +153,7 @@ impl MethodSink {
 		};
 
 		if let Err(err) = self.tx.unbounded_send(json) {
-			tracing::error!("Could not send error response to the client: {:?}", err)
+			tracing::warn!("Error sending response {:?}", err);
 		}
 
 		false

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -315,7 +315,7 @@ async fn background_task(
 			if let Some(response) = rx.next().await {
 				// If websocket message send fail then terminate the connection.
 				if let Err(err) = send_ws_message(&mut sender, response).await {
-					tracing::error!("WS transport error: {:?}; terminate connection", err);
+					tracing::warn!("WS send error: {}; terminate connection", err);
 					break;
 				}
 			} else {
@@ -362,7 +362,7 @@ async fn background_task(
 					}
 					// These errors can not be gracefully handled, so just log them and terminate the connection.
 					MonitoredError::Selector(err) => {
-						tracing::error!("WS transport error: {:?} => terminating connection {}", err, conn_id);
+						tracing::warn!("WS error: {}; terminate connection {}", err, conn_id);
 						sink.close();
 						break Err(err.into());
 					}
@@ -567,7 +567,7 @@ async fn background_task(
 							let results = collect_batch_response(rx_batch).await;
 
 							if let Err(err) = sink.send_raw(results) {
-								tracing::error!("Error sending batch response to the client: {:?}", err)
+								tracing::warn!("Error sending batch response to the client: {:?}", err)
 							} else {
 								middleware.on_response(request_start);
 							}


### PR DESCRIPTION
These logs are most likely related to that the client terminated the connection
and they come with significant overhead because it occurs almost on every connection reset.