### PR TITLE
ws-server: Submit ping regardless of WS messages

### DIFF
--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
 tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
+tokio-stream = "0.1.7"
 
 [dev-dependencies]
 anyhow = "1"

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -51,6 +51,7 @@ use soketto::data::ByteSlice125;
 use soketto::handshake::{server::Response, Server as SokettoServer};
 use soketto::Sender;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio_stream::wrappers::IntervalStream;
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
 /// Default maximum connections allowed.
@@ -319,20 +320,24 @@ async fn background_task(
 	tokio::spawn(async move {
 		// Received messages from the WebSocket.
 		let mut rx_item = rx.next();
-		let mut submit_ping = Box::pin(tokio::time::sleep(ping_interval));
+
+		// Interval to send out continuously `pings`.
+		let ping_interval = IntervalStream::new(tokio::time::interval(ping_interval));
+		tokio::pin!(ping_interval);
+		let mut next_ping = ping_interval.next();
 
 		while !stop_server2.shutdown_requested() {
 			// Ensure select is cancel-safe by fetching and storing the `rx_item` that did not finish yet.
 			// Note: Although, this is cancel-safe already, avoid using `select!` macro for future proofing.
-			match futures_util::future::select(rx_item, submit_ping).await {
-				Either::Left((Some(response), next_ping)) => {
+			match futures_util::future::select(rx_item, next_ping).await {
+				Either::Left((Some(response), ping)) => {
 					// If websocket message send fail then terminate the connection.
 					if let Err(err) = send_ws_message(&mut sender, response).await {
 						tracing::warn!("WS send error: {}; terminate connection", err);
 						break;
 					}
 					rx_item = rx.next();
-					submit_ping = next_ping;
+					next_ping = ping;
 				}
 				// Nothing else to receive.
 				Either::Left((None, _)) => break,
@@ -344,7 +349,7 @@ async fn background_task(
 						break;
 					}
 					rx_item = next_rx;
-					submit_ping = Box::pin(tokio::time::sleep(ping_interval));
+					next_ping = ping_interval.next();
 				}
 			}
 		}


### PR DESCRIPTION
This PR ensures that a `Ping` frame is submitted regardless of WS traffic.

Previously, the ping interval timer was dropped with each iteration of the select loop.
As a result, we could encounter a scenario of `Ping` starvation, where pings are never
submitted due to WS traffic being received at a fast pace.

This ensures the ping interval timer is propagated and reinitialized when triggered, leading
to a `Ping` being submitted even if the server is handling messages.

One drawback of this approach is that the server spends some cycles handling the `Ping`
frames instead of the actual server load. One advantage is that the keep-alive functionality
is entirely handled via control frames, as opposed to either: ping interval being expired, or
WS messages handled.


### Testing Done
- manual testing performed with ws server and ws client
- ws server registered to submit pings every 2 seconds
- ws client submits requests every 1 second

```bash
> ping - 1
2022-06-02T12:12:52.781744Z DEBUG jsonrpsee_ws_server::server: send ping
2022-06-02T12:12:52.781967Z TRACE soketto::connection: 3918d5d9: send: (Ping (fin 1) (rsv 000) (mask (0 0)) (len 0))
2022-06-02T12:12:52.787939Z TRACE soketto::connection: 3918d5d9: recv: (Pong (fin 1) (rsv 000) (mask (1 7e9b6b21)) (len 0))
2022-06-02T12:12:52.788033Z DEBUG jsonrpsee_ws_server::server: recv pong

> request - 1
   2022-06-02T12:12:52.788106Z TRACE soketto::connection: 3918d5d9: recv: (Text (fin 1) (rsv 000) (mask (1 bfcc4e07)) (len 45))
   2022-06-02T12:12:52.791014Z TRACE jsonrpsee_ws_server::server: send: {"jsonrpc":"2.0","result":"lo","id":3}

> request - 2
   2022-06-02T12:12:53.798444Z TRACE soketto::connection: 3918d5d9: recv: (Text (fin 1) (rsv 000) (mask (1 daff6382)) (len 45))
   2022-06-02T12:12:53.798858Z TRACE jsonrpsee_ws_server::server: send: {"jsonrpc":"2.0","result":"lo","id":4}

> ping - 2
2022-06-02T12:12:54.783803Z DEBUG jsonrpsee_ws_server::server: send ping
2022-06-02T12:12:54.784021Z TRACE soketto::connection: 3918d5d9: send: (Ping (fin 1) (rsv 000) (mask (0 0)) (len 0))
2022-06-02T12:12:54.788594Z TRACE soketto::connection: 3918d5d9: recv: (Pong (fin 1) (rsv 000) (mask (1 6664414f)) (len 0))
2022-06-02T12:12:54.788635Z DEBUG jsonrpsee_ws_server::server: recv pong
```

