### PR TITLE
fix(rpc module): fail subscription calls with bad params

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -141,7 +141,8 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::ws
 	let mut module = gen_rpc_module();
 
 	module
-		.register_subscription(SUB_METHOD_NAME, SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, mut sink, _ctx| {
+		.register_subscription(SUB_METHOD_NAME, SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, mut pending, _ctx| {
+			let sink = pending.accept()?;
 			let x = "Hello";
 			tokio::spawn(async move { sink.send(&x) });
 			Ok(())

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -141,8 +141,8 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::ws
 	let mut module = gen_rpc_module();
 
 	module
-		.register_subscription(SUB_METHOD_NAME, SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, mut pending, _ctx| {
-			let sink = pending.accept()?;
+		.register_subscription(SUB_METHOD_NAME, SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, pending, _ctx| {
+			let mut sink = pending.accept()?;
 			let x = "Hello";
 			tokio::spawn(async move { sink.send(&x) });
 			Ok(())

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -143,7 +143,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::ws
 	module
 		.register_subscription(SUB_METHOD_NAME, SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, pending, _ctx| {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			let x = "Hello";

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -142,10 +142,12 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::ws
 
 	module
 		.register_subscription(SUB_METHOD_NAME, SUB_METHOD_NAME, UNSUB_METHOD_NAME, |_params, pending, _ctx| {
-			let mut sink = pending.accept()?;
+			let mut sink = match pending.accept() {
+				Ok(sink) => sink,
+				_ => return,
+			};
 			let x = "Hello";
 			tokio::spawn(async move { sink.send(&x) });
-			Ok(())
 		})
 		.unwrap();
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -32,6 +32,7 @@ use crate::types::{ErrorResponse, Id, NotificationSer, ParamsSer, RequestSer, Re
 use async_trait::async_trait;
 use jsonrpsee_core::client::{CertificateStore, ClientT, IdKind, RequestIdManager, Subscription, SubscriptionClientT};
 use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
+use jsonrpsee_types::error::CallError;
 use rustc_hash::FxHashMap;
 use serde::de::DeserializeOwned;
 
@@ -147,7 +148,7 @@ impl ClientT for HttpClient {
 			Ok(response) => response,
 			Err(_) => {
 				let err: ErrorResponse = serde_json::from_slice(&body).map_err(Error::ParseError)?;
-				return Err(Error::Call(err.error.to_call_error()));
+				return Err(Error::Call(CallError::Custom(err.error.into_owned())));
 			}
 		};
 
@@ -186,7 +187,7 @@ impl ClientT for HttpClient {
 
 		let rps: Vec<Response<_>> =
 			serde_json::from_slice(&body).map_err(|_| match serde_json::from_slice::<ErrorResponse>(&body) {
-				Ok(e) => Error::Call(e.error.to_call_error()),
+				Ok(e) => Error::Call(CallError::Custom(e.error.into_owned())),
 				Err(e) => Error::ParseError(e),
 			})?;
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -148,7 +148,7 @@ impl ClientT for HttpClient {
 			Ok(response) => response,
 			Err(_) => {
 				let err: ErrorResponse = serde_json::from_slice(&body).map_err(Error::ParseError)?;
-				return Err(Error::Call(CallError::Custom(err.error.into_owned())));
+				return Err(Error::Call(CallError::Custom(err.error_object().clone().into_owned())));
 			}
 		};
 
@@ -187,7 +187,7 @@ impl ClientT for HttpClient {
 
 		let rps: Vec<Response<_>> =
 			serde_json::from_slice(&body).map_err(|_| match serde_json::from_slice::<ErrorResponse>(&body) {
-				Ok(e) => Error::Call(CallError::Custom(e.error.into_owned())),
+				Ok(e) => Error::Call(CallError::Custom(e.error_object().clone().into_owned())),
 				Err(e) => Error::ParseError(e),
 			})?;
 

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -33,7 +33,7 @@ use jsonrpsee_core::Error;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::Id;
 use jsonrpsee_test_utils::TimeoutFutureExt;
-use jsonrpsee_types::error::CallError;
+use jsonrpsee_types::error::{CallError, ErrorObjectOwned};
 
 #[tokio::test]
 async fn method_call_works() {
@@ -98,34 +98,34 @@ async fn response_with_wrong_id() {
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_call_error());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).into_owned());
 }
 
 #[tokio::test]
 async fn response_parse_error() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_call_error());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::ParseError).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_call_error());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_call_error());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).into_owned());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_call_error());
+	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InternalError).into_owned());
 }
 
 #[tokio::test]
@@ -172,10 +172,11 @@ async fn run_request_with_response(response: String) -> Result<String, Error> {
 	client.request("say_hello", None).with_default_timeout().await.unwrap()
 }
 
-fn assert_jsonrpc_error_response(err: Error, exp: CallError) {
+fn assert_jsonrpc_error_response(err: Error, exp: ErrorObjectOwned) {
+	let exp = CallError::Custom(exp);
 	match &err {
-		Error::Call(e) => {
-			assert_eq!(e.to_string(), exp.to_string());
+		Error::Call(err) => {
+			assert_eq!(err.to_string(), exp.to_string());
 		}
 		e => panic!("Expected error: \"{}\", got: {:?}", err, e),
 	};

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -35,7 +35,7 @@ use jsonrpsee_core::Error;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::{Id, WebSocketTestServer};
 use jsonrpsee_test_utils::TimeoutFutureExt;
-use jsonrpsee_types::error::CallError;
+use jsonrpsee_types::error::{CallError, ErrorObjectOwned};
 use serde_json::Value as JsonValue;
 
 #[tokio::test]
@@ -109,34 +109,34 @@ async fn response_with_wrong_id() {
 async fn response_method_not_found() {
 	let err =
 		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).to_call_error());
+	assert_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).into_owned());
 }
 
 #[tokio::test]
 async fn parse_error_works() {
 	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::ParseError).to_call_error());
+	assert_error_response(err, ErrorObject::from(ErrorCode::ParseError).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
 	let err =
 		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).to_call_error());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
 	let err =
 		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).to_call_error());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).into_owned());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
 	let err =
 		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
-	assert_error_response(err, ErrorObject::from(ErrorCode::InternalError).to_call_error());
+	assert_error_response(err, ErrorObject::from(ErrorCode::InternalError).into_owned());
 }
 
 #[tokio::test]
@@ -283,7 +283,8 @@ async fn run_request_with_response(response: String) -> Result<String, Error> {
 	client.request("say_hello", None).with_default_timeout().await.unwrap()
 }
 
