### PR TITLE
Remove `deny_unknown_fields` from `Request` and `Response`

### DIFF
--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -353,6 +353,17 @@ async fn invalid_request_object() {
 }
 
 #[tokio::test]
+async fn unknown_field_is_ok() {
+	let (addr, _handle) = server().with_default_timeout().await.unwrap();
+	let uri = to_http_uri(addr);
+
+	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id":1,"is_not_request_object":1}"#;
+	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, ok_response(JsonValue::String("lo".to_owned()), Id::Num(1)));
+}
+
+#[tokio::test]
 async fn notif_works() {
 	let (addr, _handle) = server().with_default_timeout().await.unwrap();
 	let uri = to_http_uri(addr);

--- a/http-server/src/tests.rs
+++ b/http-server/src/tests.rs
@@ -346,7 +346,7 @@ async fn invalid_request_object() {
 	let (addr, _handle) = server().with_default_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
-	let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
+	let req = r#"{"method":"bar","id":1}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_request(Id::Num(1)));

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -34,7 +34,6 @@ use serde_json::value::RawValue;
 
 /// JSON-RPC request object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct Request<'a> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
@@ -67,7 +66,6 @@ pub struct InvalidRequest<'a> {
 /// JSON-RPC notification (a request object without a request ID) as defined in the
 /// [spec](https://www.jsonrpc.org/specification#request-object).
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct Notification<'a, T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -34,7 +34,6 @@ use serde::{Deserialize, Serialize};
 
 /// JSON-RPC successful response object as defined in the [spec](https://www.jsonrpc.org/specification#response_object).
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct Response<'a, T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -502,6 +502,16 @@ async fn invalid_request_object() {
 }
 
 #[tokio::test]
+async fn unknown_field_is_ok() {
+	let addr = server().await;
+	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
+
+	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id":1,"is_not_request_object":1}"#;
+	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response, ok_response(JsonValue::String("hello".to_owned()), Id::Num(1)));
+}
+
+#[tokio::test]
 async fn register_methods_works() {
 	let mut module = RpcModule::new(());
 	assert!(module.register_method("say_hello", |_, _| Ok("lo")).is_ok());

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -496,7 +496,7 @@ async fn invalid_request_object() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
-	let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
+	let req = r#"{"method":"bar","id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_request(Id::Num(1)));
 }
@@ -545,7 +545,7 @@ async fn invalid_request_should_not_close_connection() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
-	let req = r#"{"jsonrpc":"2.0","method":"bar","id":1,"is_not_request_object":1}"#;
+	let req = r#"{"method":"bar","id":1,"is_not_request_object":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_request(Id::Num(1)));
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":33}"#;

--- a/ws-server/src/tests.rs
+++ b/ws-server/src/tests.rs
@@ -545,7 +545,7 @@ async fn invalid_request_should_not_close_connection() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
-	let req = r#"{"method":"bar","id":1,"is_not_request_object":1}"#;
+	let req = r#"{"method":"bar","id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_request(Id::Num(1)));
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":33}"#;


### PR DESCRIPTION
Solves #797 

@niklasad1 please let me know if this is prefered over keeping optional `deny_unknown_fields` behind a feature.