### PR TITLE
Uniform API for custom headers between clients 

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0"
 tokio = { version = "1.16", features = ["time"] }
 tracing = "0.1.34"
 tracing-futures = "0.2.5"
+http = "0.2.0"
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../../test-utils" }

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -22,7 +22,6 @@ thiserror = "1.0"
 tokio = { version = "1.16", features = ["time"] }
 tracing = "0.1.34"
 tracing-futures = "0.2.5"
-http = "0.2.0"
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../../test-utils" }

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -39,6 +39,29 @@ use serde::de::DeserializeOwned;
 use tracing_futures::Instrument;
 
 /// Http Client Builder.
+///
+/// # Examples
+///
+/// ```no_run
+///
+/// use jsonrpsee_http_client::HttpClientBuilder;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     // Build custom headers used for every submitted request.
+///     let mut headers = http::HeaderMap::new();
+///     headers.insert("Any-Header-You-Like", http::HeaderValue::from_static("42"));
+///
+///     // Build client
+///     let client = HttpClientBuilder::default()
+///          .set_headers(headers)
+///          .build("wss://localhost:443")
+///          .unwrap();
+///
+///     // use client....
+/// }
+///
+/// ```
 #[derive(Debug)]
 pub struct HttpClientBuilder {
 	max_request_body_size: u32,

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -46,12 +46,13 @@ use tracing_futures::Instrument;
 /// ```no_run
 ///
 /// use jsonrpsee_http_client::HttpClientBuilder;
+/// use hyper::http::{HeaderMap, HeaderValue};
 ///
 /// #[tokio::main]
 /// async fn main() {
 ///     // Build custom headers used for every submitted request.
-///     let mut headers = http::HeaderMap::new();
-///     headers.insert("Any-Header-You-Like", http::HeaderValue::from_static("42"));
+///     let mut headers = HeaderMap::new();
+///     headers.insert("Any-Header-You-Like", HeaderValue::from_static("42"));
 ///
 ///     // Build client
 ///     let client = HttpClientBuilder::default()

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -45,8 +45,7 @@ use tracing_futures::Instrument;
 ///
 /// ```no_run
 ///
-/// use jsonrpsee_http_client::HttpClientBuilder;
-/// use hyper::http::{HeaderMap, HeaderValue};
+/// use jsonrpsee_http_client::{HttpClientBuilder, HeaderMap, HeaderValue};
 ///
 /// #[tokio::main]
 /// async fn main() {

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -47,7 +47,7 @@ pub struct HttpClientBuilder {
 	certificate_store: CertificateStore,
 	id_kind: IdKind,
 	max_log_length: u32,
-	headers: Option<http::HeaderMap>,
+	headers: http::HeaderMap,
 }
 
 impl HttpClientBuilder {
@@ -93,7 +93,7 @@ impl HttpClientBuilder {
 	///
 	/// The caller is responsible for checking that the headers do not conflict or are duplicated.
 	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
-		self.headers = Some(headers);
+		self.headers = headers;
 		self
 	}
 
@@ -124,7 +124,7 @@ impl Default for HttpClientBuilder {
 			certificate_store: CertificateStore::Native,
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
-			headers: None,
+			headers: http::HeaderMap::new(),
 		}
 	}
 }

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 use crate::transport::HttpTransportClient;
 use crate::types::{ErrorResponse, Id, NotificationSer, ParamsSer, RequestSer, Response};
 use async_trait::async_trait;
+use hyper::http::HeaderMap;
 use jsonrpsee_core::client::{CertificateStore, ClientT, IdKind, RequestIdManager, Subscription, SubscriptionClientT};
 use jsonrpsee_core::tracing::RpcTracing;
 use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