-fn assert_error_response(err: Error, exp: CallError) {
+fn assert_error_response(err: Error, exp: ErrorObjectOwned) {
+	let exp = CallError::Custom(exp);
 	match &err {
 		Error::Call(e) => {
 			assert_eq!(e.to_string(), exp.to_string());

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -237,17 +237,18 @@ pub(crate) fn build_unsubscribe_message(
 /// Returns `Ok` if the response was successfully sent.
 /// Returns `Err(_)` if the response ID was not found.
 pub(crate) fn process_error_response(manager: &mut RequestManager, err: ErrorResponse) -> Result<(), Error> {
-	let id = err.id.clone().into_owned();
+	let id = err.id().clone().into_owned();
 
 	match manager.request_status(&id) {
 		RequestStatus::PendingMethodCall => {
 			let send_back = manager.complete_pending_call(id).expect("State checked above; qed");
-			let _ = send_back.map(|s| s.send(Err(Error::Call(CallError::Custom(err.error.into_owned())))));
+			let _ =
+				send_back.map(|s| s.send(Err(Error::Call(CallError::Custom(err.error_object().clone().into_owned())))));
 			Ok(())
 		}
 		RequestStatus::PendingSubscription => {
 			let (_, send_back, _) = manager.complete_pending_subscription(id).expect("State checked above; qed");
-			let _ = send_back.send(Err(Error::Call(CallError::Custom(err.error.into_owned()))));
+			let _ = send_back.send(Err(Error::Call(CallError::Custom(err.error_object().clone().into_owned()))));
 			Ok(())
 		}
 		_ => Err(Error::InvalidRequestId),

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -122,10 +122,7 @@ pub(crate) fn process_subscription_close_response(
 		}
 	};
 
-	debug_assert!(
-		manager.remove_subscription(request_id, sub_id).is_some(),
-		"Both request ID and sub ID in RequestManager; qed"
-	);
+	manager.remove_subscription(request_id, sub_id).expect("Both request ID and sub ID in RequestManager; qed");
 	Ok(())
 }
 

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -28,10 +28,10 @@ use std::time::Duration;
 
 use crate::client::async_client::manager::{RequestManager, RequestStatus};
 use crate::client::{RequestMessage, TransportSenderT};
-use crate::error::SubscriptionClosed;
 use crate::Error;
 
 use futures_channel::{mpsc, oneshot};
+use jsonrpsee_types::response::SubscriptionError;
 use jsonrpsee_types::{
 	ErrorResponse, Id, Notification, ParamsSer, RequestSer, Response, SubscriptionId, SubscriptionResponse,
 };
@@ -81,20 +81,15 @@ pub(crate) fn process_subscription_response(
 	let sub_id = response.params.subscription.into_owned();
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
 		Some(request_id) => request_id,
-		None => return Err(None),
+		None => {
+			tracing::error!("Subscription ID: {:?} is not an active subscription", sub_id);
+			return Err(None);
+		}
 	};
 
 	match manager.as_subscription_mut(&request_id) {
-		Some(send_back_sink) => match send_back_sink.try_send(response.params.result.clone()) {
+		Some(send_back_sink) => match send_back_sink.try_send(response.params.result) {
 			// The server sent a subscription closed notification, then close down the subscription.
-			Ok(()) if serde_json::from_value::<SubscriptionClosed>(response.params.result).is_ok() => {
-				if manager.remove_subscription(request_id, sub_id.clone()).is_some() {
-					Ok(())
-				} else {
-					tracing::error!("The server tried to close down an invalid subscription: {:?}", sub_id);
-					Err(None)
-				}
-			}
 			Ok(()) => Ok(()),
 			Err(err) => {
 				tracing::error!("Dropping subscription {:?} error: {:?}", sub_id, err);
@@ -107,6 +102,32 @@ pub(crate) fn process_subscription_response(
 			tracing::error!("Subscription ID: {:?} is not an active subscription", sub_id);
 			Err(None)
 		}
+	}
+}
+
+/// Attempts to process a subscription response.
+///
+/// Returns `Ok()` if the response was successfully sent to the frontend.
+/// Return `Err(None)` if the subscription was not found.
+/// Returns `Err(Some(msg))` if the channel to the `Subscription` was full.
+pub(crate) fn process_subscription_close_response(
+	manager: &mut RequestManager,
+	response: SubscriptionError<JsonValue>,
+) -> Result<(), Option<RequestMessage>> {
+	let sub_id = response.params.subscription.into_owned();
+	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
+		Some(request_id) => request_id,
+		None => {
+			tracing::error!("The server tried to close down an invalid subscription: {:?}", sub_id);
+			return Err(None);
+		}
+	};
+
+	if manager.remove_subscription(request_id, sub_id.clone()).is_some() {
+		Ok(())
+	} else {
+		tracing::error!("The server tried to close down an invalid subscription: {:?}", sub_id);
+		Err(None)
 	}
 }
 

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -90,7 +90,6 @@ pub(crate) fn process_subscription_response(
 
 	match manager.as_subscription_mut(&request_id) {
 		Some(send_back_sink) => match send_back_sink.try_send(response.params.result) {
-			// The server sent a subscription closed notification, then close down the subscription.
 			Ok(()) => Ok(()),
 			Err(err) => {
 				tracing::error!("Dropping subscription {:?} error: {:?}", sub_id, err);

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -4,8 +4,9 @@ mod manager;
 use std::time::Duration;
 
 use crate::client::{
-	BatchMessage, ClientT, RegisterNotificationMessage, RequestMessage, Subscription, SubscriptionClientT,
-	SubscriptionKind, SubscriptionMessage, TransportReceiverT, TransportSenderT,
+	async_client::helpers::process_subscription_close_response, BatchMessage, ClientT, RegisterNotificationMessage,
+	RequestMessage, Subscription, SubscriptionClientT, SubscriptionKind, SubscriptionMessage, TransportReceiverT,
+	TransportSenderT,
 };
 use helpers::{
 	build_unsubscribe_message, call_with_timeout, process_batch_response, process_error_response, process_notification,
@@ -20,7 +21,8 @@ use futures_util::future::Either;
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
 use jsonrpsee_types::{
-	ErrorResponse, Id, Notification, NotificationSer, ParamsSer, RequestSer, Response, SubscriptionResponse,
+	response::SubscriptionError, ErrorResponse, Id, Notification, NotificationSer, ParamsSer, RequestSer, Response,
+	SubscriptionResponse,
 };
 use serde::de::DeserializeOwned;
 use tokio::sync::Mutex;
@@ -488,6 +490,11 @@ async fn background_task<S: TransportSenderT, R: TransportReceiverT>(
 					if let Err(Some(unsub)) = process_subscription_response(&mut manager, response) {
 						let _ = stop_subscription(&mut sender, &mut manager, unsub).await;
 					}
+				}
+				// Subscription error response.
+				else if let Ok(response) = serde_json::from_str::<SubscriptionError<_>>(&raw) {
+					tracing::debug!("[backend]: recv subscription err {:?}", response);
+					let _ = process_subscription_close_response(&mut manager, response);
 				}
 				// Incoming Notification
 				else if let Ok(notif) = serde_json::from_str::<Notification<_>>(&raw) {

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -493,7 +493,7 @@ async fn background_task<S: TransportSenderT, R: TransportReceiverT>(
 				}
 				// Subscription error response.
 				else if let Ok(response) = serde_json::from_str::<SubscriptionError<_>>(&raw) {
-					tracing::debug!("[backend]: recv subscription err {:?}", response);
+					tracing::debug!("[backend]: recv subscription closed {:?}", response);
 					let _ = process_subscription_close_response(&mut manager, response);
 				}
 				// Incoming Notification

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -30,16 +30,15 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::task;
 
-use crate::error::{Error, SubscriptionClosed};
+use crate::error::Error;
 use async_trait::async_trait;
 use core::marker::PhantomData;
 use futures_channel::{mpsc, oneshot};
 use futures_util::future::FutureExt;
 use futures_util::sink::SinkExt;
 use futures_util::stream::{Stream, StreamExt};
-use jsonrpsee_types::response::SubscriptionError;
 use jsonrpsee_types::{Id, ParamsSer, SubscriptionId};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
 
 #[doc(hidden)]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -156,6 +156,17 @@ pub enum SubscriptionClosed {
 	Server(String),
 }
 
+impl std::fmt::Display for SubscriptionClosed {
+	/// Get close reason as str.
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Unsubscribed => write!(f, "Subscription was closed by a unsubscribe call"),
+			Self::ConnectionReset => write!(f, "Subscription was closed by connection reset"),
+			Self::Server(msg) => write!(f, "Subscription was closed by server: {}", msg.as_str()),
+		}
+	}
+}
+
 /// Generic transport error.
 #[derive(Debug, thiserror::Error)]
 pub enum GenericTransportError<T: std::error::Error + Send + Sync> {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -27,7 +27,7 @@
 use std::fmt;
 
 use jsonrpsee_types::error::{
-	CallError, ErrorObject, CALL_EXECUTION_FAILED_CODE, INVALID_PARAMS_CODE, SUBSCRIPTION_CLOSED,
+	CallError, ErrorObject, ErrorObjectOwned, CALL_EXECUTION_FAILED_CODE, INVALID_PARAMS_CODE, SUBSCRIPTION_CLOSED,
 	SUBSCRIPTION_CLOSED_WITH_ERROR,
 };
 use serde::{Deserialize, Serialize};
@@ -149,8 +149,8 @@ impl Error {
 	/// Get the JSON-RPC error object representation of the error.
 	pub fn as_error_object<'a, 'b: 'a>(&'b self) -> ErrorObject<'a> {
 		match self {
-			Error::Call(CallError::Custom { message, code, data }) => {
-				ErrorObject { code: (*code).into(), message: message.as_str().into(), data: data.as_deref() }
+			Error::Call(CallError::Custom(ErrorObjectOwned { code, message, data })) => {
+				ErrorObject { code: *code, message: message.as_str().into(), data: data.as_deref() }
 			}
 			Error::Call(CallError::InvalidParams(e)) => {
 				ErrorObject::code_and_message(INVALID_PARAMS_CODE, e.to_string().into())

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -28,6 +28,7 @@ use std::fmt;
 
 use jsonrpsee_types::error::{
 	CallError, ErrorObject, ErrorObjectOwned, CALL_EXECUTION_FAILED_CODE, INVALID_PARAMS_CODE, SUBSCRIPTION_CLOSED,
+	UNKNOWN_ERROR_CODE,
 };
 
 /// Convenience type for displaying errors.
@@ -145,11 +146,14 @@ impl Error {
 impl Into<ErrorObjectOwned> for Error {
 	fn into(self) -> ErrorObjectOwned {
 		match self {
-			Error::Call(CallError::Custom(err)) => err.clone(),
+			Error::Call(CallError::Custom(err)) => err,
 			Error::Call(CallError::InvalidParams(e)) => {
 				ErrorObject::owned(INVALID_PARAMS_CODE, e.to_string(), None::<()>)
 			}
-			_ => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, self.to_string(), None::<()>),
+			Error::Call(CallError::Failed(e)) => {
+				ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, e.to_string(), None::<()>)
+			}
+			_ => ErrorObject::owned(UNKNOWN_ERROR_CODE, self.to_string(), None::<()>),
 		}
 	}
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -140,9 +140,10 @@ impl Error {
 	{
 		Error::Call(CallError::from_std_error(err))
 	}
+}
 
-	/// Get the JSON-RPC error object representation of the error.
-	pub fn to_error_object(&self) -> ErrorObject<'static> {
+impl Into<ErrorObjectOwned> for Error {
+	fn into(self) -> ErrorObjectOwned {
 		match self {
 			Error::Call(CallError::Custom(err)) => err.clone(),
 			Error::Call(CallError::InvalidParams(e)) => {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -158,12 +158,6 @@ impl Error {
 			Error::SubscriptionClosed(SubscriptionClosed::Server(CloseReason::Failed(e))) => {
 				ErrorObject::code_and_message(SUBSCRIPTION_CLOSED_WITH_ERROR, e.as_str().into())
 			}
-			Error::SubscriptionClosed(SubscriptionClosed::Server(CloseReason::Unknown)) => {
-				ErrorObject::code_and_message(
-					SUBSCRIPTION_CLOSED_WITH_ERROR,
-					"Subscription closed with unknown reason".into(),
-				)
-			}
 			// Not really errors see [`SubscriptionClosed`] for further info.
 			// Such as if the subscription was closed by the client and similar.
 			Error::SubscriptionClosed(other) => {
@@ -195,8 +189,6 @@ impl From<CloseReason> for SubscriptionClosed {
 pub enum CloseReason {
 	/// The subscription was completed successfully.
 	Success,
-	/// The subscription was closed with unknown reason.
-	Unknown,
 	/// The subscription failed because of some error.
 	Failed(String),
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -144,40 +144,10 @@ impl Error {
 	}
 }
 
-/// A type with a special `subscription_closed` field to detect that
-/// a subscription has been closed to distinguish valid items produced
-/// by the server on the subscription stream from an error.
-///
-/// This is included in the `result field` of the SubscriptionResponse
-/// when an error is reported by the server.
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct SubscriptionClosed {
-	reason: SubscriptionClosedReason,
-}
-
-impl From<SubscriptionClosedReason> for SubscriptionClosed {
-	fn from(reason: SubscriptionClosedReason) -> Self {
-		Self::new(reason)
-	}
-}
-
-impl SubscriptionClosed {
-	/// Create a new [`SubscriptionClosed`].
-	pub fn new(reason: SubscriptionClosedReason) -> Self {
-		Self { reason }
-	}
-
-	/// Get the close reason.
-	pub fn close_reason(&self) -> &SubscriptionClosedReason {
-		&self.reason
-	}
-}
-
 /// A type to represent when a subscription gets closed
 /// by either the server or client side.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
-pub enum SubscriptionClosedReason {
+pub enum SubscriptionClosed {
 	/// The subscription was closed by calling the unsubscribe method.
 	Unsubscribed,
 	/// The client closed the connection.
@@ -221,32 +191,5 @@ impl From<soketto::connection::Error> for Error {
 impl From<hyper::Error> for Error {
 	fn from(hyper_err: hyper::Error) -> Error {
 		Error::Transport(hyper_err.into())
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::{SubscriptionClosed, SubscriptionClosedReason};
-
-	#[test]
-	fn subscription_closed_ser_deser_works() {
-		let items: Vec<(&str, SubscriptionClosed)> = vec![
-			(r#"{"reason":"Unsubscribed"}"#, SubscriptionClosedReason::Unsubscribed.into()),
-			(r#"{"reason":"ConnectionReset"}"#, SubscriptionClosedReason::ConnectionReset.into()),
-			(r#"{"reason":{"Server":"hoho"}}"#, SubscriptionClosedReason::Server("hoho".into()).into()),
-		];
-
-		for (s, d) in items {
-			let dsr: SubscriptionClosed = serde_json::from_str(s).unwrap();
-			assert_eq!(dsr, d);
-			let ser = serde_json::to_string(&d).unwrap();
-			assert_eq!(ser, s);
-		}
-	}
-
-	#[test]
-	fn subscription_closed_deny_unknown_field() {
-		let ser = r#"{"reason":"Unsubscribed","deny":1}"#;
-		assert!(serde_json::from_str::<SubscriptionClosed>(ser).is_err());
 	}
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -178,10 +178,8 @@ impl Error {
 /// by either the server or client side.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub enum SubscriptionClosed {
-	/// The subscription was closed by calling the unsubscribe method.
-	Unsubscribed,
-	/// The client closed the connection.
-	ConnectionReset,
+	/// The remote peer closed the connection or called the unsubscribe method.
+	RemotePeerAborted,
 	/// The server closed the subscription, providing a description of the reason as a `String`.
 	Server(CloseReason),
 }
@@ -207,8 +205,7 @@ impl std::fmt::Display for SubscriptionClosed {
 	/// Get close reason as str.
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			Self::Unsubscribed => write!(f, "Subscription was closed by a unsubscribe call"),
-			Self::ConnectionReset => write!(f, "Subscription was closed by connection reset"),
+			Self::RemotePeerAborted => write!(f, "Subscription was closed by the remote peer"),
 			Self::Server(reason) => write!(f, "Subscription was closed by server: {:?}", reason),
 		}
 	}

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -154,7 +154,7 @@ impl MethodSink {
 
 	/// Helper for sending the general purpose `Error` as a JSON-RPC errors to the client
 	pub fn send_call_error(&self, id: Id, err: Error) -> bool {
-		self.send_error(id, err.to_error_object())
+		self.send_error(id, err.into())
 	}
 
 	/// Send a raw JSON-RPC message to the client, `MethodSink` does not check verify the validity

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -136,7 +136,7 @@ impl MethodSink {
 
 	/// Send a JSON-RPC error to the client
 	pub fn send_error(&self, id: Id, error: ErrorObject) -> bool {
-		let json = match serde_json::to_string(&ErrorResponse::new(error, id)) {
+		let json = match serde_json::to_string(&ErrorResponse::borrowed(error, id)) {
 			Ok(json) => json,
 			Err(err) => {
 				tracing::error!("Error serializing error message: {:?}", err);

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -30,8 +30,8 @@ use crate::{to_json_raw_value, Error};
 use futures_channel::mpsc;
 use futures_util::StreamExt;
 use jsonrpsee_types::error::{
-	CallError, ErrorCode, ErrorObject, ErrorResponse, CALL_EXECUTION_FAILED_CODE, OVERSIZED_RESPONSE_CODE,
-	OVERSIZED_RESPONSE_MSG, UNKNOWN_ERROR_CODE,
+	CallError, ErrorCode, ErrorObject, ErrorObjectOwned, ErrorResponse, CALL_EXECUTION_FAILED_CODE,
+	OVERSIZED_RESPONSE_CODE, OVERSIZED_RESPONSE_MSG, UNKNOWN_ERROR_CODE,
 };
 use jsonrpsee_types::{Id, InvalidRequest, Response};
 use serde::Serialize;
@@ -166,7 +166,7 @@ impl MethodSink {
 			Error::Call(CallError::Failed(e)) => {
 				(ErrorCode::ServerError(CALL_EXECUTION_FAILED_CODE), e.to_string(), None)
 			}
-			Error::Call(CallError::Custom { code, message, data }) => (code.into(), message, data),
+			Error::Call(CallError::Custom(ErrorObjectOwned { code, message, data })) => (code.into(), message, data),
 			// This should normally not happen because the most common use case is to
 			// return `Error::Call` in `register_async_method`.
 			e => (ErrorCode::ServerError(UNKNOWN_ERROR_CODE), e.to_string(), None),

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -750,7 +750,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 
 /// Represent a pending subscription which waits to be accepted or rejected.
 ///
-/// Warning: you need to call either `PendingSubscription::accept` or `PendingSubscription::reject` otherwise
+/// Note: you need to call either `PendingSubscription::accept` or `PendingSubscription::reject` otherwise
 /// the subscription will be dropped with an `InvalidParams` error.
 #[derive(Debug)]
 struct InnerPendingSubscription {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -905,13 +905,11 @@ impl SubscriptionSink {
 					}
 					// Stream canceled because of error.
 					Either::Left((Err(e), _)) => {
-						let close_reason: SubscriptionClosed = CloseReason::Failed(e.to_string()).into();
-						break Err(Error::SubscriptionClosed(close_reason));
+						break Err(Error::SubscriptionClosed(CloseReason::Failed(e.to_string()).into()));
 					}
 					// Stream completed (this is not really an error)
 					Either::Left((Ok(None), _)) => {
-						let close_reason: SubscriptionClosed = CloseReason::Success.into();
-						break Err(Error::SubscriptionClosed(close_reason));
+						break Err(Error::SubscriptionClosed(CloseReason::Success.into()));
 					}
 					// The subscriber went away without telling us.
 					Either::Right(((), _)) => {
@@ -1005,13 +1003,13 @@ impl SubscriptionSink {
 	///  "method": "<method>",
 	///  "params": {
 	///    "subscription": "<subscriptionID>",
-	///    "error": { "code": <your code>, "message": <your message>, "data": <your data but might be omitted> }
+	///    "error": { "code": <code from error>, "message": <message from error>, "data": <data from error> }
 	///    }
 	///  }
 	/// }
 	/// ```
 	///
-	pub fn close(&mut self, err: Error) -> bool {
+	pub fn close(mut self, err: Error) -> bool {
 		self.is_connected.take();
 		if let Some((sink, _)) = self.subscribers.lock().remove(&self.uniq_sub) {
 			tracing::debug!("Closing subscription: {:?}", self.uniq_sub.sub_id);

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -876,11 +876,8 @@ impl SubscriptionSink {
 	///     // This will return send `[Ok(1_u32), Ok(2_u32), Err(Error::SubscriptionClosed))]` to the subscriber
 	///     // because after the `Err(_)` the stream is terminated.
 	///     tokio::spawn(async move {
-	///         // jsonrpsee doesn't send an error notification if the stream was closed unless `close` is called.
-	///         // jsonrpsee doesn't send a notification if the stream was terminated or canceled.
-	///         //
-	///         // But it's possible to get reason why subscription was terminated
-	///         //
+	///         // jsonrpsee doesn't send an error notification unless `close` is explicitly called.
+	///         // If we pipe messages to the sink, we can inspect why it ended:
 	///         match sink.pipe_from_try_stream(stream).await {
 	///            SubscriptionClosed::Success => {
 	///                let err_obj: ErrorObjectOwned = SubscriptionClosed::Success.into();

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -752,7 +752,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 /// Represent a pending subscription which waits being accepted or rejected.
 ///
 /// Warning: you need to call either `PendingSubscription::accept` or `PendingSubscription::reject` otherwise
-/// the subscription will not make any progress.
+/// the subscription will be dropped with an `InvalidParams` error.
 #[derive(Debug)]
 struct InnerPendingSubscription {
 	/// Sink.

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -803,7 +803,7 @@ impl PendingSubscription {
 	}
 }
 
-// If this type is dropped, it will return an InvalidParams error to the subscriber
+// When dropped it returns an [`InvalidParams`] error to the subscriber
 impl Drop for PendingSubscription {
 	fn drop(&mut self) {
 		if let Some(inner) = self.0.take() {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -770,7 +770,7 @@ struct InnerPendingSubscription {
 
 /// Represent a pending subscription which waits until it's either accepted or rejected.
 ///
-/// This type implement drop for ease of use, such as dropped in error short circuiting via `map_err()?`.
+/// This type implements `Drop` for ease of use, e.g. when dropped in error short circuiting via `map_err()?`.
 #[derive(Debug)]
 pub struct PendingSubscription(Option<InnerPendingSubscription>);
 

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -840,7 +840,7 @@ impl SubscriptionSink {
 	/// Send a message back to subscribers.
 	///
 	/// Returns `Ok(true)` if the message could be send
-	/// Returns `Ok(false)` if the sink was closed (this is not an error because the subscription got closed or connection was terminated)
+	/// Returns `Ok(false)` if the sink was closed (either because the subscription was closed or the connection was terminated)
 	/// Return `Err(err)` if the message could not be serialized.
 	///
 	pub fn send<T: Serialize>(&mut self, result: &T) -> Result<bool, serde_json::Error> {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -768,7 +768,7 @@ struct InnerPendingSubscription {
 	id: Id<'static>,
 }
 
-/// Represent a pending subscription which waits for being accepted or rejected.
+/// Represent a pending subscription which waits until it's either accepted or rejected.
 ///
 /// This type implement drop for ease of use, such as dropped in error short circuiting via `map_err()?`.
 #[derive(Debug)]

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -677,14 +677,14 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 			self.methods.mut_callbacks().insert(
 				subscribe_method_name,
 				MethodCallback::new_subscription(Arc::new(move |id, params, method_sink, conn| {
-					let sub_id: RpcSubscriptionId = conn.id_provider.next_id().into_owned();
+					let sub_id: RpcSubscriptionId = conn.id_provider.next_id();
 
 					let sink = PendingSubscription(Some(InnerPendingSubscription {
 						sink: method_sink.clone(),
 						close_notify: Some(conn.close_notify),
 						method: notif_method_name,
 						subscribers: subscribers.clone(),
-						uniq_sub: SubscriptionKey { conn_id: conn.conn_id, sub_id: sub_id.clone() },
+						uniq_sub: SubscriptionKey { conn_id: conn.conn_id, sub_id },
 						id: id.clone().into_owned(),
 					}));
 
@@ -721,10 +721,8 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 					};
 					let sub_id = sub_id.into_owned();
 
-					let result = subscribers
-						.lock()
-						.remove(&SubscriptionKey { conn_id: conn.conn_id, sub_id: sub_id.clone() })
-						.is_some();
+					let result =
+						subscribers.lock().remove(&SubscriptionKey { conn_id: conn.conn_id, sub_id }).is_some();
 
 					sink.send_response(id, result)
 				})),

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -88,7 +88,7 @@ pub struct ConnState<'a> {
 pub enum SubscriptionResult {
 	/// The subscription stream was executed successfully.
 	Success,
-	/// The subscription was aborted the remote peer.
+	/// The subscription was aborted by the remote peer.
 	Aborted,
 }
 

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -86,7 +86,7 @@ pub struct ConnState<'a> {
 /// Outcome of a successful terminated subscription.
 #[derive(Debug)]
 pub enum SubscriptionResult {
-	/// The subscription stream was executed successful.
+	/// The subscription stream was executed successfully.
 	Success,
 	/// The subscription was aborted the remote peer.
 	Aborted,

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -803,6 +803,7 @@ impl PendingSubscription {
 	}
 }
 
+// If this type is dropped, it will return an InvalidParams error to the subscriber
 impl Drop for PendingSubscription {
 	fn drop(&mut self) {
 		if let Some(inner) = self.0.take() {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -748,7 +748,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 	}
 }
 
-/// Represent a pending subscription which waits being accepted or rejected.
+/// Represent a pending subscription which waits to be accepted or rejected.
 ///
 /// Warning: you need to call either `PendingSubscription::accept` or `PendingSubscription::reject` otherwise
 /// the subscription will be dropped with an `InvalidParams` error.

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -767,17 +767,12 @@ struct InnerPendingSubscription {
 pub struct PendingSubscription(Option<InnerPendingSubscription>);
 
 impl PendingSubscription {
-	/// Reject the subscription call.
-	pub fn reject(self, err: Error) -> Result<(), Error> {
-		self.reject_from_error_object(err.to_error_object())
-	}
-
 	/// Reject the subscription call from [`ErrorObject`].
-	pub fn reject_from_error_object(mut self, err: ErrorObject) -> Result<(), Error> {
+	pub fn reject(mut self, err: impl Into<ErrorObjectOwned>) -> Result<(), Error> {
 		if let Some(inner) = self.0.take() {
 			let InnerPendingSubscription { sink, id, .. } = inner;
 
-			if sink.send_error(id, err.borrow()) {
+			if sink.send_error(id, err.into()) {
 				Ok(())
 			} else {
 				Err(Error::Custom("Connection is closed".to_string()))
@@ -1026,12 +1021,6 @@ impl SubscriptionSink {
 			}
 		}
 		false
-	}
-
-	/// Similar to [`SubscriptionSink`] but extracts the JSON-RPC error object from [`Error`] and sends it out
-	/// as error notification on the subscription.
-	pub fn close_from_jsonrpsee_error(self, err: Error) -> bool {
-		self.close(err.to_error_object())
 	}
 }
 

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -917,9 +917,6 @@ impl SubscriptionSink {
 									SubscriptionClosed::Server(CloseReason::Failed(f)) => {
 										Err(Error::SubscriptionClosed(CloseReason::Failed(f).into()))
 									}
-									SubscriptionClosed::Server(CloseReason::Unknown) => {
-										Err(Error::SubscriptionClosed(CloseReason::Unknown.into()))
-									}
 								};
 								break res;
 							}

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -996,10 +996,10 @@ impl SubscriptionSink {
 		}
 	}
 
-	/// Send an error notification on the subscription with a special field `error`.
+	/// Close the subscription, sending a notification with a special `error` field containing the provided error.
 	///
-	/// This may be used for indicating to connected clients that a given subscription has been canceled
-	/// as well so not necessarily an error but this is used for compat reason with existing JavaScript libraries.
+	/// This can be used to signal an actual error, or just to signal that the subscription has been closed,
+	/// depending on your preference. 
 	///
 	/// The APIs [`SubscriptionSink::pipe_from_stream`] and [`SubscriptionSink::pipe_from_stream`] uses this
 	/// when the stream is terminated.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 tokio = { version = "1.8", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+serde_json = { version = "1" }
 
 [[example]]
 name = "http"

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -45,7 +45,7 @@ where
 
 	/// Subscription that takes a `StorageKey` as input and produces a `Vec<Hash>`.
 	#[subscription(name = "subscribeStorage" => "override", item = Vec<Hash>)]
-	fn subscribe_storage(&self, keys: Option<Vec<StorageKey>>) -> Result<(), Error>;
+	fn subscribe_storage(&self, keys: Option<Vec<StorageKey>>);
 }
 
 pub struct RpcServerImpl;
@@ -60,12 +60,10 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 		Ok(vec![storage_key])
 	}
 
-	fn subscribe_storage(
-		&self,
-		pending: PendingSubscription,
-		_keys: Option<Vec<ExampleStorageKey>>,
-	) -> Result<(), Error> {
-		pending.accept()?.send(&vec![[0; 32]]).map(|_| ()).map_err(Into::into)
+	fn subscribe_storage(&self, pending: PendingSubscription, _keys: Option<Vec<ExampleStorageKey>>) {
+		if let Ok(mut sink) = pending.accept() {
+			let _ = sink.send(&vec![[0; 32]]);
+		}
 	}
 }
 

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -61,7 +61,7 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 	}
 
 	fn subscribe_storage(&self, pending: PendingSubscription, _keys: Option<Vec<ExampleStorageKey>>) {
-		if let Ok(mut sink) = pending.accept() {
+		if let Some(mut sink) = pending.accept() {
 			let _ = sink.send(&vec![[0; 32]]);
 		}
 	}

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -65,7 +65,7 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 		pending: PendingSubscription,
 		_keys: Option<Vec<ExampleStorageKey>>,
 	) -> Result<(), Error> {
-		pending.accept()?.send(&vec![[0; 32]])
+		pending.accept()?.send(&vec![[0; 32]]).map(|_| ()).map_err(Into::into)
 	}
 }
 

--- a/examples/proc_macro.rs
+++ b/examples/proc_macro.rs
@@ -29,7 +29,7 @@ use std::net::SocketAddr;
 use jsonrpsee::core::{async_trait, client::Subscription, Error};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::ws_server::{SubscriptionSink, WsServerBuilder, WsServerHandle};
+use jsonrpsee::ws_server::{PendingSubscription, WsServerBuilder, WsServerHandle};
 
 type ExampleHash = [u8; 32];
 type ExampleStorageKey = Vec<u8>;
@@ -62,10 +62,10 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 
 	fn subscribe_storage(
 		&self,
-		mut sink: SubscriptionSink,
+		pending: PendingSubscription,
 		_keys: Option<Vec<ExampleStorageKey>>,
 	) -> Result<(), Error> {
-		sink.send(&vec![[0; 32]])
+		pending.accept()?.send(&vec![[0; 32]])
 	}
 }
 

--- a/examples/ws_pubsub_broadcast.rs
+++ b/examples/ws_pubsub_broadcast.rs
@@ -74,7 +74,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	module.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", move |_, pending, _| {
 		let rx = BroadcastStream::new(tx.clone().subscribe());
 		let mut sink = match pending.accept() {
-			Ok(sink) => sink,
+			Some(sink) => sink,
 			_ => return,
 		};
 

--- a/examples/ws_pubsub_broadcast.rs
+++ b/examples/ws_pubsub_broadcast.rs
@@ -70,8 +70,9 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 
 	std::thread::spawn(move || produce_items(tx2));
 
-	module.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", move |_, sink, _| {
+	module.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", move |_, pending, _| {
 		let rx = BroadcastStream::new(tx.clone().subscribe());
+		let sink = pending.accept()?;
 
 		tokio::spawn(async move {
 			let _ = sink.pipe_from_try_stream(rx).await;

--- a/examples/ws_pubsub_broadcast.rs
+++ b/examples/ws_pubsub_broadcast.rs
@@ -31,6 +31,7 @@ use std::net::SocketAddr;
 use futures::future;
 use futures::StreamExt;
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
+use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::ws_server::{RpcModule, WsServerBuilder};
@@ -75,7 +76,15 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		let mut sink = pending.accept()?;
 
 		tokio::spawn(async move {
-			let _ = sink.pipe_from_try_stream(rx).await.map_err(|e| sink.close(e));
+			match sink.pipe_from_try_stream(rx).await {
+				SubscriptionClosed::Success => {
+					sink.close(SubscriptionClosed::Success);
+				}
+				SubscriptionClosed::RemotePeerAborted => (),
+				SubscriptionClosed::Failed(err) => {
+					sink.close(err);
+				}
+			};
 		});
 		Ok(())
 	})?;

--- a/examples/ws_pubsub_broadcast.rs
+++ b/examples/ws_pubsub_broadcast.rs
@@ -72,10 +72,10 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 
 	module.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", move |_, pending, _| {
 		let rx = BroadcastStream::new(tx.clone().subscribe());
-		let sink = pending.accept()?;
+		let mut sink = pending.accept()?;
 
 		tokio::spawn(async move {
-			let _ = sink.pipe_from_try_stream(rx).await;
+			let _ = sink.pipe_from_try_stream(rx).await.map_err(|e| sink.close(e));
 		});
 		Ok(())
 	})?;

--- a/examples/ws_pubsub_with_params.rs
+++ b/examples/ws_pubsub_with_params.rs
@@ -42,20 +42,20 @@ async fn main() -> anyhow::Result<()> {
 		.try_init()
 		.expect("setting default subscriber failed");
 
-	let addr = run_server().await?;
-	let url = format!("ws://{}", addr);
+	// let addr = run_server().await?;
+	let url = format!("ws://127.0.0.1:9944");
 
 	let client = WsClientBuilder::default().build(&url).await?;
 
 	// Subscription with a single parameter
 	let mut sub_params_one =
-		client.subscribe::<Option<char>>("sub_one_param", rpc_params![3], "unsub_one_param").await?;
+		client.subscribe::<Option<char>>("author_submitAndWatchExtrinsic", rpc_params![], "unsub_one_param").await?;
 	tracing::info!("subscription with one param: {:?}", sub_params_one.next().await);
 
 	// Subscription with multiple parameters
-	let mut sub_params_two =
-		client.subscribe::<String>("sub_params_two", rpc_params![2, 5], "unsub_params_two").await?;
-	tracing::info!("subscription with two params: {:?}", sub_params_two.next().await);
+	// let mut sub_params_two =
+	//     client.subscribe::<String>("sub_params_two", rpc_params![2, 5], "unsub_params_two").await?;
+	// tracing::info!("subscription with two params: {:?}", sub_params_two.next().await);
 
 	Ok(())
 }

--- a/examples/ws_pubsub_with_params.rs
+++ b/examples/ws_pubsub_with_params.rs
@@ -68,7 +68,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	module
 		.register_subscription("sub_one_param", "sub_one_param", "unsub_one_param", |params, pending, _| {
 			let (idx, mut sink) = match (params.one(), pending.accept()) {
-				(Ok(idx), Ok(sink)) => (idx, sink),
+				(Ok(idx), Some(sink)) => (idx, sink),
 				_ => return,
 			};
 			let item = LETTERS.chars().nth(idx);
@@ -93,7 +93,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	module
 		.register_subscription("sub_params_two", "params_two", "unsub_params_two", |params, pending, _| {
 			let (one, two, mut sink) = match (params.parse::<(usize, usize)>(), pending.accept()) {
-				(Ok((one, two)), Ok(sink)) => (one, two, sink),
+				(Ok((one, two)), Some(sink)) => (one, two, sink),
 				_ => return,
 			};
 

--- a/examples/ws_pubsub_with_params.rs
+++ b/examples/ws_pubsub_with_params.rs
@@ -65,8 +65,9 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module
-		.register_subscription("sub_one_param", "sub_one_param", "unsub_one_param", |params, sink, _| {
+		.register_subscription("sub_one_param", "sub_one_param", "unsub_one_param", |params, pending, _| {
 			let idx: usize = params.one()?;
+			let sink = pending.accept()?;
 			let item = LETTERS.chars().nth(idx);
 
 			let interval = interval(Duration::from_millis(200));
@@ -79,8 +80,9 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		})
 		.unwrap();
 	module
-		.register_subscription("sub_params_two", "params_two", "unsub_params_two", |params, sink, _| {
+		.register_subscription("sub_params_two", "params_two", "unsub_params_two", |params, pending, _| {
 			let (one, two): (usize, usize) = params.parse()?;
+			let sink = pending.accept()?;
 			let item = &LETTERS[one..two];
 
 			let interval = interval(Duration::from_millis(200));

--- a/http-server/src/response.rs
+++ b/http-server/src/response.rs
@@ -34,7 +34,7 @@ const TEXT: &str = "text/plain";
 
 /// Create a response for json internal error.
 pub fn internal_error() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&ErrorResponse::new(ErrorCode::InternalError.into(), Id::Null))
+	let error = serde_json::to_string(&ErrorResponse::borrowed(ErrorCode::InternalError.into(), Id::Null))
 		.expect("built from known-good data; qed");
 
 	from_template(hyper::StatusCode::INTERNAL_SERVER_ERROR, error, JSON)
@@ -74,7 +74,7 @@ pub fn invalid_allow_headers() -> hyper::Response<hyper::Body> {
 
 /// Create a json response for oversized requests (413)
 pub fn too_large() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&ErrorResponse::new(ErrorCode::OversizedRequest.into(), Id::Null))
+	let error = serde_json::to_string(&ErrorResponse::borrowed(ErrorCode::OversizedRequest.into(), Id::Null))
 		.expect("built from known-good data; qed");
 
 	from_template(hyper::StatusCode::PAYLOAD_TOO_LARGE, error, JSON)
@@ -82,7 +82,7 @@ pub fn too_large() -> hyper::Response<hyper::Body> {
 
 /// Create a json response for empty or malformed requests (400)
 pub fn malformed() -> hyper::Response<hyper::Body> {
-	let error = serde_json::to_string(&ErrorResponse::new(ErrorCode::ParseError.into(), Id::Null))
+	let error = serde_json::to_string(&ErrorResponse::borrowed(ErrorCode::ParseError.into(), Id::Null))
 		.expect("built from known-good data; qed");
 
 	from_template(hyper::StatusCode::BAD_REQUEST, error, JSON)

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -162,10 +162,10 @@ async fn single_method_call_with_faulty_context() {
 	let (addr, _handle) = server().with_default_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
-	let req = r#"{"jsonrpc":"2.0","method":"should_err", "params":[],"id":1}"#;
+	let req = r#"{"jsonrpc":"2.0","method":"should_err","params":[],"id":1}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	assert_eq!(response.body, call_execution_failed("RPC context failed", Id::Num(1)));
+	assert_eq!(response.body, call_execution_failed("RPC call failed: RPC context failed", Id::Num(1)));
 }
 
 #[tokio::test]

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -165,7 +165,7 @@ async fn single_method_call_with_faulty_context() {
 	let req = r#"{"jsonrpc":"2.0","method":"should_err","params":[],"id":1}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	assert_eq!(response.body, call_execution_failed("RPC call failed: RPC context failed", Id::Num(1)));
+	assert_eq!(response.body, call_execution_failed("RPC context failed", Id::Num(1)));
 }
 
 #[tokio::test]

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -80,7 +80,7 @@ pub use jsonrpsee_types as types;
 
 /// Set of RPC methods that can be mounted to the server.
 #[cfg(any(feature = "http-server", feature = "ws-server"))]
-pub use jsonrpsee_core::server::rpc_module::{RpcModule, SubscriptionSink};
+pub use jsonrpsee_core::server::rpc_module::{PendingSubscription, RpcModule, SubscriptionSink};
 
 #[cfg(any(
 	feature = "http-server",

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -79,7 +79,7 @@ fn find_jsonrpsee_crate(http_name: &str, ws_name: &str) -> Result<proc_macro2::T
 ///    fn call(&self, a: A) -> RpcResult<B>;
 ///
 ///    #[subscription(name = "subscribe", item = Vec<C>)]
-///    fn sub(&self) -> RpcResult<()>;
+///    fn sub(&self);
 ///  }
 /// ```
 ///

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -55,7 +55,7 @@ pub(crate) mod visitor;
 /// - The trait will have one additional (already implemented) method, `into_rpc`, which turns any object that
 ///   implements the server trait into an `RpcModule`.
 /// - For subscription methods, there will be one additional argument inserted right after `&self`: `subscription_sink:
-///   PendingSubscription`. It should be used to actually maintain the subscription.
+///   PendingSubscription`. It should be used accept or reject a pending subscription.
 ///
 /// Since this macro can generate up to two traits, both server and client traits will have
 /// a new name. For the `Foo` trait, server trait will be named `FooServer`, and client,

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -287,7 +287,7 @@ pub(crate) mod visitor;
 ///         // The stream API can be used to pipe items from the underlying stream
 ///         // as subscription responses.
 ///         fn sub_override_notif_method(&self, pending: PendingSubscription) -> RpcResult<()> {
-///             let sink = pending.accept()?;    
+///             let mut sink = pending.accept()?;    
 ///             tokio::spawn(async move {
 ///                 let stream = futures_util::stream::iter(["one", "two", "three"]);
 ///                 sink.pipe_from_stream(stream).await;

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -242,7 +242,7 @@ pub(crate) mod visitor;
 ///         /// }
 ///         /// ```
 ///         #[subscription(name = "sub" => "subNotif", unsubscribe = "unsub", item = String)]
-///         fn sub_override_notif_method(&self) -> RpcResult<()>;
+///         fn sub_override_notif_method(&self);
 ///
 ///         /// Use the same method name for both the `subscribe call` and `notifications`
 ///         ///
@@ -259,7 +259,7 @@ pub(crate) mod visitor;
 ///         /// }
 ///         /// ```
 ///         #[subscription(name = "subscribe", item = String)]
-///         fn sub(&self) -> RpcResult<()>;
+///         fn sub(&self);
 ///     }
 ///
 ///     // Structure that will implement the `MyRpcServer` trait.
@@ -286,23 +286,21 @@ pub(crate) mod visitor;
 ///
 ///         // The stream API can be used to pipe items from the underlying stream
 ///         // as subscription responses.
-///         fn sub_override_notif_method(&self, pending: PendingSubscription) -> RpcResult<()> {
-///             let mut sink = pending.accept()?;    
+///         fn sub_override_notif_method(&self, pending: PendingSubscription) {
+///             let mut sink = pending.accept().unwrap();     
 ///             tokio::spawn(async move {
 ///                 let stream = futures_util::stream::iter(["one", "two", "three"]);
 ///                 sink.pipe_from_stream(stream).await;
 ///             });
-///
-///             Ok(())
 ///         }
 ///
 ///         // We could've spawned a `tokio` future that yields values while our program works,
 ///         // but for simplicity of the example we will only send two values and then close
 ///         // the subscription.
-///         fn sub(&self, pending: PendingSubscription) -> RpcResult<()> {
-///             let mut sink = pending.accept()?;    
-///             sink.send(&"Response_A")?;
-///             sink.send(&"Response_B")
+///         fn sub(&self, pending: PendingSubscription) {
+///             let mut sink = pending.accept().unwrap();
+///             let _ = sink.send(&"Response_A");
+///             let _ = sink.send(&"Response_B");
 ///         }
 ///     }
 /// }

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -69,7 +69,7 @@ impl RpcDescription {
 
 		let subscriptions = self.subscriptions.iter().map(|sub| {
 			let docs = &sub.docs;
-			let subscription_sink_ty = self.jrps_server_item(quote! { SubscriptionSink });
+			let subscription_sink_ty = self.jrps_server_item(quote! { PendingSubscription });
 			// Add `SubscriptionSink` as the second input parameter to the signature.
 			let subscription_sink: syn::FnArg = syn::parse_quote!(subscription_sink: #subscription_sink_ty);
 			let mut sub_sig = sub.signature.clone();
@@ -196,9 +196,9 @@ impl RpcDescription {
 				};
 
 				handle_register_result(quote! {
-					rpc.register_subscription(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, sink, context| {
+					rpc.register_subscription(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, subscription_sink, context| {
 						#parsing
-						context.as_ref().#rust_method_name(sink, #params_seq)
+						context.as_ref().#rust_method_name(subscription_sink, #params_seq)
 					})
 				})
 			})

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -311,7 +311,7 @@ impl RpcDescription {
 							Err(e) => {
 								#tracing::error!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
-								let _ = #pending.reject_from_error_object(_e.to_error_object());
+								let _ = #pending.reject(_e);
 								return;
 							}
 						};
@@ -335,7 +335,7 @@ impl RpcDescription {
 							Err(e) => {
 								#tracing::error!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
-								let _ = #pending.reject_from_error_object(_e.to_error_object());
+								let _ = #pending.reject(_e);
 								return;
 							}
 						};
@@ -386,7 +386,7 @@ impl RpcDescription {
 						Err(e) => {
 							#tracing::error!("Failed to parse JSON-RPC params as object: {}", e);
 							let _e: #err = e.into();
-							let _ = #pending.reject_from_error_object(_e.to_error_object());
+							let _ = #pending.reject(_e);
 							return;
 						}
 					};

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -312,7 +312,7 @@ impl RpcDescription {
 								#tracing::error!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
 								let _ = #pending.reject_from_error_object(_e.to_error_object());
-								return Err(_e)
+								return;
 							}
 						};
 					}
@@ -336,7 +336,7 @@ impl RpcDescription {
 								#tracing::error!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
 								let _ = #pending.reject_from_error_object(_e.to_error_object());
-								return Err(_e)
+								return;
 							}
 						};
 					}
@@ -387,7 +387,7 @@ impl RpcDescription {
 							#tracing::error!("Failed to parse JSON-RPC params as object: {}", e);
 							let _e: #err = e.into();
 							let _ = #pending.reject_from_error_object(_e.to_error_object());
-							return Err(_e);
+							return;
 						}
 					};
 

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -311,7 +311,7 @@ impl RpcDescription {
 							Err(e) => {
 								#tracing::error!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
-								let _ = #pending.reject(_e);
+								#pending.reject(_e);
 								return;
 							}
 						};
@@ -335,7 +335,7 @@ impl RpcDescription {
 							Err(e) => {
 								#tracing::error!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
-								let _ = #pending.reject(_e);
+								#pending.reject(_e);
 								return;
 							}
 						};
@@ -386,7 +386,7 @@ impl RpcDescription {
 						Err(e) => {
 							#tracing::error!("Failed to parse JSON-RPC params as object: {}", e);
 							let _e: #err = e.into();
-							let _ = #pending.reject(_e);
+							#pending.reject(_e);
 							return;
 						}
 					};

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -311,7 +311,7 @@ impl RpcDescription {
 							Err(e) => {
 								#tracing::error!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
-								let _ = #pending.reject_from_error_object(_e.as_error_object());
+								let _ = #pending.reject_from_error_object(_e.to_error_object());
 								return Err(_e)
 							}
 						};
@@ -335,7 +335,7 @@ impl RpcDescription {
 							Err(e) => {
 								#tracing::error!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								let _e: #err = e.into();
-								let _ = #pending.reject_from_error_object(_e.as_error_object());
+								let _ = #pending.reject_from_error_object(_e.to_error_object());
 								return Err(_e)
 							}
 						};
@@ -386,7 +386,7 @@ impl RpcDescription {
 						Err(e) => {
 							#tracing::error!("Failed to parse JSON-RPC params as object: {}", e);
 							let _e: #err = e.into();
-							let _ = #pending.reject_from_error_object(_e.as_error_object());
+							let _ = #pending.reject_from_error_object(_e.to_error_object());
 							return Err(_e);
 						}
 					};

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -262,6 +262,14 @@ impl RpcDescription {
 							"Element cannot be both subscription and method at the same time",
 						));
 					}
+
+					if !matches!(method.sig.output, syn::ReturnType::Default) {
+						return Err(syn::Error::new_spanned(
+							&method,
+							"Subscription methods must not return anything; the error must send via subscription via either `PendingSubscription::reject` or `SubscripionSink::close`",
+						));
+					}
+
 					if method.sig.asyncness.is_some() {
 						return Err(syn::Error::new_spanned(&method, "Subscription methods must not be `async`"));
 					}

--- a/proc-macros/tests/ui/correct/alias_doesnt_use_namespace.rs
+++ b/proc-macros/tests/ui/correct/alias_doesnt_use_namespace.rs
@@ -8,7 +8,7 @@ pub trait Rpc {
 	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[subscription(name = "subscribeGetFood", item = String, aliases = ["getFood"], unsubscribe_aliases = ["unsubscribegetFood"])]
-	fn sub(&self) -> RpcResult<()>;
+	fn sub(&self);
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -65,7 +65,7 @@ impl RpcServer for RpcServerImpl {
 
 	fn sub(&self, pending: PendingSubscription) {
 		let mut sink = match pending.accept() {
-			Ok(sink) => sink,
+			Some(sink) => sink,
 			_ => return,
 		};
 		let _ = sink.send(&"Response_A");
@@ -74,7 +74,7 @@ impl RpcServer for RpcServerImpl {
 
 	fn sub_with_params(&self, pending: PendingSubscription, val: u32) {
 		let mut sink = match pending.accept() {
-			Ok(sink) => sink,
+			Some(sink) => sink,
 			_ => return,
 		};
 		let _ = sink.send(&val);
@@ -82,7 +82,7 @@ impl RpcServer for RpcServerImpl {
 	}
 
 	fn sub_with_override_notif_method(&self, pending: PendingSubscription) {
-		if let Ok(mut sink) = pending.accept() {
+		if let Some(mut sink) = pending.accept() {
 			let _ = sink.send(&1);
 		}
 	}

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -6,7 +6,7 @@ use jsonrpsee::core::{async_trait, client::ClientT, RpcResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::*;
-use jsonrpsee::ws_server::{SubscriptionSink, WsServerBuilder};
+use jsonrpsee::ws_server::{PendingSubscription, WsServerBuilder};
 
 #[rpc(client, server, namespace = "foo")]
 pub trait Rpc {
@@ -63,18 +63,20 @@ impl RpcServer for RpcServerImpl {
 		Ok(10u16)
 	}
 
-	fn sub(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
+	fn sub(&self, pending: PendingSubscription) -> RpcResult<()> {
+		let mut sink = pending.accept()?;
 		sink.send(&"Response_A")?;
 		sink.send(&"Response_B")
 	}
 
-	fn sub_with_params(&self, mut sink: SubscriptionSink, val: u32) -> RpcResult<()> {
+	fn sub_with_params(&self, pending: PendingSubscription, val: u32) -> RpcResult<()> {
+		let mut sink = pending.accept()?;
 		sink.send(&val)?;
 		sink.send(&val)
 	}
 
-	fn sub_with_override_notif_method(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
-		sink.send(&1)
+	fn sub_with_override_notif_method(&self, pending: PendingSubscription) -> RpcResult<()> {
+		pending.accept()?.send(&1)
 	}
 }
 

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -30,7 +30,7 @@ impl RpcServer for RpcServerImpl {
 
 	fn sub(&self, pending: PendingSubscription) {
 		let mut sink = match pending.accept() {
-			Ok(sink) => sink,
+			Some(sink) => sink,
 			_ => return,
 		};
 

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -13,7 +13,7 @@ pub trait Rpc {
 	fn sync_method(&self) -> RpcResult<u16>;
 
 	#[subscription(name = "subscribe", item = String)]
-	fn sub(&self) -> RpcResult<()>;
+	fn sub(&self);
 }
 
 pub struct RpcServerImpl;
@@ -28,10 +28,14 @@ impl RpcServer for RpcServerImpl {
 		Ok(10u16)
 	}
 
-	fn sub(&self, pending: PendingSubscription) -> RpcResult<()> {
-		let mut sink = pending.accept()?;
-		sink.send(&"Response_A")?;
-		sink.send(&"Response_B")
+	fn sub(&self, pending: PendingSubscription) {
+		let mut sink = match pending.accept() {
+			Ok(sink) => sink,
+			_ => return,
+		};
+
+		let _ = sink.send(&"Response_A");
+		let _ = sink.send(&"Response_B");
 	}
 }
 

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::ws_server::{SubscriptionSink, WsServerBuilder};
+use jsonrpsee::ws_server::{PendingSubscription, WsServerBuilder};
 
 #[rpc(server)]
 pub trait Rpc {
@@ -28,7 +28,8 @@ impl RpcServer for RpcServerImpl {
 		Ok(10u16)
 	}
 
-	fn sub(&self, mut sink: SubscriptionSink) -> RpcResult<()> {
+	fn sub(&self, pending: PendingSubscription) -> RpcResult<()> {
+		let mut sink = pending.accept()?;
 		sink.send(&"Response_A")?;
 		sink.send(&"Response_B")
 	}

--- a/proc-macros/tests/ui/correct/parse_angle_brackets.rs
+++ b/proc-macros/tests/ui/correct/parse_angle_brackets.rs
@@ -1,4 +1,4 @@
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use jsonrpsee::proc_macros::rpc;
 
 fn main() {
 	#[rpc(server)]
@@ -12,6 +12,6 @@ fn main() {
 			// angle braces need to be accounted for manually.
 			item = TransactionStatus<Hash, BlockHash>,
 		)]
-		fn dummy_subscription(&self) -> RpcResult<()>;
+		fn dummy_subscription(&self);
 	}
 }

--- a/proc-macros/tests/ui/correct/rpc_deny_missing_docs.rs
+++ b/proc-macros/tests/ui/correct/rpc_deny_missing_docs.rs
@@ -13,7 +13,7 @@ pub trait ApiWithDocumentation {
 
 	/// Subscription docs.
 	#[subscription(name = "sub", unsubscribe = "unsub", item = String)]
-	fn sub(&self) -> RpcResult<()>;
+	fn sub(&self);
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.rs
+++ b/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.rs
@@ -1,9 +1,9 @@
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use jsonrpsee::proc_macros::rpc;
 
 #[rpc(client, server)]
 pub trait DuplicatedSubAlias {
 	#[subscription(name = "subscribeAlias", item = String, aliases = ["hello_is_goodbye"], unsubscribe_aliases = ["hello_is_goodbye"])]
-	fn async_method(&self) -> RpcResult<()>;
+	fn async_method(&self);
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.stderr
+++ b/proc-macros/tests/ui/incorrect/sub/sub_conflicting_alias.stderr
@@ -1,5 +1,5 @@
 error: "hello_is_goodbye" is already defined
  --> $DIR/sub_conflicting_alias.rs:6:5
   |
-6 |     fn async_method(&self) -> RpcResult<()>;
+6 |     fn async_method(&self);
   |        ^^^^^^^^^^^^

--- a/proc-macros/tests/ui/incorrect/sub/sub_dup_name_override.rs
+++ b/proc-macros/tests/ui/incorrect/sub/sub_dup_name_override.rs
@@ -1,12 +1,12 @@
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use jsonrpsee::proc_macros::rpc;
 
 // Subscription method must not use the same override name.
 #[rpc(client, server)]
 pub trait DupOverride {
 	#[subscription(name = "subscribeOne" => "override", item = u8)]
-	fn one(&self) -> RpcResult<()>;
+	fn one(&self);
 	#[subscription(name = "subscribeTwo" => "override", item = u8)]
-	fn two(&self) -> RpcResult<()>;
+	fn two(&self);
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/sub/sub_dup_name_override.stderr
+++ b/proc-macros/tests/ui/incorrect/sub/sub_dup_name_override.stderr
@@ -1,5 +1,5 @@
 error: "override" is already defined
  --> $DIR/sub_dup_name_override.rs:9:5
   |
-9 |     fn two(&self) -> RpcResult<()>;
+9 |     fn two(&self);
   |        ^^^

--- a/proc-macros/tests/ui/incorrect/sub/sub_name_override.rs
+++ b/proc-macros/tests/ui/incorrect/sub/sub_name_override.rs
@@ -1,10 +1,10 @@
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use jsonrpsee::proc_macros::rpc;
 
 // Subscription method name conflict with notif override.
 #[rpc(client, server)]
 pub trait DupName {
 	#[subscription(name = "one" => "one", unsubscribe = "unsubscribeOne", item = u8)]
-	fn one(&self) -> RpcResult<()>;
+	fn one(&self);
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/sub/sub_name_override.stderr
+++ b/proc-macros/tests/ui/incorrect/sub/sub_name_override.stderr
@@ -1,5 +1,5 @@
 error: "one" is already defined
  --> $DIR/sub_name_override.rs:7:5
   |
-7 |     fn one(&self) -> RpcResult<()>;
+7 |     fn one(&self);
   |        ^^^

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -87,7 +87,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 			std::thread::spawn(move || {
 				std::thread::sleep(Duration::from_secs(1));
 				let err: Error = CallError::Custom(ErrorObjectOwned {
-					code: SUBSCRIPTION_CLOSED_WITH_ERROR,
+					code: SUBSCRIPTION_CLOSED_WITH_ERROR.into(),
 					message: "Server closed the stream because it was lazy".into(),
 					data: None,
 				})

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 
 use jsonrpsee::core::Error;
 use jsonrpsee::http_server::{AccessControl, HttpServerBuilder, HttpServerHandle};
-use jsonrpsee::types::error::{CallError, SUBSCRIPTION_CLOSED_WITH_ERROR};
+use jsonrpsee::types::error::{CallError, ErrorObjectOwned, SUBSCRIPTION_CLOSED_WITH_ERROR};
 use jsonrpsee::ws_server::{WsServerBuilder, WsServerHandle};
 use jsonrpsee::RpcModule;
 
@@ -86,11 +86,11 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 			let sink = pending.accept()?;
 			std::thread::spawn(move || {
 				std::thread::sleep(Duration::from_secs(1));
-				let err: Error = CallError::Custom {
+				let err: Error = CallError::Custom(ErrorObjectOwned {
 					code: SUBSCRIPTION_CLOSED_WITH_ERROR,
 					message: "Server closed the stream because it was lazy".into(),
 					data: None,
-				}
+				})
 				.into();
 				sink.close(err);
 			});

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -41,7 +41,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 	module
 		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, pending, _| {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			std::thread::spawn(move || loop {
@@ -56,7 +56,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 	module
 		.register_subscription("subscribe_foo", "subscribe_foo", "unsubscribe_foo", |_, pending, _| {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			std::thread::spawn(move || loop {
@@ -76,7 +76,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 			};
 
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 
@@ -93,7 +93,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 	module
 		.register_subscription("subscribe_noop", "subscribe_noop", "unsubscribe_noop", |_, pending, _| {
 			let sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			std::thread::spawn(move || {

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -27,10 +27,11 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use jsonrpsee::core::Error;
+use jsonrpsee::core::{Error, RpcResult};
 use jsonrpsee::http_server::{AccessControl, HttpServerBuilder, HttpServerHandle};
 use jsonrpsee::ws_server::{WsServerBuilder, WsServerHandle};
 use jsonrpsee::RpcModule;
+use jsonrpsee::{proc_macros::rpc, SubscriptionSink};
 
 pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle) {
 	let server = WsServerBuilder::default().build("127.0.0.1:0").await.unwrap();
@@ -90,6 +91,25 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 			Ok(())
 		})
 		.unwrap();
+
+	#[rpc(server)]
+	pub trait Api {
+		#[subscription(
+				name = "subscribe_bad" => "s",
+				item = usize,
+			)]
+		fn subscribe(&self, x: usize) -> RpcResult<()>;
+	}
+
+	struct Impl;
+
+	impl ApiServer for Impl {
+		fn subscribe(&self, _sink: SubscriptionSink, _x: usize) -> RpcResult<()> {
+			Ok(())
+		}
+	}
+
+	module.merge(Impl.into_rpc()).unwrap();
 
 	let addr = server.local_addr().unwrap();
 	let server_handle = server.start(module).unwrap();

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -83,7 +83,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 
 	module
 		.register_subscription("subscribe_noop", "subscribe_noop", "unsubscribe_noop", |_, pending, _| {
-			let mut sink = pending.accept()?;
+			let sink = pending.accept()?;
 			std::thread::spawn(move || {
 				std::thread::sleep(Duration::from_secs(1));
 				let err: Error = CallError::Custom {

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -86,7 +86,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 		.register_subscription("subscribe_noop", "subscribe_noop", "unsubscribe_noop", |_, mut sink, _| {
 			std::thread::spawn(move || {
 				std::thread::sleep(Duration::from_secs(1));
-				sink.close_with_custom_message("Server closed the stream because it was lazy")
+				sink.close("Server closed the stream because it was lazy")
 			});
 			Ok(())
 		})

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -27,9 +27,8 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use jsonrpsee::core::Error;
 use jsonrpsee::http_server::{AccessControl, HttpServerBuilder, HttpServerHandle};
-use jsonrpsee::types::error::{CallError, ErrorObjectOwned, SUBSCRIPTION_CLOSED_WITH_ERROR};
+use jsonrpsee::types::error::{ErrorObjectOwned, SUBSCRIPTION_CLOSED_WITH_ERROR};
 use jsonrpsee::ws_server::{WsServerBuilder, WsServerHandle};
 use jsonrpsee::RpcModule;
 
@@ -43,7 +42,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, pending, _| {
 			let mut sink = pending.accept()?;
 			std::thread::spawn(move || loop {
-				if let Err(Error::SubscriptionClosed(_)) = sink.send(&"hello from subscription") {
+				if let Ok(false) = sink.send(&"hello from subscription") {
 					break;
 				}
 				std::thread::sleep(Duration::from_millis(50));
@@ -56,7 +55,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 		.register_subscription("subscribe_foo", "subscribe_foo", "unsubscribe_foo", |_, pending, _| {
 			let mut sink = pending.accept()?;
 			std::thread::spawn(move || loop {
-				if let Err(Error::SubscriptionClosed(_)) = sink.send(&1337) {
+				if let Ok(false) = sink.send(&1337) {
 					break;
 				}
 				std::thread::sleep(Duration::from_millis(100));
@@ -72,7 +71,7 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 
 			std::thread::spawn(move || loop {
 				count = count.wrapping_add(1);
-				if let Err(Error::SubscriptionClosed(_)) = sink.send(&count) {
+				if let Err(_) | Ok(false) = sink.send(&count) {
 					break;
 				}
 				std::thread::sleep(Duration::from_millis(100));
@@ -86,12 +85,11 @@ pub async fn websocket_server_with_subscription() -> (SocketAddr, WsServerHandle
 			let sink = pending.accept()?;
 			std::thread::spawn(move || {
 				std::thread::sleep(Duration::from_secs(1));
-				let err: Error = CallError::Custom(ErrorObjectOwned {
+				let err = ErrorObjectOwned {
 					code: SUBSCRIPTION_CLOSED_WITH_ERROR.into(),
 					message: "Server closed the stream because it was lazy".into(),
 					data: None,
-				})
-				.into();
+				};
 				sink.close(err);
 			});
 			Ok(())

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -382,7 +382,7 @@ async fn ws_server_should_stop_subscription_after_client_drop() {
 	let close_err = rx.next().await.unwrap();
 
 	// assert that the server received `SubscriptionClosed` after the client was dropped.
-	assert!(matches!(close_err, SubscriptionClosed::ConnectionReset));
+	assert!(matches!(close_err, SubscriptionClosed::RemotePeerAborted));
 }
 
 #[tokio::test]

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -402,7 +402,7 @@ async fn ws_server_cancels_subscriptions_on_reset_conn() {
 			let stream = IntervalStream::new(interval).map(move |_| 0_usize);
 
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 
@@ -448,7 +448,7 @@ async fn ws_server_cancels_sub_stream_after_err() {
 			"unsubscribe_with_err_on_stream",
 			move |_, pending, _| {
 				let mut sink = match pending.accept() {
-					Ok(sink) => sink,
+					Some(sink) => sink,
 					_ => return,
 				};
 
@@ -488,7 +488,7 @@ async fn ws_server_subscribe_with_stream() {
 	module
 		.register_subscription("subscribe_5_ints", "n", "unsubscribe_5_ints", |_, pending, _| {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -667,3 +667,16 @@ fn comma_separated_header_values(headers: &hyper::HeaderMap, header: &str) -> Ve
 		.map(|header| header.to_ascii_lowercase())
 		.collect()
 }
+
+#[tokio::test]
+async fn ws_subscribe_with_bad_params() {
+	let (server_addr, _handle) = websocket_server_with_subscription().await;
+	let server_url = format!("ws://{}", server_addr);
+	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
+
+	let err = client
+		.subscribe::<serde_json::Value>("subscribe_bad", rpc_params!["0x0"], "unsubscribe_bad")
+		.await
+		.unwrap_err();
+	assert!(matches!(err, Error::Call(_)));
+}

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -34,7 +34,7 @@ use jsonrpsee::core::{client::SubscriptionClientT, Error};
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::http_server::HttpServerBuilder;
 use jsonrpsee::rpc_params;
-use jsonrpsee::types::error::{CallError, ErrorCode};
+use jsonrpsee::types::error::{CallError, ErrorCode, ErrorObjectOwned};
 use jsonrpsee::types::ParamsSer;
 use jsonrpsee::ws_client::*;
 use jsonrpsee::ws_server::WsServerBuilder;
@@ -345,13 +345,13 @@ async fn calls_with_bad_params() {
 		.await
 		.unwrap_err();
 	assert!(
-		matches!(err, Error::Call(CallError::Custom { message, code, .. }) if message.contains("invalid type: string \"0x0\", expected u32") && code == ErrorCode::InvalidParams.code())
+		matches!(err, Error::Call(CallError::Custom ( ErrorObjectOwned { code, message, .. })) if message.contains("invalid type: string \"0x0\", expected u32") && code == ErrorCode::InvalidParams)
 	);
 
 	// Call with faulty params as array.
 	let err = client.request::<serde_json::Value>("foo_foo", rpc_params!["faulty", "ok"]).await.unwrap_err();
 	assert!(
-		matches!(err, Error::Call(CallError::Custom { message, code, .. }) if message.contains("invalid type: string \"faulty\", expected u8") && code == ErrorCode::InvalidParams.code())
+		matches!(err, Error::Call(CallError::Custom ( ErrorObjectOwned { code, message, .. })) if message.contains("invalid type: string \"faulty\", expected u8") && code == ErrorCode::InvalidParams)
 	);
 
 	// Sub with faulty params as map.
@@ -361,7 +361,7 @@ async fn calls_with_bad_params() {
 	let err =
 		client.subscribe::<serde_json::Value>("foo_echo", Some(params), "foo_unsubscribe_echo").await.unwrap_err();
 	assert!(
-		matches!(err, Error::Call(CallError::Custom { message, code, .. }) if message.contains("invalid type: string \"0x0\", expected u32") && code == ErrorCode::InvalidParams.code())
+		matches!(err, Error::Call(CallError::Custom ( ErrorObjectOwned { code, message, .. })) if message.contains("invalid type: string \"0x0\", expected u32") && code == ErrorCode::InvalidParams)
 	);
 
 	// Call with faulty params as map.
@@ -371,6 +371,6 @@ async fn calls_with_bad_params() {
 	let params = ParamsSer::Map(map);
 	let err = client.request::<serde_json::Value>("foo_foo", Some(params)).await.unwrap_err();
 	assert!(
-		matches!(err, Error::Call(CallError::Custom { message, code, .. }) if message.contains("invalid type: integer `99`, expected a string") && code == ErrorCode::InvalidParams.code())
+		matches!(err, Error::Call(CallError::Custom ( ErrorObjectOwned { code, message, .. })) if message.contains("invalid type: integer `99`, expected a string") && code == ErrorCode::InvalidParams)
 	);
 }

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -203,6 +203,11 @@ pub async fn websocket_server() -> SocketAddr {
 
 #[tokio::test]
 async fn proc_macros_generic_ws_client_api() {
+	tracing_subscriber::FmtSubscriber::builder()
+		.with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+		.try_init()
+		.expect("setting default subscriber failed");
+
 	let server_addr = websocket_server().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
@@ -214,7 +219,7 @@ async fn proc_macros_generic_ws_client_api() {
 	let mut sub = client.sub().await.unwrap();
 	let first_recv = sub.next().await.unwrap().unwrap();
 	assert_eq!(first_recv, "Response_A".to_string());
-	let second_recv = sub.next().await.unwrap().unwrap();
+	/*let second_recv = sub.next().await.unwrap().unwrap();
 	assert_eq!(second_recv, "Response_B".to_string());
 
 	// Sub with params
@@ -222,7 +227,7 @@ async fn proc_macros_generic_ws_client_api() {
 	let first_recv = sub.next().await.unwrap().unwrap();
 	assert_eq!(first_recv, 42);
 	let second_recv = sub.next().await.unwrap().unwrap();
-	assert_eq!(second_recv, 42);
+	assert_eq!(second_recv, 42);*/
 }
 
 #[tokio::test]

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -191,7 +191,7 @@ mod rpc_impl {
 	#[async_trait]
 	impl OnlyGenericSubscriptionServer<String, String> for RpcServerImpl {
 		fn sub(&self, pending: PendingSubscription, _: String) -> RpcResult<()> {
-			pending.accept()?.send(&"hello")
+			pending.accept()?.send(&"hello").map(|_| ()).map_err(Into::into)
 		}
 	}
 }

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -168,7 +168,7 @@ mod rpc_impl {
 
 		fn sub(&self, pending: PendingSubscription) {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			let _ = sink.send(&"Response_A");
@@ -177,7 +177,7 @@ mod rpc_impl {
 
 		fn sub_with_params(&self, pending: PendingSubscription, val: u32) {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			let _ = sink.send(&val);
@@ -196,7 +196,7 @@ mod rpc_impl {
 	impl OnlyGenericSubscriptionServer<String, String> for RpcServerImpl {
 		fn sub(&self, pending: PendingSubscription, _: String) {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			let _ = sink.send(&"hello");

--- a/tests/tests/resource_limiting.rs
+++ b/tests/tests/resource_limiting.rs
@@ -32,7 +32,7 @@ use jsonrpsee::core::Error;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::types::error::CallError;
+use jsonrpsee::types::error::{CallError, ErrorObjectOwned};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::ws_server::{WsServerBuilder, WsServerHandle};
 use jsonrpsee::RpcModule;
@@ -119,8 +119,8 @@ async fn http_server(module: RpcModule<()>) -> Result<(SocketAddr, HttpServerHan
 
 fn assert_server_busy(fail: Result<String, Error>) {
 	match fail {
-		Err(Error::Call(CallError::Custom { code, message, data: _ })) => {
-			assert_eq!(code, -32604);
+		Err(Error::Call(CallError::Custom(ErrorObjectOwned { code, message, .. }))) => {
+			assert_eq!(code.code(), -32604);
 			assert_eq!(message, "Server is busy, try again later");
 		}
 		fail => panic!("Expected error, got: {:?}", fail),

--- a/tests/tests/resource_limiting.rs
+++ b/tests/tests/resource_limiting.rs
@@ -32,7 +32,7 @@ use jsonrpsee::core::Error;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::types::error::{CallError, ErrorObjectOwned};
+use jsonrpsee::types::error::CallError;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::ws_server::{WsServerBuilder, WsServerHandle};
 use jsonrpsee::RpcModule;
@@ -119,9 +119,9 @@ async fn http_server(module: RpcModule<()>) -> Result<(SocketAddr, HttpServerHan
 
 fn assert_server_busy(fail: Result<String, Error>) {
 	match fail {
-		Err(Error::Call(CallError::Custom(ErrorObjectOwned { code, message, .. }))) => {
-			assert_eq!(code.code(), -32604);
-			assert_eq!(message, "Server is busy, try again later");
+		Err(Error::Call(CallError::Custom(err))) => {
+			assert_eq!(err.code(), -32604);
+			assert_eq!(err.message(), "Server is busy, try again later");
 		}
 		fail => panic!("Expected error, got: {:?}", fail),
 	}

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -201,7 +201,7 @@ async fn subscribing_without_server() {
 	module
 		.register_subscription("my_sub", "my_sub", "my_unsub", |_, pending, _| {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 
@@ -239,7 +239,7 @@ async fn close_test_subscribing_without_server() {
 	module
 		.register_subscription("my_sub", "my_sub", "my_unsub", |_, pending, _| {
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 
@@ -298,7 +298,7 @@ async fn subscribing_without_server_bad_params() {
 			};
 
 			let mut sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			sink.send(&p).unwrap();

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -26,9 +26,9 @@
 
 use std::collections::HashMap;
 
-use jsonrpsee::core::error::{Error, SubscriptionClosed};
+use jsonrpsee::core::error::{CloseReason, Error, SubscriptionClosed};
 use jsonrpsee::core::server::rpc_module::*;
-use jsonrpsee::types::error::{CallError, ErrorObject, SUBSCRIPTION_CLOSED};
+use jsonrpsee::types::error::CallError;
 use jsonrpsee::types::{EmptyParams, Params};
 use serde::{Deserialize, Serialize};
 
@@ -209,7 +209,7 @@ async fn subscribing_without_server() {
 					let _ = sink.send(&letter);
 					std::thread::sleep(std::time::Duration::from_millis(500));
 				}
-				sink.close(&ErrorObject::code_and_message(SUBSCRIPTION_CLOSED, "Subscription terminated successful"));
+				sink.close(Error::SubscriptionClosed(CloseReason::Success.into()));
 			});
 
 			Ok(())
@@ -246,8 +246,8 @@ async fn close_test_subscribing_without_server() {
 					std::thread::sleep(std::time::Duration::from_millis(500));
 				}
 				// Get the close reason.
-				if let Error::SubscriptionClosed(close) = sink.send(&"lo").unwrap_err() {
-					sink.close(&ErrorObject::code_and_message(SUBSCRIPTION_CLOSED, &close.to_string()));
+				if let Err(e) = sink.send(&"lo") {
+					sink.close(e);
 				}
 			});
 			Ok(())

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 
 use jsonrpsee::core::error::{CloseReason, Error, SubscriptionClosed};
 use jsonrpsee::core::server::rpc_module::*;
-use jsonrpsee::types::error::CallError;
+use jsonrpsee::types::error::{CallError, ErrorObjectOwned};
 use jsonrpsee::types::{EmptyParams, Params};
 use serde::{Deserialize, Serialize};
 
@@ -106,7 +106,7 @@ async fn calling_method_without_server() {
 	let err = module.call::<_, ()>("foo", (false,)).await.unwrap_err();
 	assert!(matches!(
 		err,
-		Error::Call(CallError::Custom { code, message, data: _}) if code == -32602 && message.as_str() == "invalid type: boolean `false`, expected u16 at line 1 column 6"
+		Error::Call(CallError::Custom ( ErrorObjectOwned { code, message, .. })) if code.code() == -32602 && message.as_str() == "invalid type: boolean `false`, expected u16 at line 1 column 6"
 	));
 
 	// Call async method with params and context
@@ -187,7 +187,7 @@ async fn calling_method_without_server_using_proc_macro() {
 	// Call sync method with bad params
 	let err = module.call::<_, ()>("rebel", (Gun { shoots: true }, false)).await.unwrap_err();
 	assert!(matches!(err,
-		Error::Call(CallError::Custom { code, message, data: _}) if code == -32602 && message.as_str() == "invalid type: boolean `false`, expected a map at line 1 column 5"
+		Error::Call(CallError::Custom ( ErrorObjectOwned { code, message, .. })) if code.code() == -32602 && message.as_str() == "invalid type: boolean `false`, expected a map at line 1 column 5"
 	));
 
 	// Call async method with params and context

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -266,7 +266,7 @@ async fn close_test_subscribing_without_server() {
 
 	// The first subscription was not closed using the unsubscribe method and
 	// it will be treated as the connection was closed.
-	let exp = SubscriptionClosed::ConnectionReset;
+	let exp = SubscriptionClosed::RemotePeerAborted;
 	assert!(
 		matches!(my_sub.next::<String>().await, Some(Err(Error::SubscriptionClosed(close_reason))) if close_reason == exp)
 	);

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -26,7 +26,7 @@
 
 use std::collections::HashMap;
 
-use jsonrpsee::core::error::{Error, SubscriptionClosed, SubscriptionClosedReason};
+use jsonrpsee::core::error::{Error, SubscriptionClosed};
 use jsonrpsee::core::server::rpc_module::*;
 use jsonrpsee::types::error::CallError;
 use jsonrpsee::types::{EmptyParams, Params};
@@ -222,7 +222,7 @@ async fn subscribing_without_server() {
 	}
 
 	let sub_err = my_sub.next::<char>().await.unwrap().unwrap_err();
-	let exp = SubscriptionClosed::new(SubscriptionClosedReason::Server("No close reason provided".to_string()));
+	let exp = SubscriptionClosed::Server("No close reason provided".to_string());
 
 	// The subscription is now closed by the server.
 	assert!(matches!(sub_err, Error::SubscriptionClosed(close_reason) if close_reason == exp));
@@ -266,7 +266,7 @@ async fn close_test_subscribing_without_server() {
 
 	// The first subscription was not closed using the unsubscribe method and
 	// it will be treated as the connection was closed.
-	let exp = SubscriptionClosed::new(SubscriptionClosedReason::ConnectionReset);
+	let exp = SubscriptionClosed::ConnectionReset;
 	assert!(
 		matches!(my_sub.next::<String>().await, Some(Err(Error::SubscriptionClosed(close_reason))) if close_reason == exp)
 	);

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -76,8 +76,8 @@ pub struct ErrorObject<'a> {
 
 impl<'a> ErrorObject<'a> {
 	/// Create a new `ErrorObject` with optional data.
-	pub fn new(code: ErrorCode, data: Option<&'a RawValue>) -> ErrorObject<'a> {
-		Self { code, message: code.message().into(), data }
+	pub fn new(code: ErrorCode, message: Cow<'a, str>, data: Option<&'a RawValue>) -> ErrorObject<'a> {
+		Self { code, message, data }
 	}
 
 	/// Create a new `ErrorObject` from message and code.
@@ -119,6 +119,16 @@ pub struct ErrorObjectOwned {
 }
 
 impl ErrorObjectOwned {
+	/// Create a new `ErrorObjectOwned` with optional data.
+	pub fn new(code: ErrorCode, message: impl Into<String>, data: &impl Serialize) -> Self {
+		let data = serde_json::value::to_raw_value(&data).ok();
+		Self { code, message: message.into(), data }
+	}
+
+	/// Create a new `ErrorObject` from message and code.
+	pub fn code_and_message(code: i32, message: impl Into<String>) -> Self {
+		Self { code: code.into(), message: message.into(), data: None }
+	}
 	/// Get the borrowed variant [`ErrorObject`].
 	pub fn borrow<'a>(&'a self) -> ErrorObject<'a> {
 		ErrorObject { code: self.code, message: self.message.as_str().into(), data: self.data.as_deref() }

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -176,8 +176,6 @@ pub const SERVER_IS_BUSY_CODE: i32 = -32604;
 pub const CALL_EXECUTION_FAILED_CODE: i32 = -32000;
 /// Unknown error.
 pub const UNKNOWN_ERROR_CODE: i32 = -32001;
-/// Invalid subscription error code.
-pub const INVALID_SUBSCRIPTION_CODE: i32 = -32002;
 /// Subscription got closed by the server.
 pub const SUBSCRIPTION_CLOSED: i32 = -32003;
 /// Subscription got closed by the server.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -82,7 +82,7 @@ impl<'a> ErrorObject<'a> {
 
 	/// Create a new `ErrorObject` from message and code.
 	pub fn code_and_message(code: i32, message: Cow<'a, str>) -> ErrorObject<'a> {
-		Self { code: code.into(), message: message.into(), data: None }
+		Self { code: code.into(), message, data: None }
 	}
 
 	/// Create an owned ErrorObject via [`CallError`]

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -39,18 +39,38 @@ use thiserror::Error;
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ErrorResponse<'a> {
 	/// JSON-RPC version.
-	pub jsonrpc: TwoPointZero,
+	jsonrpc: TwoPointZero,
 	/// Error.
 	#[serde(borrow)]
-	pub error: ErrorObject<'a>,
+	error: ErrorObject<'a>,
 	/// Request ID
-	pub id: Id<'a>,
+	id: Id<'a>,
 }
 
 impl<'a> ErrorResponse<'a> {
-	/// Create a new `ErrorResponse`.
-	pub fn new(error: ErrorObject<'a>, id: Id<'a>) -> Self {
+	/// Create a borrowed `ErrorResponse`.
+	pub fn borrowed(error: ErrorObject<'a>, id: Id<'a>) -> Self {
 		Self { jsonrpc: TwoPointZero, error, id }
+	}
+
+	/// Create a borrowed `ErrorResponse`.
+	pub fn owned(error: ErrorObject<'static>, id: Id<'static>) -> Self {
+		Self { jsonrpc: TwoPointZero, error, id }
+	}
+
+	/// Take ownership of the parameters within, if we haven't already.
+	pub fn into_owned(self) -> ErrorResponse<'static> {
+		ErrorResponse { jsonrpc: self.jsonrpc, error: self.error.into_owned(), id: self.id.into_owned() }
+	}
+
+	/// Get the [`ErrorObject`] of the error response.
+	pub fn error_object(&self) -> &ErrorObject {
+		&self.error
+	}
+
+	/// Get the [`Id`] of the error response.
+	pub fn id(&self) -> &Id {
+		&self.id
 	}
 }
 

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -81,7 +81,7 @@ impl<'a> ErrorObject<'a> {
 	}
 
 	/// Create a new `ErrorObject` from message and code.
-	pub fn code_and_message(code: i32, message: &'a str) -> ErrorObject<'a> {
+	pub fn code_and_message(code: i32, message: Cow<'a, str>) -> ErrorObject<'a> {
 		Self { code: code.into(), message: message.into(), data: None }
 	}
 

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -126,6 +126,10 @@ pub const CALL_EXECUTION_FAILED_CODE: i32 = -32000;
 pub const UNKNOWN_ERROR_CODE: i32 = -32001;
 /// Invalid subscription error code.
 pub const INVALID_SUBSCRIPTION_CODE: i32 = -32002;
+/// Subscription got closed by the server.
+pub const SUBSCRIPTION_CLOSED: i32 = -32003;
+/// Subscription got closed by the server.
+pub const SUBSCRIPTION_CLOSED_WITH_ERROR: i32 = -32004;
 
 /// Parse error message
 pub const PARSE_ERROR_MSG: &str = "Parse error";

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -80,6 +80,11 @@ impl<'a> ErrorObject<'a> {
 		Self { code, message: code.message().into(), data }
 	}
 
+	/// Create a new `ErrorObject` from message and code.
+	pub fn code_and_message(code: i32, message: &'a str) -> ErrorObject<'a> {
+		Self { code: code.into(), message: message.into(), data: None }
+	}
+
 	/// Create an owned ErrorObject via [`CallError`]
 	pub fn to_call_error(self) -> CallError {
 		CallError::Custom {

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -118,6 +118,13 @@ pub struct ErrorObjectOwned {
 	pub data: Option<Box<RawValue>>,
 }
 
+impl ErrorObjectOwned {
+	/// Get the borrowed variant [`ErrorObject`].
+	pub fn borrow<'a>(&'a self) -> ErrorObject<'a> {
+		ErrorObject { code: self.code, message: self.message.as_str().into(), data: self.data.as_deref() }
+	}
+}
+
 /// Parse error code.
 pub const PARSE_ERROR_CODE: i32 = -32700;
 /// Oversized request error code.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -76,13 +76,13 @@ pub struct ErrorObject<'a> {
 
 impl<'a> ErrorObject<'a> {
 	/// Create a new `ErrorObject` with optional data.
-	pub fn new(code: ErrorCode, message: Cow<'a, str>, data: Option<&'a RawValue>) -> ErrorObject<'a> {
-		Self { code, message, data }
+	pub fn new(code: i32, message: &'a str, data: Option<&'a RawValue>) -> ErrorObject<'a> {
+		Self { code: code.into(), message: message.into(), data }
 	}
 
 	/// Create a new `ErrorObject` from message and code.
-	pub fn code_and_message(code: i32, message: Cow<'a, str>) -> ErrorObject<'a> {
-		Self { code: code.into(), message, data: None }
+	pub fn code_and_message(code: i32, message: &'a str) -> ErrorObject<'a> {
+		Self { code: code.into(), message: message.into(), data: None }
 	}
 
 	/// Create an owned ErrorObject.
@@ -120,9 +120,9 @@ pub struct ErrorObjectOwned {
 
 impl ErrorObjectOwned {
 	/// Create a new `ErrorObjectOwned` with optional data.
-	pub fn new(code: ErrorCode, message: impl Into<String>, data: &impl Serialize) -> Self {
+	pub fn new(code: i32, message: impl Into<String>, data: impl Serialize) -> Self {
 		let data = serde_json::value::to_raw_value(&data).ok();
-		Self { code, message: message.into(), data }
+		Self { code: code.into(), message: message.into(), data }
 	}
 
 	/// Create a new `ErrorObject` from message and code.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -43,7 +43,7 @@ pub mod response;
 /// JSON-RPC response error object related types.
 pub mod error;
 
-pub use error::ErrorResponse;
+pub use error::{ErrorObject, ErrorObjectOwned, ErrorResponse};
 pub use params::{Id, Params, ParamsSequence, ParamsSer, SubscriptionId, TwoPointZero};
 pub use request::{InvalidRequest, Notification, NotificationSer, Request, RequestSer};
 pub use response::{Response, SubscriptionPayload, SubscriptionResponse};

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -60,8 +60,20 @@ pub struct SubscriptionPayload<'a, T> {
 	pub result: T,
 }
 
-/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member.
+/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member along with `result` field.
 pub type SubscriptionResponse<'a, T> = Notification<'a, SubscriptionPayload<'a, T>>;
+/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member along with `error` field.
+pub type SubscriptionError<'a, T> = Notification<'a, SubscriptionPayloadError<'a, T>>;
+
+/// Error value for subscriptions.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubscriptionPayloadError<'a, T> {
+	/// Subscription ID
+	#[serde(borrow)]
+	pub subscription: SubscriptionId<'a>,
+	/// Result.
+	pub error: T,
+}
 
 #[cfg(test)]
 mod tests {

--- a/ws-server/src/lib.rs
+++ b/ws-server/src/lib.rs
@@ -39,7 +39,7 @@ mod server;
 mod tests;
 
 pub use future::{ServerHandle as WsServerHandle, ShutdownWaiter as WsShutdownWaiter};
-pub use jsonrpsee_core::server::rpc_module::{RpcModule, SubscriptionSink};
+pub use jsonrpsee_core::server::rpc_module::{PendingSubscription, RpcModule, SubscriptionSink};
 pub use jsonrpsee_core::{id_providers::*, traits::IdProvider};
 pub use jsonrpsee_types as types;
 pub use server::{Builder as WsServerBuilder, Server as WsServer};

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -332,7 +332,7 @@ async fn batch_method_call_where_some_calls_fail() {
 
 	assert_eq!(
 		response,
-		r#"[{"jsonrpc":"2.0","result":"hello","id":1},{"jsonrpc":"2.0","error":{"code":-32000,"message":"RPC call failed: MyAppError"},"id":2},{"jsonrpc":"2.0","result":79,"id":3}]"#
+		r#"[{"jsonrpc":"2.0","result":"hello","id":1},{"jsonrpc":"2.0","error":{"code":-32000,"message":"MyAppError"},"id":2},{"jsonrpc":"2.0","result":79,"id":3}]"#
 	);
 }
 
@@ -410,7 +410,7 @@ async fn single_method_call_with_faulty_context() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_err", "params":[],"id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
-	assert_eq!(response, call_execution_failed("RPC call failed: RPC context failed", Id::Num(1)));
+	assert_eq!(response, call_execution_failed("RPC context failed", Id::Num(1)));
 }
 
 #[tokio::test]
@@ -450,7 +450,7 @@ async fn async_method_call_that_fails() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"err_async", "params":[],"id":1}"#;
 	let response = client.send_request_text(req).await.unwrap();
-	assert_eq!(response, call_execution_failed("RPC call failed: nah", Id::Num(1)));
+	assert_eq!(response, call_execution_failed("nah", Id::Num(1)));
 }
 
 #[tokio::test]
@@ -560,10 +560,7 @@ async fn valid_request_that_fails_to_execute_should_not_close_connection() {
 	// Good request, but causes error.
 	let req = r#"{"jsonrpc":"2.0","method":"call_fail","params":[],"id":123}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
-	assert_eq!(
-		response,
-		r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"RPC call failed: MyAppError"},"id":123}"#
-	);
+	assert_eq!(response, r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"MyAppError"},"id":123}"#);
 
 	// Connection is still good.
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":333}"#;

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -120,7 +120,8 @@ async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 		})
 		.unwrap();
 	module
-		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, sink, _| {
+		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, pending, _| {
+			let sink = pending.accept()?;
 			std::thread::spawn(move || loop {
 				let _ = &sink;
 				std::thread::sleep(std::time::Duration::from_secs(30));
@@ -669,7 +670,8 @@ async fn custom_subscription_id_works() {
 	let addr = server.local_addr().unwrap();
 	let mut module = RpcModule::new(());
 	module
-		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, sink, _| {
+		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, pending, _| {
+			let sink = pending.accept()?;
 			std::thread::spawn(move || loop {
 				let _ = &sink;
 				std::thread::sleep(std::time::Duration::from_secs(30));

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -122,7 +122,7 @@ async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 	module
 		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, pending, _| {
 			let sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			std::thread::spawn(move || loop {
@@ -677,7 +677,7 @@ async fn custom_subscription_id_works() {
 	module
 		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, pending, _| {
 			let sink = match pending.accept() {
-				Ok(sink) => sink,
+				Some(sink) => sink,
 				_ => return,
 			};
 			std::thread::spawn(move || loop {


### PR DESCRIPTION
To summarize, with this PR:
- We can reject a pending subscription with a `{ jsonrpc: "2.0", error: {...}, "id":<ID> }` style error of our choice using `pending.reject(error)`.
- We can end a subscription at any time with `{ jsonrpsee: "2.0", method: "subscribe_foo", params: { subscription: "123abc", error: { ... } } }` style error using `sink.close(error)`.
- Subscriptions that are dropped are now not silently closed with an error anymore (for compatibility reasons, incase subscriptions want to signal that they got closed by: "completed successfully" or "error" they must either call `close` on SubscriptionSink explictly). In other words, we enforce no opinion on what happens when a subscription is closed, and leave it up to the subscription itself to decide whether to emit an "error" or communicate closure via some other "ordinary notification".
- The clients have been changed to require the new error format for closing subscriptions `{ jsonrpsee: "2.0", method: "subscribe_foo", params: { subscription: "123abc", error: { ... } } }`
- `Subscription::next` in the client no longer parses `SubscriptionClosed` instead just returns `None` when a closed message is received.

Tested it on: https://github.com/paritytech/substrate/compare/dp-jsonrpsee-integration-2...na-jsonrpsee-comp-bad-params?expand=1