### PR TITLE
[-> #739] Special handling for unsubscribe calls.

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,7 +18,7 @@ jsonrpc-http-server = { version = "18.0.0", optional = true }
 jsonrpc-pubsub = { version = "18.0.0", optional = true }
 num_cpus = "1"
 serde_json = "1"
-tokio = { version = "1.8", features = ["rt-multi-thread"] }
+tokio = { version = "1.16", features = ["rt-multi-thread"] }
 
 [[bench]]
 name = "bench"

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -19,12 +19,12 @@ jsonrpsee-core = { path = "../../core", version = "0.11.0", features = ["client"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.8", features = ["time"] }
+tokio = { version = "1.16", features = ["time"] }
 tracing = "0.1"
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../../test-utils" }
-tokio = { version = "1.8", features = ["net", "rt-multi-thread", "macros"] }
+tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["tls"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ rustc-hash = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }
 soketto = { version = "0.7.1", optional = true }
 parking_lot = { version = "0.12", optional = true }
-tokio = { version = "1.8", optional = true }
+tokio = { version = "1.16", optional = true }
 wasm-bindgen-futures = { version = "0.4.19", optional = true }
 futures-timer = { version = "3", optional = true }
 
@@ -66,5 +66,5 @@ async-wasm-client = [
 
 [dev-dependencies]
 serde_json = "1.0"
-tokio = { version = "1.8", features = ["macros", "rt"] }
+tokio = { version = "1.16", features = ["macros", "rt"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "macros"] }

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -64,7 +64,6 @@ pub type SubscriptionMethod = Arc<dyn Send + Sync + Fn(Id, Params, &MethodSink, 
 // Method callback to unsubscribe.
 type UnsubscriptionMethod = Arc<dyn Send + Sync + Fn(Id, Params, &MethodSink, ConnectionId) -> bool>;
 
-
 /// Connection ID, used for stateful protocol such as WebSockets.
 /// For stateless protocols such as http it's unused, so feel free to set it some hardcoded value.
 pub type ConnectionId = usize;
@@ -417,10 +416,8 @@ impl Methods {
 			Some(MethodKind::Subscription(cb)) => {
 				let conn_state = ConnState { conn_id: 0, close_notify, id_provider: &RandomIntegerIdProvider };
 				(cb)(id, params, &sink, conn_state)
-			},
-			Some(MethodKind::Unsubscription(cb)) => {
-				(cb)(id, params, &sink, 0)
 			}
+			Some(MethodKind::Unsubscription(cb)) => (cb)(id, params, &sink, 0),
 		};
 
 		let resp = rx_sink.next().await.expect("tx and rx still alive; qed");
@@ -739,8 +736,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 					};
 					let sub_id = sub_id.into_owned();
 
-					let result =
-						subscribers.lock().remove(&SubscriptionKey { conn_id, sub_id }).is_some();
+					let result = subscribers.lock().remove(&SubscriptionKey { conn_id, sub_id }).is_some();
 
 					sink.send_response(id, result)
 				})),

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -61,6 +61,9 @@ pub type AsyncMethod<'a> = Arc<
 >;
 /// Method callback for subscriptions.
 pub type SubscriptionMethod = Arc<dyn Send + Sync + Fn(Id, Params, &MethodSink, ConnState) -> bool>;
+// Method callback to unsubscribe.
+type UnsubscriptionMethod = Arc<dyn Send + Sync + Fn(Id, Params, &MethodSink, ConnectionId) -> bool>;
+
 
 /// Connection ID, used for stateful protocol such as WebSockets.
 /// For stateless protocols such as http it's unused, so feel free to set it some hardcoded value.
@@ -77,7 +80,7 @@ pub type RawRpcResponse = (String, mpsc::UnboundedReceiver<String>, Subscription
 pub struct ConnState<'a> {
 	/// Connection ID
 	pub conn_id: ConnectionId,
-	/// Get notified when the connection to subscribers is closed.
+	/// Get notified when the connection to subscribers is closed.1
 	pub close_notify: SubscriptionPermit,
 	/// ID provider.
 	pub id_provider: &'a dyn IdProvider,
@@ -114,8 +117,10 @@ pub enum MethodKind {
 	Sync(SyncMethod),
 	/// Asynchronous method handler.
 	Async(AsyncMethod<'static>),
-	/// Subscription method handler
+	/// Subscription method handler.
 	Subscription(SubscriptionMethod),
+	/// Unsubscription method handler.
+	Unsubscription(UnsubscriptionMethod),
 }
 
 /// Information about resources the method uses during its execution. Initialized when the the server starts.
@@ -189,6 +194,13 @@ impl MethodCallback {
 		}
 	}
 
+	fn new_unsubscription(callback: UnsubscriptionMethod) -> Self {
+		MethodCallback {
+			callback: MethodKind::Unsubscription(callback),
+			resources: MethodResources::Uninitialized([].into()),
+		}
+	}
+
 	/// Attempt to claim resources prior to executing a method. On success returns a guard that releases
 	/// claimed resources when dropped.
 	pub fn claim(&self, name: &str, resources: &Resources) -> Result<ResourceGuard, Error> {
@@ -210,6 +222,7 @@ impl Debug for MethodKind {
 			Self::Async(_) => write!(f, "Async"),
 			Self::Sync(_) => write!(f, "Sync"),
 			Self::Subscription(_) => write!(f, "Subscription"),
+			Self::Unsubscription(_) => write!(f, "Unsubscription"),
 		}
 	}
 }
@@ -404,6 +417,9 @@ impl Methods {
 			Some(MethodKind::Subscription(cb)) => {
 				let conn_state = ConnState { conn_id: 0, close_notify, id_provider: &RandomIntegerIdProvider };
 				(cb)(id, params, &sink, conn_state)
+			},
+			Some(MethodKind::Unsubscription(cb)) => {
+				(cb)(id, params, &sink, 0)
 			}
 		};
 
@@ -708,7 +724,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		{
 			self.methods.mut_callbacks().insert(
 				unsubscribe_method_name,
-				MethodCallback::new_subscription(Arc::new(move |id, params, sink, conn| {
+				MethodCallback::new_unsubscription(Arc::new(move |id, params, sink, conn_id| {
 					let sub_id = match params.one::<RpcSubscriptionId>() {
 						Ok(sub_id) => sub_id,
 						Err(_) => {
@@ -724,7 +740,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 					let sub_id = sub_id.into_owned();
 
 					let result =
-						subscribers.lock().remove(&SubscriptionKey { conn_id: conn.conn_id, sub_id }).is_some();
+						subscribers.lock().remove(&SubscriptionKey { conn_id, sub_id }).is_some();
 
 					sink.send_response(id, result)
 				})),

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tokio = { version = "1.8", features = ["full"] }
+tokio = { version = "1.16", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde_json = { version = "1" }
 

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -19,7 +19,7 @@ globset = "0.4"
 lazy_static = "1.4"
 tracing = "0.1"
 serde_json = "1"
-tokio = { version = "1.8", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.16", features = ["rt-multi-thread", "macros"] }
 unicase = "2.6.0"
 
 [dev-dependencies]

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -554,7 +554,7 @@ async fn process_validated_request(
 							false
 						}
 					},
-					MethodKind::Subscription(_) => {
+					MethodKind::Subscription(_) | MethodKind::Unsubscription(_) => {
 						tracing::error!("Subscriptions not supported on HTTP");
 						sink.send_error(req.id, ErrorCode::InternalError.into());
 						false
@@ -622,7 +622,7 @@ async fn process_validated_request(
 								None
 							}
 						},
-						MethodKind::Subscription(_) => {
+						MethodKind::Subscription(_) | MethodKind::Unsubscription(_) => {
 							tracing::error!("Subscriptions not supported on HTTP");
 							sink.send_error(req.id, ErrorCode::InternalError.into());
 							middleware.on_result(&req.method, false, request_start);

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -21,6 +21,6 @@ proc-macro-crate = "1"
 [dev-dependencies]
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 trybuild = "1.0"
-tokio = { version = "1.8", features = ["rt", "macros"] }
+tokio = { version = "1.16", features = ["rt", "macros"] }
 futures-channel = { version = "0.3.14", default-features = false }
 futures-util = { version = "0.3.14", default-features = false }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -16,5 +16,5 @@ tracing = "0.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 soketto = { version = "0.7.1", features = ["http"] }
-tokio = { version = "1.8", features = ["net", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,7 @@ env_logger = "0.9"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
-tokio = { version = "1.8", features = ["full"] }
+tokio = { version = "1.16", features = ["full"] }
 tracing = "0.1"
 serde = "1"
 serde_json = "1"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -17,7 +17,7 @@ jsonrpsee-core = { path = "../core", version = "0.11.0", features = ["server", "
 tracing = "0.1"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
-tokio = { version = "1.8", features = ["net", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 
 [dev-dependencies]

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -583,7 +583,7 @@ async fn background_task(
 													None
 												}
 											}
-										},
+										}
 										MethodKind::Unsubscription(callback) => {
 											match method_callback.claim(&req.method, resources) {
 												Ok(guard) => {

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -458,6 +458,23 @@ async fn background_task(
 									middleware.on_response(request_start);
 								}
 							},
+							MethodKind::Unsubscription(callback) => match method.claim(&req.method, &resources) {
+								Ok(guard) => {
+									let result = callback(id, params, &sink, conn_id);
+									middleware.on_result(name, result, request_start);
+									middleware.on_response(request_start);
+									drop(guard);
+								}
+								Err(err) => {
+									tracing::error!(
+										"[Methods::execute_with_resources] failed to lock resources: {:?}",
+										err
+									);
+									sink.send_error(req.id, ErrorCode::ServerIsBusy.into());
+									middleware.on_result(name, false, request_start);
+									middleware.on_response(request_start);
+								}
+							},
 						},
 					}
 				} else {
@@ -551,6 +568,26 @@ async fn background_task(
 														sink_batch.send_error(req.id, ErrorCode::ServerIsBusy.into());
 														false
 													};
+													middleware.on_result(&req.method, result, request_start);
+													drop(guard);
+													None
+												}
+												Err(err) => {
+													tracing::error!(
+														"[Methods::execute_with_resources] failed to lock resources: {:?}",
+														err
+													);
+
+													sink_batch.send_error(req.id, ErrorCode::ServerIsBusy.into());
+													middleware.on_result(&req.method, false, request_start);
+													None
+												}
+											}
+										},
+										MethodKind::Unsubscription(callback) => {
+											match method_callback.claim(&req.method, resources) {
+												Ok(guard) => {
+													let result = callback(id, params, &sink_batch, conn_id);
 													middleware.on_result(&req.method, result, request_start);
 													drop(guard);
 													None


### PR DESCRIPTION
Also point at Tokio 1.16 since we use a method added then.

This avoids acquiring a permit for unsubscribe calls, so that they always make it past the subscription limit.

(I wonder whether they should also avoid any resource claiming, too?)

This is to be merged into #739 if we're happy with the approach! 

Todo: 
- [ ] Add a test to check that unsubscribe methods make it past the limit.
- [ ] Check/fix proc macro stuff?
