### PR TITLE
Refactor HTTP header validation

### DIFF
--- a/core/src/http_helpers.rs
+++ b/core/src/http_helpers.rs
@@ -106,7 +106,7 @@ pub fn read_header_values<'a>(
 }
 
 /// Get the header values from the `access-control-request-headers` header.
-pub fn get_cors_request_headers<'a>(headers: &'a hyper::header::HeaderMap) -> impl Iterator<Item = &str> {
+pub fn get_cors_request_headers(headers: &hyper::header::HeaderMap) -> impl Iterator<Item=&str> {
 	const ACCESS_CONTROL_REQUEST_HEADERS: &str = "access-control-request-headers";
 
 	read_header_values(headers, ACCESS_CONTROL_REQUEST_HEADERS)

--- a/core/src/server/access_control/cors.rs
+++ b/core/src/server/access_control/cors.rs
@@ -322,13 +322,18 @@ lazy_static! {
 	/// Returns headers which are always allowed.
 	static ref ALWAYS_ALLOWED_HEADERS: HashSet<Ascii<&'static str>> = {
 		let mut hs = HashSet::new();
+		// CORS safelisted: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
 		hs.insert(Ascii::new("Accept"));
 		hs.insert(Ascii::new("Accept-Language"));
-		hs.insert(Ascii::new("Access-Control-Request-Headers"));
 		hs.insert(Ascii::new("Content-Language"));
 		hs.insert(Ascii::new("Content-Type"));
-		hs.insert(Ascii::new("Host"));
+
+		// CORS preflight request: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
 		hs.insert(Ascii::new("Origin"));
+		hs.insert(Ascii::new("Access-Control-Request-Headers"));
+		hs.insert(Ascii::new("Access-Control-Request-Method"));
+
+		hs.insert(Ascii::new("Host"));
 		hs.insert(Ascii::new("Content-Length"));
 		hs.insert(Ascii::new("Connection"));
 		hs.insert(Ascii::new("User-Agent"));

--- a/core/src/server/access_control/cors.rs
+++ b/core/src/server/access_control/cors.rs
@@ -333,10 +333,12 @@ lazy_static! {
 		hs.insert(Ascii::new("Access-Control-Request-Headers"));
 		hs.insert(Ascii::new("Access-Control-Request-Method"));
 
+		// All requests must have a valid "Host" value that is filtered internally.
 		hs.insert(Ascii::new("Host"));
+		// "Content-Length" is capped by `max_request_body_size` (Default: 10 MB)
 		hs.insert(Ascii::new("Content-Length"));
+		// Set by various tools: (ie `User-Agent: curl/7.79.1`).
 		hs.insert(Ascii::new("Connection"));
-		hs.insert(Ascii::new("User-Agent"));
 		hs
 	};
 }

--- a/core/src/server/access_control/cors.rs
+++ b/core/src/server/access_control/cors.rs
@@ -274,7 +274,7 @@ pub(crate) fn get_cors_allow_headers<T: AsRef<str>, O, F: Fn(T) -> O>(
 	cors_allow_headers: &AllowHeaders,
 	to_result: F,
 ) -> AllowCors<Vec<O>> {
-	// Check if the header fields which were sent in the request are allowed
+	// When CORS headers are strictly filtered, the provided request headers must match exactly the filtering CORS list.
 	if let AllowHeaders::Only(only) = cors_allow_headers {
 		let are_all_allowed = headers.all(|header| {
 			let name = &Ascii::new(header.as_ref());

--- a/core/src/server/access_control/cors.rs
+++ b/core/src/server/access_control/cors.rs
@@ -278,7 +278,7 @@ pub(crate) fn get_cors_allow_headers<T: AsRef<str>, O, F: Fn(T) -> O>(
 	if let AllowHeaders::Only(only) = cors_allow_headers {
 		let are_all_allowed = headers.all(|header| {
 			let name = &Ascii::new(header.as_ref());
-			only.iter().any(|h| Ascii::new(&*h) == name) || ALWAYS_ALLOWED_HEADERS.contains(name)
+			only.iter().any(|h| Ascii::new(&*h) == name) || DEFAULT_ALLOWED_HEADERS.contains(name)
 		});
 
 		if !are_all_allowed {
@@ -298,7 +298,7 @@ pub(crate) fn get_cors_allow_headers<T: AsRef<str>, O, F: Fn(T) -> O>(
 				.filter(|header| {
 					let name = &Ascii::new(header.as_ref());
 					filtered = true;
-					only.iter().any(|h| Ascii::new(&*h) == name) || ALWAYS_ALLOWED_HEADERS.contains(name)
+					only.iter().any(|h| Ascii::new(&*h) == name) || DEFAULT_ALLOWED_HEADERS.contains(name)
 				})
 				.map(to_result)
 				.collect();
@@ -319,8 +319,8 @@ pub(crate) fn get_cors_allow_headers<T: AsRef<str>, O, F: Fn(T) -> O>(
 }
 
 lazy_static! {
-	/// Returns headers which are always allowed.
-	static ref ALWAYS_ALLOWED_HEADERS: HashSet<Ascii<&'static str>> = {
+	/// The following header are always allowed regardless of specified control access.
+	static ref DEFAULT_ALLOWED_HEADERS: HashSet<Ascii<&'static str>> = {
 		let mut hs = HashSet::new();
 		// CORS safelisted: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
 		hs.insert(Ascii::new("Accept"));

--- a/core/src/server/access_control/cors.rs
+++ b/core/src/server/access_control/cors.rs
@@ -335,10 +335,10 @@ lazy_static! {
 
 		// All requests must have a valid "Host" value that is filtered internally.
 		hs.insert(Ascii::new("Host"));
-		// "Content-Length" is capped by `max_request_body_size` (Default: 10 MB)
+		// "Content-Length" is capped by `max_request_body_size` (Default: 10 MB).
 		hs.insert(Ascii::new("Content-Length"));
 		// Set by various tools: (ie `User-Agent: curl/7.79.1`).
-		hs.insert(Ascii::new("Connection"));
+		hs.insert(Ascii::new("User-Agent"));
 		hs
 	};
 }

--- a/core/src/server/access_control/mod.rs
+++ b/core/src/server/access_control/mod.rs
@@ -43,7 +43,6 @@ impl AccessControl {
 	///
 	/// header_name: all keys of the header in the request
 	/// cors_request_headers: values of `access-control-request-headers` headers.
-	///
 	pub fn verify_headers<T, I, II>(&self, header_names: I, cors_request_headers: II) -> Result<(), Error>
 	where
 		T: AsRef<str>,

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -489,9 +489,9 @@ impl<M: Middleware> Server<M> {
 								let allowed_header_bytes = allowed_headers.as_bytes();
 
 								let res = hyper::Response::builder()
-									.header("access-control-allow-origin", origin)
-									.header("access-control-allow-methods", "POST")
-									.header("access-control-allow-headers", allowed_header_bytes)
+									.header(hyper::http::header::ACCESS_CONTROL_ALLOW_ORIGIN, origin)
+									.header(hyper::http::header::ACCESS_CONTROL_ALLOW_METHODS, "POST")
+									.header(hyper::http::header::ACCESS_CONTROL_ALLOW_HEADERS, allowed_header_bytes)
 									.body(hyper::Body::empty())
 									.unwrap_or_else(|e| {
 										tracing::error!("Error forming preflight response: {}", e);


### PR DESCRIPTION
In this PR, the `DEFAULT_ALLOWED_HEADERS` list is trimmed to a minimum number of headers.
The list contains default headers for access control regardless of provided user input.

Furthermore, the `HTTP` server returns the provided list from `verify_headers` for `OPTIONS` methods.

Closes #795.