### PR TITLE
Make it possible to disable batch requests support

### DIFF
--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -75,6 +75,10 @@ pub fn oversized_request() -> String {
 	r#"{"jsonrpc":"2.0","error":{"code":-32701,"message":"Request is too big"},"id":null}"#.into()
 }
 
+pub fn batches_not_supported() -> String {
+	r#"{"jsonrpc":"2.0","error":{"code":-32005,"message":"Batched requests are not supported by this server"},"id":null}"#.into()
+}
+
 pub fn oversized_response(id: Id, max_limit: u32) -> String {
 	format!(
 		r#"{{"jsonrpc":"2.0","error":{{"code":-32702,"message":"Response is too big","data":"Exceeded max limit {}"}},"id":{}}}"#,

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -180,6 +180,8 @@ pub const UNKNOWN_ERROR_CODE: i32 = -32001;
 pub const SUBSCRIPTION_CLOSED: i32 = -32003;
 /// Subscription got closed by the server.
 pub const SUBSCRIPTION_CLOSED_WITH_ERROR: i32 = -32004;
+/// Batched requests are not supported by the server.
+pub const BATCHES_NOT_SUPPORTED_CODE: i32 = -32005;
 
 /// Parse error message
 pub const PARSE_ERROR_MSG: &str = "Parse error";
@@ -199,6 +201,8 @@ pub const METHOD_NOT_FOUND_MSG: &str = "Method not found";
 pub const SERVER_IS_BUSY_MSG: &str = "Server is busy, try again later";
 /// Reserved for implementation-defined server-errors.
 pub const SERVER_ERROR_MSG: &str = "Server error";
+/// Batched requests not supported error message.
+pub const BATCHES_NOT_SUPPORTED_MSG: &str = "Batched requests are not supported by this server";
 
 /// JSONRPC error code
 #[derive(Error, Debug, PartialEq, Copy, Clone)]


### PR DESCRIPTION
While it doesn't comply to the JSON RPC spec, some servers may explicitly decide to not support batched requests for various reasons. This PR makes it possible.