### PR TITLE
Implement `ping-pong` for WebSocket server

### DIFF
--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 [dependencies]
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
-futures-timer = { version = "3" }
 jsonrpsee-types = { path = "../types", version = "0.13.1" }
 jsonrpsee-core = { path = "../core", version = "0.13.1", features = ["server", "soketto"] }
 tracing = "0.1"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 [dependencies]
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
+futures-timer = { version = "3" }
 jsonrpsee-types = { path = "../types", version = "0.13.1" }
 jsonrpsee-core = { path = "../core", version = "0.13.1", features = ["server", "soketto"] }
 tracing = "0.1"


### PR DESCRIPTION
This PR exposes the ping-pong interface of the WebSocket server.

This is the counterpart of the client #772, requested by #738 .


### Testing Done
- modified `examples/ws` into two binaries, one for the server, one for the client; started them with trace logs

```bash
2022-05-27T10:24:20.552095Z DEBUG jsonrpsee_ws_server::server: send ping
2022-05-27T10:24:20.552336Z TRACE soketto::connection: bd133ba0: send: (Ping (fin 1) (rsv 000) (mask (0 0)) (len 0))
2022-05-27T10:24:20.552676Z TRACE soketto::connection: bd133ba0: Sender flushing connection
2022-05-27T10:24:20.556269Z TRACE soketto: read 2 bytes
2022-05-27T10:24:20.556340Z TRACE soketto: read 4 bytes
2022-05-27T10:24:20.556374Z TRACE soketto::connection: bd133ba0: recv: (Pong (fin 1) (rsv 000) (mask (1 fba99e45)) (len 0))
2022-05-27T10:24:20.556414Z DEBUG jsonrpsee_ws_server::server: recv pong
```