@@ -70,7 +71,7 @@ pub struct HttpClientBuilder {
 	certificate_store: CertificateStore,
 	id_kind: IdKind,
 	max_log_length: u32,
-	headers: http::HeaderMap,
+	headers: HeaderMap,
 }
 
 impl HttpClientBuilder {
@@ -115,7 +116,7 @@ impl HttpClientBuilder {
 	/// Set a custom header passed to the server with every request (default is none).
 	///
 	/// The caller is responsible for checking that the headers do not conflict or are duplicated.
-	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
+	pub fn set_headers(mut self, headers: HeaderMap) -> Self {
 		self.headers = headers;
 		self
 	}
@@ -147,7 +148,7 @@ impl Default for HttpClientBuilder {
 			certificate_store: CertificateStore::Native,
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
-			headers: http::HeaderMap::new(),
+			headers: HeaderMap::new(),
 		}
 	}
 }

--- a/client/http-client/src/lib.rs
+++ b/client/http-client/src/lib.rs
@@ -43,4 +43,5 @@ pub mod transport;
 mod tests;
 
 pub use client::{HttpClient, HttpClientBuilder};
+pub use hyper::http::{HeaderMap, HeaderValue};
 pub use jsonrpsee_types as types;

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -7,6 +7,7 @@
 // the JSON-RPC request id to a value that might have already been used.
 
 use hyper::client::{Client, HttpConnector};
+use hyper::http::HeaderMap;
 use hyper::Uri;
 use jsonrpsee_core::client::CertificateStore;
 use jsonrpsee_core::error::GenericTransportError;
