### PR TITLE
chore(deps): upgrade `tracing v0.1.34`

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["time"] }
-tracing = "0.1"
+tracing = "0.1.34"
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../../test-utils" }

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/jsonrpsee-ws-client"
 [dependencies]
 jsonrpsee-types = { path = "../../types", version = "0.14.0", optional = true }
 jsonrpsee-core = { path = "../../core", version = "0.14.0", features = ["client"] }
-tracing = "0.1"
+tracing = "0.1.34"
 
 # optional
 thiserror = { version = "1", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ async-channel = { version = "1.6", optional = true }
 async-lock = { version = "2.4", optional = true }
 futures-util = { version = "0.3.14", default-features = false, optional = true }
 hyper = { version = "0.14.10", default-features = false, features = ["stream"], optional = true }
-tracing = { version = "0.1", optional = true }
+tracing = { version = "0.1.34", optional = true }
 rustc-hash = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }
 soketto = { version = "0.7.1", optional = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 env_logger = "0.9"
 futures = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
-tracing = "0.1"
+tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 tokio = { version = "1.16", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -15,7 +15,7 @@ futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false }
 jsonrpsee-types = { path = "../types", version = "0.14.0" }
 jsonrpsee-core = { path = "../core", version = "0.14.0", features = ["server", "http-helpers"] }
-tracing = "0.1"
+tracing = "0.1.34"
 serde_json = { version = "1.0", features = ["raw_value"] }
 serde = "1"
 tokio = { version = "1.16", features = ["rt-multi-thread", "macros"] }

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -21,7 +21,7 @@ jsonrpsee-ws-server = { path = "../ws-server", version = "0.14.0", optional = tr
 jsonrpsee-proc-macros = { path = "../proc-macros", version = "0.14.0", optional = true }
 jsonrpsee-core = { path = "../core", version = "0.14.0", optional = true }
 jsonrpsee-types = { path = "../types", version = "0.14.0", optional = true }
-tracing = { version = "0.1", optional = true }
+tracing = { version = "0.1.34", optional = true }
 
 [features]
 client-ws-transport = ["jsonrpsee-client-transport/ws", "jsonrpsee-client-transport/tls"]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1"
 futures-channel = "0.3.14"
 futures-util = "0.3.14"
 hyper = { version = "0.14.10", features = ["full"] }
-tracing = "0.1"
+tracing = "0.1.34"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 soketto = { version = "0.7.1", features = ["http"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ beef = { version = "0.5.1", features = ["impl_serde"] }
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["full"] }
 tokio = { version = "1.16", features = ["full"] }
-tracing = "0.1"
+tracing = "0.1.34"
 serde = "1"
 serde_json = "1"
 hyper = { version = "0.14", features = ["http1", "client"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/jsonrpsee-types"
 [dependencies]
 anyhow = "1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
-tracing = { version = "0.1", default-features = false }
+tracing = { version = "0.1.34", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -14,7 +14,7 @@ futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
 jsonrpsee-types = { path = "../types", version = "0.14.0" }
 jsonrpsee-core = { path = "../core", version = "0.14.0", features = ["server", "soketto"] }
-tracing = "0.1"
+tracing = "0.1.34"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"
 tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }


### PR DESCRIPTION
To include the bugfix for `tracing::enabled!` when `log` is enabled.
Follow up on #722