### PR TITLE
Benchmarks for different header sizes

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -320,7 +320,7 @@ fn http_custom_headers_round_trip(
 	name: &str,
 	request: RequestType,
 ) {
-	for header_size in [1 * KIB, 2 * KIB, 8 * KIB] {
+	for header_size in [KIB, 2 * KIB, 8 * KIB] {
 		let mut headers = HeaderMap::new();
 		headers.insert("key", "A".repeat(header_size).parse().unwrap());
 
@@ -334,7 +334,7 @@ fn http_custom_headers_round_trip(
 /// Bench WS handshake with different header sizes.
 fn ws_custom_headers_handshake(rt: &TokioRuntime, crit: &mut Criterion, url: &str, name: &str, request: RequestType) {
 	let mut group = crit.benchmark_group(request.group_name(name));
-	for header_size in [0, 1 * KIB, 2 * KIB, 4 * KIB] {
+	for header_size in [0, KIB, 2 * KIB, 4 * KIB] {
 		group.bench_function(format!("{}", header_size), |b| {
 			b.to_async(rt).iter(|| async move {
 				let mut headers = HeaderMap::new();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,6 +5,7 @@ use futures_util::future::{join_all, FutureExt};
 use futures_util::stream::FuturesUnordered;
 use helpers::{http_client, ws_client, SUB_METHOD_NAME, UNSUB_METHOD_NAME};
 use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
+use jsonrpsee::http_client::HeaderMap;
 use jsonrpsee::types::{Id, ParamsSer, RequestSer};
 use pprof::criterion::{Output, PProfProfiler};
 use tokio::runtime::Runtime as TokioRuntime;
@@ -85,7 +86,7 @@ trait RequestBencher {
 	fn http_benches(crit: &mut Criterion) {
 		let rt = TokioRuntime::new().unwrap();
 		let (url, _server) = rt.block_on(helpers::http_server(rt.handle().clone()));
-		let client = Arc::new(http_client(&url));
+		let client = Arc::new(http_client(&url, HeaderMap::new()));
 		round_trip(&rt, crit, client.clone(), "http_round_trip", Self::REQUEST_TYPE);
 		http_concurrent_conn_calls(&rt, crit, &url, "http_concurrent_conn_calls", Self::REQUEST_TYPE);
 		batch_round_trip(&rt, crit, client, "http_batch_requests", Self::REQUEST_TYPE);
@@ -293,7 +294,7 @@ fn http_concurrent_conn_calls(rt: &TokioRuntime, crit: &mut Criterion, url: &str
 	for conns in [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] {
 		group.bench_function(format!("{}", conns), |b| {
 			b.to_async(rt).iter_with_setup(
-				|| (0..conns).map(|_| http_client(url)),
+				|| (0..conns).map(|_| http_client(url, HeaderMap::new())),
 				|clients| async {
 					let tasks = clients.map(|client| {
 						rt.spawn(async move {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -334,7 +334,7 @@ fn http_custom_headers_round_trip(
 /// Bench WS handshake with different header sizes.
 fn ws_custom_headers_handshake(rt: &TokioRuntime, crit: &mut Criterion, url: &str, name: &str, request: RequestType) {
 	let mut group = crit.benchmark_group(request.group_name(name));
-	for header_size in [0 * KIB, 1 * KIB, 2 * KIB, 4 * KIB] {
+	for header_size in [0, 1 * KIB, 2 * KIB, 4 * KIB] {
 		group.bench_function(format!("{}", header_size), |b| {
 			b.to_async(rt).iter(|| async move {
 				let mut headers = HeaderMap::new();

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -1,3 +1,4 @@
+use jsonrpsee::client_transport::ws::{Uri, WsTransportClientBuilder};
 use jsonrpsee::http_client::{HeaderMap, HttpClient, HttpClientBuilder};
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 
@@ -12,6 +13,9 @@ pub(crate) const UNSUB_METHOD_NAME: &str = "unsub";
 
 pub(crate) const SYNC_METHODS: [&str; 3] = [SYNC_FAST_CALL, SYNC_MEM_CALL, SYNC_SLOW_CALL];
 pub(crate) const ASYNC_METHODS: [&str; 3] = [SYNC_FAST_CALL, SYNC_MEM_CALL, SYNC_SLOW_CALL];
+
+// 1 KiB = 1024 bytes
+pub(crate) const KIB: usize = 1024;
 
 /// Run jsonrpc HTTP server for benchmarks.
 #[cfg(feature = "jsonrpc-crate")]
@@ -197,4 +201,9 @@ pub(crate) async fn ws_client(url: &str) -> WsClient {
 		.build(url)
 		.await
 		.unwrap()
+}
+
+pub(crate) async fn ws_handshake(url: &str, headers: HeaderMap) {
+	let uri: Uri = url.parse().unwrap();
+	WsTransportClientBuilder::default().max_request_body_size(u32::MAX).set_headers(headers).build(uri).await.unwrap();
 }

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -1,4 +1,4 @@
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::http_client::{HeaderMap, HttpClient, HttpClientBuilder};
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 
 pub(crate) const SYNC_FAST_CALL: &str = "fast_call";
@@ -181,10 +181,11 @@ fn gen_rpc_module() -> jsonrpsee::RpcModule<()> {
 	module
 }
 
-pub(crate) fn http_client(url: &str) -> HttpClient {
+pub(crate) fn http_client(url: &str, headers: HeaderMap) -> HttpClient {
 	HttpClientBuilder::default()
 		.max_request_body_size(u32::MAX)
 		.max_concurrent_requests(1024 * 1024)
+		.set_headers(headers)
 		.build(url)
 		.unwrap()
 }


### PR DESCRIPTION
This PR adds benchmarks for:
- HTTP round trips with custom headers
- WS handshake with custom headers

## Results

### HTTP

|  Benchmark  | 0 KiB header | 1 KiB header | 5 KiB header | 25 KiB header | 100 KiB Header| 
| ---- | ---- | ---- | ---- | ---- |----|
| sync/http_custom_headers_round_trip | **57.518 us** | 51.544 us  | 64.647 us | 64.291 us | 102.75 us
| async/http_custom_headers_round_trip | **65.822 us** | 62.544 us  | 72.057 us | 63.859 us | 131.97 us


### WS

|  Benchmark  | 0 KiB header | 1 KiB header | 2 KiB header | 4 KiB header | 
| ---- | ---- | ---- | ---- | ---- |
| sync/ws_custom_headers_handshake | **86.346 us** | 88.853 us  | 89.603 us | 96.346 us |
| async/ws_custom_headers_handshake | **90.601 us** | 89.546 us  | 89.251 us | 91.919 us |

