### PR TITLE
fix(http client): use https connector for https

### DIFF
--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -58,15 +58,7 @@ impl HttpTransportClient {
 		}
 
 		let client = match target.scheme_str() {
-			Some("http") => {
-				let mut connector = HttpConnector::new();
-
-				connector.set_reuse_address(true);
-				connector.set_nodelay(true);
-
-				let client = Client::builder().build::<_, hyper::Body>(connector);
-				HyperClient::Http(client)
-			}
+			Some("http") => HyperClient::Http(Client::new()),
 			#[cfg(feature = "tls")]
 			Some("https") => {
 				let connector = match cert_store {

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -251,17 +251,15 @@ async fn http_making_more_requests_than_allowed_should_not_deadlock() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn https_works() {
-	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io").unwrap();
+	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io:443").unwrap();
 	let response: String = client.request("system_chain", None).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
 
 #[tokio::test]
-#[ignore]
 async fn wss_works() {
-	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io").await.unwrap();
+	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io:443").await.unwrap();
 	let response: String = client.request("system_chain", None).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }


### PR DESCRIPTION
Closing https://github.com/paritytech/jsonrpsee/issues/748

Wrapping the `HttpConnector` in the `HttpsConnector` doesn't work, see for futher info https://github.com/rustls/hyper-rustls/issues/169 which this PR fixes.