@@ -49,7 +50,7 @@ pub struct HttpTransportClient {
 	/// Logs bigger than this limit will be truncated.
 	max_log_length: u32,
 	/// Custom headers to pass with every request.
-	headers: http::HeaderMap,
+	headers: HeaderMap,
 }
 
 impl HttpTransportClient {
@@ -59,7 +60,7 @@ impl HttpTransportClient {
 		max_request_body_size: u32,
 		cert_store: CertificateStore,
 		max_log_length: u32,
-		headers: http::HeaderMap,
+		headers: HeaderMap,
 	) -> Result<Self, Error> {
 		let target: Uri = target.as_ref().parse().map_err(|e| Error::Url(format!("Invalid URL: {}", e)))?;
 		if target.port_u16().is_none() {
@@ -97,7 +98,7 @@ impl HttpTransportClient {
 		// Cache request headers: 2 default headers, followed by user custom headers.
 		// Maintain order for headers in case of duplicate keys:
 		// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2
-		let mut cached_headers = http::HeaderMap::with_capacity(2 + headers.len());
+		let mut cached_headers = HeaderMap::with_capacity(2 + headers.len());
 		cached_headers.insert(hyper::header::CONTENT_TYPE, hyper::header::HeaderValue::from_static(CONTENT_TYPE_JSON));
 		cached_headers.insert(hyper::header::ACCEPT, hyper::header::HeaderValue::from_static(CONTENT_TYPE_JSON));
 		for (key, value) in headers.into_iter() {

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -206,36 +206,39 @@ mod tests {
 
 	#[test]
 	fn invalid_http_url_rejected() {
-		let err = HttpTransportClient::new("ws://localhost:9933", 80, CertificateStore::Native, 80).unwrap_err();
+		let err = HttpTransportClient::new("ws://localhost:9933", 80, CertificateStore::Native, 80, None).unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 
 	#[cfg(feature = "tls")]
 	#[test]
 	fn https_works() {
-		let client = HttpTransportClient::new("https://localhost:9933", 80, CertificateStore::Native, 80).unwrap();
+		let client =
+			HttpTransportClient::new("https://localhost:9933", 80, CertificateStore::Native, 80, None).unwrap();
 		assert_target(&client, "localhost", "https", "/", 9933, 80);
 	}
 
 	#[cfg(not(feature = "tls"))]
 	#[test]
 	fn https_fails_without_tls_feature() {
-		let err = HttpTransportClient::new("https://localhost:9933", 80, CertificateStore::Native, 80).unwrap_err();
+		let err =
+			HttpTransportClient::new("https://localhost:9933", 80, CertificateStore::Native, 80, None).unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 
 	#[test]
 	fn faulty_port() {
-		let err = HttpTransportClient::new("http://localhost:-43", 80, CertificateStore::Native, 80).unwrap_err();
+		let err = HttpTransportClient::new("http://localhost:-43", 80, CertificateStore::Native, 80, None).unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
-		let err = HttpTransportClient::new("http://localhost:-99999", 80, CertificateStore::Native, 80).unwrap_err();
+		let err =
+			HttpTransportClient::new("http://localhost:-99999", 80, CertificateStore::Native, 80, None).unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 
 	#[test]
 	fn url_with_path_works() {
 		let client =
-			HttpTransportClient::new("http://localhost:9944/my-special-path", 1337, CertificateStore::Native, 80)
+			HttpTransportClient::new("http://localhost:9944/my-special-path", 1337, CertificateStore::Native, 80, None)
 				.unwrap();
 		assert_target(&client, "localhost", "http", "/my-special-path", 9944, 1337);
 	}
@@ -247,6 +250,7 @@ mod tests {
 			u32::MAX,
 			CertificateStore::WebPki,
 			80,
+			None,
 		)
 		.unwrap();
 		assert_target(&client, "127.0.0.1", "http", "/my?name1=value1&name2=value2", 9999, u32::MAX);
@@ -255,14 +259,15 @@ mod tests {
 	#[test]
 	fn url_with_fragment_is_ignored() {
 		let client =
-			HttpTransportClient::new("http://127.0.0.1:9944/my.htm#ignore", 999, CertificateStore::Native, 80).unwrap();
+			HttpTransportClient::new("http://127.0.0.1:9944/my.htm#ignore", 999, CertificateStore::Native, 80, None)
+				.unwrap();
 		assert_target(&client, "127.0.0.1", "http", "/my.htm", 9944, 999);
 	}
 
 	#[tokio::test]
 	async fn request_limit_works() {
 		let eighty_bytes_limit = 80;
-		let client = HttpTransportClient::new("http://localhost:9933", 80, CertificateStore::WebPki, 99).unwrap();
+		let client = HttpTransportClient::new("http://localhost:9933", 80, CertificateStore::WebPki, 99, None).unwrap();
 		assert_eq!(client.max_request_body_size, eighty_bytes_limit);
 
 		let body = "a".repeat(81);

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -7,7 +7,7 @@
 // the JSON-RPC request id to a value that might have already been used.
 
 use hyper::client::{Client, HttpConnector};
-use hyper::http::HeaderMap;
+use hyper::http::{HeaderMap, HeaderValue};
 use hyper::Uri;
 use jsonrpsee_core::client::CertificateStore;
 use jsonrpsee_core::error::GenericTransportError;
@@ -99,8 +99,8 @@ impl HttpTransportClient {
 		// Maintain order for headers in case of duplicate keys:
 		// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2
 		let mut cached_headers = HeaderMap::with_capacity(2 + headers.len());
-		cached_headers.insert(hyper::header::CONTENT_TYPE, hyper::header::HeaderValue::from_static(CONTENT_TYPE_JSON));
-		cached_headers.insert(hyper::header::ACCEPT, hyper::header::HeaderValue::from_static(CONTENT_TYPE_JSON));
+		cached_headers.insert(hyper::header::CONTENT_TYPE, HeaderValue::from_static(CONTENT_TYPE_JSON));
+		cached_headers.insert(hyper::header::ACCEPT, HeaderValue::from_static(CONTENT_TYPE_JSON));
 		for (key, value) in headers.into_iter() {
 			if let Some(key) = key {
 				cached_headers.insert(key, value);

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -100,8 +100,10 @@ impl HttpTransportClient {
 		let mut cached_headers = http::HeaderMap::with_capacity(2 + headers.len());
 		cached_headers.insert(hyper::header::CONTENT_TYPE, hyper::header::HeaderValue::from_static(CONTENT_TYPE_JSON));
 		cached_headers.insert(hyper::header::ACCEPT, hyper::header::HeaderValue::from_static(CONTENT_TYPE_JSON));
-		for (key, value) in headers.iter() {
-			cached_headers.insert(key, value.clone());
+		for (key, value) in headers.into_iter() {
+			if let Some(key) = key {
+				cached_headers.insert(key, value);
+			}
 		}
 
 		Ok(Self { target, client, max_request_body_size, max_log_length, headers: cached_headers })

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -194,7 +194,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::{CertificateStore, Error, HttpTransportClient};
+	use super::*;
 
 	fn assert_target(
 		client: &HttpTransportClient,
@@ -213,54 +213,37 @@ mod tests {
 
 	#[test]
 	fn invalid_http_url_rejected() {
-		let err =
-			HttpTransportClient::new("ws://localhost:9933", 80, CertificateStore::Native, 80, http::HeaderMap::new())
-				.unwrap_err();
+		let err = HttpTransportClient::new("ws://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new())
+			.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 
 	#[cfg(feature = "tls")]
 	#[test]
 	fn https_works() {
-		let client = HttpTransportClient::new(
-			"https://localhost:9933",
-			80,
-			CertificateStore::Native,
-			80,
-			http::HeaderMap::new(),
-		)
-		.unwrap();
+		let client =
+			HttpTransportClient::new("https://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new())
+				.unwrap();
 		assert_target(&client, "localhost", "https", "/", 9933, 80);
 	}
 
 	#[cfg(not(feature = "tls"))]
 	#[test]
 	fn https_fails_without_tls_feature() {
-		let err = HttpTransportClient::new(
-			"https://localhost:9933",
-			80,
-			CertificateStore::Native,
-			80,
-			http::HeaderMap::new(),
-		)
-		.unwrap_err();
+		let err =
+			HttpTransportClient::new("https://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new())
+				.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 
 	#[test]
 	fn faulty_port() {
-		let err =
-			HttpTransportClient::new("http://localhost:-43", 80, CertificateStore::Native, 80, http::HeaderMap::new())
-				.unwrap_err();
+		let err = HttpTransportClient::new("http://localhost:-43", 80, CertificateStore::Native, 80, HeaderMap::new())
+			.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
-		let err = HttpTransportClient::new(
-			"http://localhost:-99999",
-			80,
-			CertificateStore::Native,
-			80,
-			http::HeaderMap::new(),
-		)
-		.unwrap_err();
+		let err =
+			HttpTransportClient::new("http://localhost:-99999", 80, CertificateStore::Native, 80, HeaderMap::new())
+				.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 
@@ -271,7 +254,7 @@ mod tests {
 			1337,
 			CertificateStore::Native,
 			80,
-			http::HeaderMap::new(),
+			HeaderMap::new(),
 		)
 		.unwrap();
 		assert_target(&client, "localhost", "http", "/my-special-path", 9944, 1337);
@@ -284,7 +267,7 @@ mod tests {
 			u32::MAX,
 			CertificateStore::WebPki,
 			80,
-			http::HeaderMap::new(),
+			HeaderMap::new(),
 		)
 		.unwrap();
 		assert_target(&client, "127.0.0.1", "http", "/my?name1=value1&name2=value2", 9999, u32::MAX);
@@ -297,7 +280,7 @@ mod tests {
 			999,
 			CertificateStore::Native,
 			80,
-			http::HeaderMap::new(),
+			HeaderMap::new(),
 		)
 		.unwrap();
 		assert_target(&client, "127.0.0.1", "http", "/my.htm", 9944, 999);
@@ -307,7 +290,7 @@ mod tests {
 	async fn request_limit_works() {
 		let eighty_bytes_limit = 80;
 		let client =
-			HttpTransportClient::new("http://localhost:9933", 80, CertificateStore::WebPki, 99, http::HeaderMap::new())
+			HttpTransportClient::new("http://localhost:9933", 80, CertificateStore::WebPki, 99, HeaderMap::new())
 				.unwrap();
 		assert_eq!(client.max_request_body_size, eighty_bytes_limit);
 

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -42,7 +42,7 @@ use stream::EitherStream;
 use thiserror::Error;
 use tokio::net::TcpStream;
 
-pub use http::{uri::InvalidUri, Uri};
+pub use http::{uri::InvalidUri, HeaderMap, HeaderValue, Uri};
 pub use soketto::handshake::client::Header;
 
 /// Sending end of WebSocket transport.

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -65,7 +65,7 @@ pub struct WsTransportClientBuilder {
 	/// Timeout for the connection.
 	pub connection_timeout: Duration,
 	/// Custom headers to pass during the HTTP handshake.
-	pub headers: http::HeaderMap,
+	pub headers: Option<http::HeaderMap>,
 	/// Max payload size
 	pub max_request_body_size: u32,
 	/// Max number of redirections.
@@ -78,7 +78,7 @@ impl Default for WsTransportClientBuilder {
 			certificate_store: CertificateStore::Native,
 			max_request_body_size: TEN_MB_SIZE_BYTES,
 			connection_timeout: Duration::from_secs(10),
-			headers: http::HeaderMap::new(),
+			headers: None,
 			max_redirections: 5,
 		}
 	}
@@ -107,7 +107,7 @@ impl WsTransportClientBuilder {
 	///
 	/// The caller is responsible for checking that the headers do not conflict or are duplicated.
 	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
-		self.headers = headers;
+		self.headers = Some(headers);
 		self
 	}
 
@@ -288,11 +288,15 @@ impl WsTransportClientBuilder {
 					&target.path_and_query,
 				);
 
-				let headers: Vec<_> = self
-					.headers
-					.iter()
-					.map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() })
-					.collect();
+				let headers: Vec<_> = if let Some(header_map) = &self.headers {
+					header_map
+						.iter()
+						.map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() })
+						.collect()
+				} else {
+					// Avoid defaults when `http:HeaderMap` is added to `soketto`.
+					Default::default()
+				};
 
 				client.set_headers(&headers);
 

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -65,7 +65,7 @@ pub struct WsTransportClientBuilder {
 	/// Timeout for the connection.
 	pub connection_timeout: Duration,
 	/// Custom headers to pass during the HTTP handshake.
-	pub headers: Option<http::HeaderMap>,
+	pub headers: http::HeaderMap,
 	/// Max payload size
 	pub max_request_body_size: u32,
 	/// Max number of redirections.
@@ -78,7 +78,7 @@ impl Default for WsTransportClientBuilder {
 			certificate_store: CertificateStore::Native,
 			max_request_body_size: TEN_MB_SIZE_BYTES,
 			connection_timeout: Duration::from_secs(10),
-			headers: None,
+			headers: http::HeaderMap::new(),
 			max_redirections: 5,
 		}
 	}
@@ -107,7 +107,7 @@ impl WsTransportClientBuilder {
 	///
 	/// The caller is responsible for checking that the headers do not conflict or are duplicated.
 	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
-		self.headers = Some(headers);
+		self.headers = headers;
 		self
 	}
 
@@ -288,16 +288,11 @@ impl WsTransportClientBuilder {
 					&target.path_and_query,
 				);
 
-				let headers: Vec<_> = if let Some(header_map) = &self.headers {
-					header_map
-						.iter()
-						.map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() })
-						.collect()
-				} else {
-					// Avoid defaults when `http:HeaderMap` is added to `soketto`.
-					Default::default()
-				};
-
+				let headers: Vec<_> = self
+					.headers
+					.iter()
+					.map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() })
+					.collect();
 				client.set_headers(&headers);
 
 				// Perform the initial handshake.

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/jsonrpsee-ws-client"
 jsonrpsee-types = { path = "../../types", version = "0.14.0" }
 jsonrpsee-client-transport = { path = "../transport", version = "0.14.0", features = ["ws"] }
 jsonrpsee-core = { path = "../../core", version = "0.14.0", features = ["async-client"] }
+http = "0.2.0"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -40,6 +40,7 @@ mod tests;
 pub use jsonrpsee_core::client::Client as WsClient;
 pub use jsonrpsee_types as types;
 
+pub use http::{HeaderMap, HeaderValue};
 use std::time::Duration;
 
 use jsonrpsee_client_transport::ws::{InvalidUri, Uri, WsTransportClientBuilder};
@@ -52,13 +53,13 @@ use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 ///
 /// ```no_run
 ///
-/// use jsonrpsee_ws_client::WsClientBuilder;
+/// use jsonrpsee_ws_client::{WsClientBuilder, HeaderMap, HeaderValue};
 ///
 /// #[tokio::main]
 /// async fn main() {
 ///     // Build custom headers used during the handshake process.
-///     let mut headers = http::HeaderMap::new();
-///     headers.insert("Any-Header-You-Like", http::HeaderValue::from_static("42"));
+///     let mut headers = HeaderMap::new();
+///     headers.insert("Any-Header-You-Like", HeaderValue::from_static("42"));
 ///
 ///     // Build client
 ///     let client = WsClientBuilder::default()
@@ -93,7 +94,7 @@ impl Default for WsClientBuilder {
 			request_timeout: Duration::from_secs(60),
 			connection_timeout: Duration::from_secs(10),
 			ping_interval: None,
-			headers: http::HeaderMap::new(),
+			headers: HeaderMap::new(),
 			max_concurrent_requests: 256,
 			max_notifs_per_subscription: 1024,
 			max_redirections: 5,

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -74,7 +74,7 @@ pub struct WsClientBuilder {
 	request_timeout: Duration,
 	connection_timeout: Duration,
 	ping_interval: Option<Duration>,
-	headers: Option<http::HeaderMap>,
+	headers: http::HeaderMap,
 	max_concurrent_requests: usize,
 	max_notifs_per_subscription: usize,
 	max_redirections: usize,
@@ -89,7 +89,7 @@ impl Default for WsClientBuilder {
 			request_timeout: Duration::from_secs(60),
 			connection_timeout: Duration::from_secs(10),
 			ping_interval: None,
-			headers: None,
+			headers: http::HeaderMap::new(),
 			max_concurrent_requests: 256,
 			max_notifs_per_subscription: 1024,
 			max_redirections: 5,
@@ -131,7 +131,7 @@ impl WsClientBuilder {
 
 	/// See documentation [`WsTransportClientBuilder::set_headers`] (default is none).
 	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
-		self.headers = Some(headers);
+		self.headers = headers;
 		self
 	}
 

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -57,8 +57,10 @@ use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 /// #[tokio::main]
 /// async fn main() {
 ///     // build client
+///     let mut headers = http::HeaderMap::new();
+///     headers.insert("Any-Header-You-Like", http::HeaderValue::from_static("42"));
 ///     let client = WsClientBuilder::default()
-///          .add_header("Any-Header-You-Like", "42")
+///          .set_headers(headers)
 ///          .build("wss://localhost:443")
 ///          .await
 ///          .unwrap();

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -56,9 +56,11 @@ use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // build client
+///     // Build custom headers used during the handshake process.
 ///     let mut headers = http::HeaderMap::new();
 ///     headers.insert("Any-Header-You-Like", http::HeaderValue::from_static("42"));
+///
+///     // Build client
 ///     let client = WsClientBuilder::default()
 ///          .set_headers(headers)
 ///          .build("wss://localhost:443")

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -42,7 +42,7 @@ pub use jsonrpsee_types as types;
 
 use std::time::Duration;
 
-use jsonrpsee_client_transport::ws::{Header, InvalidUri, Uri, WsTransportClientBuilder};
+use jsonrpsee_client_transport::ws::{InvalidUri, Uri, WsTransportClientBuilder};
 use jsonrpsee_core::client::{CertificateStore, ClientBuilder, IdKind};
 use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 
@@ -68,20 +68,20 @@ use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 ///
 /// ```
 #[derive(Clone, Debug)]
-pub struct WsClientBuilder<'a> {
+pub struct WsClientBuilder {
 	certificate_store: CertificateStore,
 	max_request_body_size: u32,
 	request_timeout: Duration,
 	connection_timeout: Duration,
 	ping_interval: Option<Duration>,
-	headers: Vec<Header<'a>>,
+	headers: http::HeaderMap,
 	max_concurrent_requests: usize,
 	max_notifs_per_subscription: usize,
 	max_redirections: usize,
 	id_kind: IdKind,
 }
 
-impl<'a> Default for WsClientBuilder<'a> {
+impl Default for WsClientBuilder {
 	fn default() -> Self {
 		Self {
 			certificate_store: CertificateStore::Native,
@@ -89,7 +89,7 @@ impl<'a> Default for WsClientBuilder<'a> {
 			request_timeout: Duration::from_secs(60),
 			connection_timeout: Duration::from_secs(10),
 			ping_interval: None,
-			headers: Vec::new(),
+			headers: http::HeaderMap::new(),
 			max_concurrent_requests: 256,
 			max_notifs_per_subscription: 1024,
 			max_redirections: 5,
@@ -98,7 +98,7 @@ impl<'a> Default for WsClientBuilder<'a> {
 	}
 }
 
-impl<'a> WsClientBuilder<'a> {
+impl WsClientBuilder {
 	/// See documentation [`WsTransportClientBuilder::certificate_store`] (default is native).
 	pub fn certificate_store(mut self, certificate_store: CertificateStore) -> Self {
 		self.certificate_store = certificate_store;
@@ -129,9 +129,9 @@ impl<'a> WsClientBuilder<'a> {
 		self
 	}
 
-	/// See documentation [`WsTransportClientBuilder::add_header`] (default is none).
-	pub fn add_header(mut self, name: &'a str, value: &'a str) -> Self {
-		self.headers.push(Header { name, value: value.as_bytes() });
+	/// See documentation [`WsTransportClientBuilder::set_headers`] (default is none).
+	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
+		self.headers = headers;
 		self
 	}
 

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -74,7 +74,7 @@ pub struct WsClientBuilder {
 	request_timeout: Duration,
 	connection_timeout: Duration,
 	ping_interval: Option<Duration>,
-	headers: http::HeaderMap,
+	headers: Option<http::HeaderMap>,
 	max_concurrent_requests: usize,
 	max_notifs_per_subscription: usize,
 	max_redirections: usize,
@@ -89,7 +89,7 @@ impl Default for WsClientBuilder {
 			request_timeout: Duration::from_secs(60),
 			connection_timeout: Duration::from_secs(10),
 			ping_interval: None,
-			headers: http::HeaderMap::new(),
+			headers: None,
 			max_concurrent_requests: 256,
 			max_notifs_per_subscription: 1024,
 			max_redirections: 5,
@@ -131,7 +131,7 @@ impl WsClientBuilder {
 
 	/// See documentation [`WsTransportClientBuilder::set_headers`] (default is none).
 	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
-		self.headers = headers;
+		self.headers = Some(headers);
 		self
 	}
 


### PR DESCRIPTION
Jsonrpsee allows users to set custom headers during the WS handshake (for the ws-clients).

This PR extends the ability to add custom headers for the HTTP clients.

The PR introduces a uniform API for the client builders, relying on `http::HeaderMap`
```rust
pub fn set_headers(mut self, headers: http::HeaderMap) -> Self
```
that behaves as follows:
- ws-client: Custom headers are used only during the handshake
- http-client: Custom headers are submitted with every request

One advantage is that the ws-client and http-client have a uniform API, used for caching or any custom user operations, extending jsonrpsee beyond the realm of the `Substrate`.
One disadvantage is that ws-client uses `soketto` that internally requires an `httparse::Header` object, which leads to conversion from `http::HeaderMap` only if present.

### Next Steps
- [x] Write documentation to illustrate differences between ws/http clients

Closes #809.