### PR TITLE
ws-server: Handle `soketto::Incoming::Closed` frames

### DIFF
--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -394,7 +394,12 @@ async fn background_task(
 					match receiver.receive(&mut data).await? {
 						soketto::Incoming::Data(d) => break Ok(d),
 						soketto::Incoming::Pong(_) => tracing::debug!("recv pong"),
-						_ => continue,
+						soketto::Incoming::Closed(reason) => {
+							// Log the close reason for debugging purposes and return the `Closed` error
+							// to avoid logging unnecessary warnings on clean shutdown.
+							tracing::debug!("WS transport: connection: {} closed with reason: {:?} ", conn_id, reason);
+							break Err(SokettoError::Closed);
+						}
 					}
 				}
 			};

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -395,7 +395,7 @@ async fn background_task(
 						soketto::Incoming::Data(d) => break Ok(d),
 						soketto::Incoming::Pong(_) => tracing::debug!("recv pong"),
 						soketto::Incoming::Closed(_) => {
-							// The closing reason is already logged by `sokketo` trace log level.
+							// The closing reason is already logged by `soketto` trace log level.
 							// Return the `Closed` error to avoid logging unnecessary warnings on clean shutdown.
 							break Err(SokettoError::Closed);
 						}

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -424,7 +424,7 @@ async fn background_task(
 					}
 					// These errors can not be gracefully handled, so just log them and terminate the connection.
 					MonitoredError::Selector(err) => {
-						tracing::warn!("WS error: {}; terminate connection {}", err, conn_id);
+						tracing::debug!("WS error: {}; terminate connection {}", err, conn_id);
 						sink.close();
 						break Err(err.into());
 					}

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -394,10 +394,9 @@ async fn background_task(
 					match receiver.receive(&mut data).await? {
 						soketto::Incoming::Data(d) => break Ok(d),
 						soketto::Incoming::Pong(_) => tracing::debug!("recv pong"),
-						soketto::Incoming::Closed(reason) => {
-							// Log the close reason for debugging purposes and return the `Closed` error
-							// to avoid logging unnecessary warnings on clean shutdown.
-							tracing::debug!("WS transport: connection: {} closed with reason: {:?} ", conn_id, reason);
+						soketto::Incoming::Closed(_) => {
+							// The closing reason is already logged by `sokketo` trace log level.
+							// Return the `Closed` error to avoid logging unnecessary warnings on clean shutdown.
 							break Err(SokettoError::Closed);
 						}
 					}


### PR DESCRIPTION
Ensure that incoming `Closed` frames are not ignored.

This PR captures the close reason for the connection when detected by the `receiver`.

While at it, the `WS error` log line was polluting internal metrics when clients disconnected suddenly. Have changed it from `warning` to `debug`.

### Logs 
- obtained with a custom client that closes its sender part in the `background_task` 

```rust
2022-07-06T15:21:18.739200Z TRACE soketto::connection: e0000f78: recv, incoming CLOSE: CloseReason { code: 1000, descr: Some("") }
2022-07-06T15:21:18.739225Z DEBUG jsonrpsee_ws_server::server: WS transport: remote peer terminated the connection: 1
```

Closes #813 .