### PR TITLE
fix: skip leading whitespace

### DIFF
--- a/core/src/http_helpers.rs
+++ b/core/src/http_helpers.rs
@@ -54,7 +54,9 @@ pub async fn read_body(
 		return Err(GenericTransportError::TooLarge);
 	}
 
-	let single = match first_chunk.get(0) {
+	let first_non_whitespace = first_chunk.iter().find(|byte| !byte.is_ascii_whitespace());
+
+	let single = match first_non_whitespace {
 		Some(b'{') => true,
 		Some(b'[') => false,
 		_ => return Err(GenericTransportError::Malformed),

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -275,10 +275,6 @@ async fn garbage_request_fails() {
 	let response = http_request(req.into(), uri.clone()).await.unwrap();
 	assert_eq!(response.body, parse_error(Id::Null));
 
-	let req = r#"         {"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-	let response = http_request(req.into(), uri.clone()).await.unwrap();
-	assert_eq!(response.body, parse_error(Id::Null));
-
 	let req = r#"{}"#;
 	let response = http_request(req.into(), uri.clone()).await.unwrap();
 	assert_eq!(response.body, parse_error(Id::Null));
@@ -295,10 +291,6 @@ async fn garbage_request_fails() {
 	let response = http_request(req.into(), uri.clone()).await.unwrap();
 	assert_eq!(response.body, parse_error(Id::Null));
 
-	let req = r#" [{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}]"#;
-	let response = http_request(req.into(), uri.clone()).await.unwrap();
-	assert_eq!(response.body, parse_error(Id::Null));
-
 	let req = r#"[]"#;
 	let response = http_request(req.into(), uri.clone()).await.unwrap();
 	assert_eq!(response.body, invalid_request(Id::Null));
@@ -306,6 +298,24 @@ async fn garbage_request_fails() {
 	let req = r#"[{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
 	let response = http_request(req.into(), uri.clone()).await.unwrap();
 	assert_eq!(response.body, parse_error(Id::Null));
+}
+
+#[tokio::test]
+async fn whitespace_is_not_significant() {
+	let (addr, _handle) = server().with_default_timeout().await.unwrap();
+	let uri = to_http_uri(addr);
+
+	let req = r#"         {"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
+	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	let expected = r#"{"jsonrpc":"2.0","result":3,"id":1}"#;
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, expected);
+
+	let req = r#" [{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}]"#;
+	let response = http_request(req.into(), uri.clone()).await.unwrap();
+	let expected = r#"[{"jsonrpc":"2.0","result":3,"id":1}]"#;
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, expected);
 }
 
 #[tokio::test]

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -377,7 +377,9 @@ async fn background_task(
 
 		let request_start = middleware.on_request();
 
-		match data.get(0) {
+		let first_non_whitespace = data.iter().find(|byte| !byte.is_ascii_whitespace());
+
+		match first_non_whitespace {
 			Some(b'{') => {
 				if let Ok(req) = serde_json::from_slice::<Request>(&data) {
 					tracing::debug!("recv method call={}", req.method);

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -349,10 +349,6 @@ async fn garbage_request_fails() {
 	let response = client.send_request_text(req).await.unwrap();
 	assert_eq!(response, parse_error(Id::Null));
 
-	let req = r#"         {"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-	let response = client.send_request_text(req).await.unwrap();
-	assert_eq!(response, parse_error(Id::Null));
-
 	let req = r#"{}"#;
 	let response = client.send_request_text(req).await.unwrap();
 	assert_eq!(response, parse_error(Id::Null));
@@ -369,10 +365,6 @@ async fn garbage_request_fails() {
 	let response = client.send_request_text(req).await.unwrap();
 	assert_eq!(response, parse_error(Id::Null));
 
-	let req = r#" [{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}]"#;
-	let response = client.send_request_text(req).await.unwrap();
-	assert_eq!(response, parse_error(Id::Null));
-
 	let req = r#"[]"#;
 	let response = client.send_request_text(req).await.unwrap();
 	assert_eq!(response, invalid_request(Id::Null));
@@ -380,6 +372,20 @@ async fn garbage_request_fails() {
 	let req = r#"[{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
 	let response = client.send_request_text(req).await.unwrap();
 	assert_eq!(response, parse_error(Id::Null));
+}
+
+#[tokio::test]
+async fn whitespace_is_not_significant() {
+	let addr = server().await;
+	let mut client = WebSocketTestClient::new(addr).await.unwrap();
+
+	let req = r#"         {"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
+	let response = client.send_request_text(req).await.unwrap();
+	assert_eq!(response, ok_response(JsonValue::Number(3u32.into()), Id::Num(1)));
+
+	let req = r#" [{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}]"#;
+	let response = client.send_request_text(req).await.unwrap();
+	assert_eq!(response, r#"[{"jsonrpc":"2.0","result":3,"id":1}]"#);
 }
 
 #[tokio::test]


### PR DESCRIPTION
In json, whitespace is not significant, so we shouldn't rely on the first character to be { or |. serde_json parses such json
 just fine.