### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ v0.15.0 is a breaking release. The main changes are:
 - It's now possible to apply resource limits to subscriptions as well as regular calls.
 - We now allow trait bounds to be overridden in the proc macros. See `examples/examples/proc_macro_bounds.rs` for examples.
 - We've tidied up the subscription API, removing the `PendingSink` concept (you can still manually accept or reject a sink, but otherwise it'll be accepted automatically if you send a message down it) ([#799](https://github.com/paritytech/jsonrpsee/pull/799)).
-- Our logging `Middleware` trait has been split into `HttpMiddleware` and `WsMiddleware` to better capture the differences between the two. if you use custom middleware, you'll need to implement one or the other trait on it depending on your used transport method ([#793](https://github.com/paritytech/jsonrpsee/pull/793)).
+- Our logging `Middleware` trait has been split into `HttpMiddleware` and `WsMiddleware` to better capture the differences between the two. if you use custom middleware, you'll need to implement one or the other trait on it depending on your used transport method ([#793](https://github.com/paritytech/jsonrpsee/pull/793)). We also provide params and the method type to middleware calls now, too ([#820](https://github.com/paritytech/jsonrpsee/pull/820)).
 - We've consistified the API for setting headers across HTTP and WS clients ([#799](https://github.com/paritytech/jsonrpsee/pull/814)).
 
 Here's the full list of changes:
@@ -40,6 +40,7 @@ Here's the full list of changes:
 - chore(deps): update pprof requirement from 0.9 to 0.10 [#810](https://github.com/paritytech/jsonrpsee/pull/810)
 - Return error from subscription callbacks [#799](https://github.com/paritytech/jsonrpsee/pull/799)
 - middleware refactoring [#793](https://github.com/paritytech/jsonrpsee/pull/793)
+- feat(middleware): expose type of the method call [#820](https://github.com/paritytech/jsonrpsee/pull/820)
 - Uniform API for custom headers between clients [#814](https://github.com/paritytech/jsonrpsee/pull/814)
 - Update links to client directories. [#822](https://github.com/paritytech/jsonrpsee/pull/822)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,44 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [Unreleased]
+## [v0.15.0] - 2022-07-20
+
+v0.15.0 is a breaking release. The main changes are:
+
+- It's now possible to apply resource limits to subscriptions as well as regular calls.
+- We now allow trait bounds to be overridden in the proc macros. See `examples/examples/proc_macro_bounds.rs` for examples.
+- We've tidied up the subscription API, removing the `PendingSink` concept (you can still manually accept or reject a sink, but otherwise it'll be accepted automatically if you send a message down it) ([#799](https://github.com/paritytech/jsonrpsee/pull/799)).
+- Our logging `Middleware` trait has been split into `HttpMiddleware` and `WsMiddleware` to better capture the differences between the two. if you use custom middleware, you'll need to implement one or the other trait on it depending on your used transport method ([#793](https://github.com/paritytech/jsonrpsee/pull/793)).
+- We've consistified the API for setting headers across HTTP and WS clients ([#799](https://github.com/paritytech/jsonrpsee/pull/814)).
+
+Here's the full list of changes:
+
+### [Fixed]
+
+- Fix client generation with param_kind = map [#805](https://github.com/paritytech/jsonrpsee/pull/805)
+- ws-server: Handle soketto::Incoming::Closed frames [#815](https://github.com/paritytech/jsonrpsee/pull/815)
+- fix(ws server): reply HTTP 403 on all failed conns [#819](https://github.com/paritytech/jsonrpsee/pull/819)
+- fix clippy [#817](https://github.com/paritytech/jsonrpsee/pull/817)
+
+### [Added]
+
+- Add resource limiting for Subscriptions [#786](https://github.com/paritytech/jsonrpsee/pull/786)
+- feat(logging): add tracing span per JSON-RPC call [#722](https://github.com/paritytech/jsonrpsee/pull/722)
+- feat(clients): add explicit unsubscribe API [#789](https://github.com/paritytech/jsonrpsee/pull/789)
+- Allow trait bounds to be overridden in macro [#808](https://github.com/paritytech/jsonrpsee/pull/808)
+
+### [Changed]
+
+- Point to a new v1.0 milestone in the README.md [#801](https://github.com/paritytech/jsonrpsee/pull/801)
+- chore(deps): upgrade tracing v0.1.34 [#800](https://github.com/paritytech/jsonrpsee/pull/800)
+- Replace cargo-nextest with cargo-test for running tests [#802](https://github.com/paritytech/jsonrpsee/pull/802)
+- Remove deny_unknown_fields from Request and Response [#803](https://github.com/paritytech/jsonrpsee/pull/803)
+- substrate-subxt -> subxt [#807](https://github.com/paritytech/jsonrpsee/pull/807)
+- chore(deps): update pprof requirement from 0.9 to 0.10 [#810](https://github.com/paritytech/jsonrpsee/pull/810)
+- Return error from subscription callbacks [#799](https://github.com/paritytech/jsonrpsee/pull/799)
+- middleware refactoring [#793](https://github.com/paritytech/jsonrpsee/pull/793)
+- Uniform API for custom headers between clients [#814](https://github.com/paritytech/jsonrpsee/pull/814)
+- Update links to client directories. [#822](https://github.com/paritytech/jsonrpsee/pull/822)
 
 ## [v0.14.0] - 2022-06-14
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -1,7 +1,50 @@
-# How to release `jsonrpsee`
+# Release Checklist
 
-1. Bump the version of all crates
-1. Run all tests
-1. In the `CHANGELOG.md` file, move everything under "Unreleased" to a new section named `## [vx.y.z] – YYYY-MM-DD`
-1. Publish: `./scripts/publish.sh`
-1. Once published, make sure to "create a release" for the pushed tag on github.
+These steps assume that you've checked out the Jsonrpsee repository and are in the root directory of it.
+
+We also assume that ongoing work done is being merged directly to the `master` branch.
+
+1.  Ensure that everything you'd like to see released is on the `master` branch.
+
+2.  Create a release branch off `master`, for example `chore-release-v0.15.0`. Decide how far the version needs to be bumped based
+    on the changes to date. If unsure what to bump the version to (e.g. is it a major, minor or patch release), check with the
+    Parity Tools team.
+
+3.  Bump the crate versions in `Cargo.toml` to whatever was decided in step 2. The easiest approach is to search and replace, checking
+    that you didn't replace any other crate versions along the way.
+
+4.  Update `CHANGELOG.md` to reflect the difference between this release and the last. If you're unsure of
+    what to add, check with the Tools team. See the `CHANGELOG.md` file for details of the format it follows.
+
+    First, if there have been any significant changes, add a description of those changes to the top of the
+    changelog entry for this release. This will help people to understand the impact of the change and what they need to do
+    to adopt it.
+
+    Next, you can use the following script to generate the merged PRs between releases:
+
+    ```
+    ./scripts/generate_changelog.sh
+    ```
+
+    Ensure that the script picked the latest published release tag (e.g. if releasing `v0.15.0`, the script should
+    provide something like `[+] Latest release tag: v0.14.0` ). Then group the PRs into "Fixed", "Added" and "Changed" sections,
+    and make any other adjustments that you feel are necessary for clarity.
+
+6.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`.
+
+7.  Once the branch has been reviewed and passes CI, merge it.
+
+8.  Now, we're ready to publish the release to crates.io. Run `./scripts/publish.sh` to publish all crates in the correct order.
+
+9.  If the release was successful, tag the commit that we released in the `master` branch with the
+    version that we just released, for example:
+
+    ```
+    git tag -s v0.15.0 # use the version number you've just published to crates.io, not this
+    git push --tags
+    ```
+
+    Once this is pushed, go along to [the releases page on GitHub](https://github.com/paritytech/jsonrpsee/releases)
+    and draft a new release which points to the tag you just pushed to `master` above. Copy the changelog comments
+    for the current release into the release description.
+

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -30,14 +30,14 @@ We also assume that ongoing work done is being merged directly to the `master` b
     provide something like `[+] Latest release tag: v0.14.0` ). Then group the PRs into "Fixed", "Added" and "Changed" sections,
     and make any other adjustments that you feel are necessary for clarity.
 
-6.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`. Name the branch something
+5.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`. Name the branch something
     like `chore(release): v0.15.0`.
 
-7.  Once the branch has been reviewed and passes CI, merge it.
+6.  Once the branch has been reviewed and passes CI, merge it.
 
-8.  Now, we're ready to publish the release to crates.io. Run `./scripts/publish.sh` to publish all crates in the correct order.
+7.  Now, we're ready to publish the release to crates.io. Run `./scripts/publish.sh` to publish all crates in the correct order.
 
-9.  If the release was successful, tag the commit that we released in the `master` branch with the
+8.  If the release was successful, tag the commit that we released in the `master` branch with the
     version that we just released, for example:
 
     ```

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -30,7 +30,8 @@ We also assume that ongoing work done is being merged directly to the `master` b
     provide something like `[+] Latest release tag: v0.14.0` ). Then group the PRs into "Fixed", "Added" and "Changed" sections,
     and make any other adjustments that you feel are necessary for clarity.
 
-6.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`.
+6.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`. Name the branch something
+    like `chore(release): v0.15.0`.
 
 7.  Once the branch has been reviewed and passes CI, merge it.
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-benchmarks"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Benchmarks for jsonrpsee"
 edition = "2021"

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-http-client"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "HTTP client for JSON-RPC"
 edition = "2021"
@@ -14,8 +14,8 @@ async-trait = "0.1"
 rustc-hash = "1"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.23", optional = true }
-jsonrpsee-types = { path = "../../types", version = "0.14.0" }
-jsonrpsee-core = { path = "../../core", version = "0.14.0", features = ["client", "http-helpers"] }
+jsonrpsee-types = { path = "../../types", version = "0.15.0" }
+jsonrpsee-core = { path = "../../core", version = "0.15.0", features = ["client", "http-helpers"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-client-transport"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "WebSocket client for JSON-RPC"
 edition = "2021"
@@ -10,8 +10,8 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
-jsonrpsee-types = { path = "../../types", version = "0.14.0", optional = true }
-jsonrpsee-core = { path = "../../core", version = "0.14.0", features = ["client"] }
+jsonrpsee-types = { path = "../../types", version = "0.15.0", optional = true }
+jsonrpsee-core = { path = "../../core", version = "0.15.0", features = ["client"] }
 tracing = "0.1.34"
 
 # optional

--- a/client/wasm-client/Cargo.toml
+++ b/client/wasm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-wasm-client"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "WASM client for JSON-RPC"
 edition = "2021"
@@ -10,9 +10,9 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
-jsonrpsee-types = { path = "../../types", version = "0.14.0" }
-jsonrpsee-client-transport = { path = "../transport", version = "0.14.0", features = ["web"] }
-jsonrpsee-core = { path = "../../core", version = "0.14.0", features = ["async-wasm-client"] }
+jsonrpsee-types = { path = "../../types", version = "0.15.0" }
+jsonrpsee-client-transport = { path = "../transport", version = "0.15.0", features = ["web"] }
+jsonrpsee-core = { path = "../../core", version = "0.15.0", features = ["async-wasm-client"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-ws-client"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "WebSocket client for JSON-RPC"
 edition = "2021"
@@ -10,9 +10,9 @@ homepage = "https://github.com/paritytech/jsonrpsee"
 documentation = "https://docs.rs/jsonrpsee-ws-client"
 
 [dependencies]
-jsonrpsee-types = { path = "../../types", version = "0.14.0" }
-jsonrpsee-client-transport = { path = "../transport", version = "0.14.0", features = ["ws"] }
-jsonrpsee-core = { path = "../../core", version = "0.14.0", features = ["async-client"] }
+jsonrpsee-types = { path = "../../types", version = "0.15.0" }
+jsonrpsee-client-transport = { path = "../transport", version = "0.15.0", features = ["ws"] }
+jsonrpsee-core = { path = "../../core", version = "0.15.0", features = ["async-client"] }
 http = "0.2.0"
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-core"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utilities for jsonrpsee"
 edition = "2021"
@@ -11,7 +11,7 @@ anyhow = "1"
 async-trait = "0.1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 futures-channel = "0.3.14"
-jsonrpsee-types = { path = "../types", version = "0.14.0" }
+jsonrpsee-types = { path = "../types", version = "0.15.0" }
 thiserror = "1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-examples"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Examples for jsonrpsee"
 edition = "2021"

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-http-server"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "HTTP server for JSON-RPC"
 edition = "2021"
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/jsonrpsee-http-server"
 hyper = { version = "0.14.10", features = ["server", "http1", "http2", "tcp"] }
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false }
-jsonrpsee-types = { path = "../types", version = "0.14.0" }
-jsonrpsee-core = { path = "../core", version = "0.14.0", features = ["server", "http-helpers"] }
+jsonrpsee-types = { path = "../types", version = "0.15.0" }
+jsonrpsee-core = { path = "../core", version = "0.15.0", features = ["server", "http-helpers"] }
 tracing = "0.1.34"
 tracing-futures = "0.2.5"
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpsee"
 description = "JSON-RPC crate"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT"
 edition = "2021"
@@ -12,15 +12,15 @@ documentation = "https://docs.rs/jsonrpsee"
 [dependencies]
 # No support for namespaced features yet so workspace dependencies are prefixed with `jsonrpsee-`.
 # See https://github.com/rust-lang/cargo/issues/5565 for more details.
-jsonrpsee-http-client = { path = "../client/http-client", version = "0.14.0", optional = true }
-jsonrpsee-ws-client = { path = "../client/ws-client", version = "0.14.0", optional = true }
-jsonrpsee-wasm-client = { path = "../client/wasm-client", version = "0.14.0", optional = true }
-jsonrpsee-client-transport = { path = "../client/transport", version = "0.14.0", optional = true }
-jsonrpsee-http-server = { path = "../http-server", version = "0.14.0", optional = true }
-jsonrpsee-ws-server = { path = "../ws-server", version = "0.14.0", optional = true }
-jsonrpsee-proc-macros = { path = "../proc-macros", version = "0.14.0", optional = true }
-jsonrpsee-core = { path = "../core", version = "0.14.0", optional = true }
-jsonrpsee-types = { path = "../types", version = "0.14.0", optional = true }
+jsonrpsee-http-client = { path = "../client/http-client", version = "0.15.0", optional = true }
+jsonrpsee-ws-client = { path = "../client/ws-client", version = "0.15.0", optional = true }
+jsonrpsee-wasm-client = { path = "../client/wasm-client", version = "0.15.0", optional = true }
+jsonrpsee-client-transport = { path = "../client/transport", version = "0.15.0", optional = true }
+jsonrpsee-http-server = { path = "../http-server", version = "0.15.0", optional = true }
+jsonrpsee-ws-server = { path = "../ws-server", version = "0.15.0", optional = true }
+jsonrpsee-proc-macros = { path = "../proc-macros", version = "0.15.0", optional = true }
+jsonrpsee-core = { path = "../core", version = "0.15.0", optional = true }
+jsonrpsee-types = { path = "../types", version = "0.15.0", optional = true }
 tracing = { version = "0.1.34", optional = true }
 
 [features]

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpsee-proc-macros"
 description = "Procedueral macros for jsonrpsee"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# This script obtains the changelog to be introduced in the new release.
+
+set -eu
+
+REMOTE_LINK="https://github.com/paritytech/jsonrpsee/pull/"
+
+function usage() {
+    cat <<HELP_USAGE
+This script obtains the changelog between the latest release tag and origin/master.
+
+Usage: $0 [-h]
+
+    -h  Print help message.
+HELP_USAGE
+}
+
+function log_error() {
+    echo "Error:" "$@" >&2
+    exit 1
+}
+
+function log_info() {
+    echo -e "[+]" "$@"
+}
+
+while getopts "h?" opt; do
+    case "$opt" in
+        h|\?)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
+GIT_BIN=$(which git) || log_error 'git is not installed. Please follow https://github.com/git-guides/install-git for instructions'
+
+# Generate the changelog between the provided tag and origin/master.
+function generate_changelog() {
+    local tag="$1"
+
+    prs=$($GIT_BIN --no-pager log --pretty=format:"%s" "$tag"..origin/master) || log_error 'Failed to obtain commit list'
+
+    log_info "Changelog\n"
+    while IFS= read -r line; do
+        # Obtain the pr number from each line. The regex should match, as provided by the previous grep.
+        if [[ $line =~ "(#"([0-9]+)")"$ ]]; then
+            pr_number="${BASH_REMATCH[1]}"
+        else
+            continue
+        fi
+
+        # Generate a valid PR link.
+        pr_link="$REMOTE_LINK$pr_number"
+        # Generate the link as markdown.
+        pr_md_link=" ([#$pr_number]($pr_link))"
+        # Print the changelog line as `- commit-title pr-link`.
+        echo "$line" | awk -v var="$pr_md_link" '{NF--; printf "- "; printf; print var}'
+    done <<< "$prs"
+}
+
+# Get latest release tag.
+tag=$($GIT_BIN describe --match "v[0-9]*" --abbrev=0 origin/master) || log_error 'Failed to obtain the latest release tag'
+log_info "Latest release tag: $tag"
+
+generate_changelog "$tag"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-test-utils"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 edition = "2021"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-integration-tests"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Integration tests for jsonrpsee"
 edition = "2021"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-types"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Shared types for jsonrpsee"
 edition = "2021"

--- a/ws-server/Cargo.toml
+++ b/ws-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-ws-server"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "WebSocket server for JSON-RPC"
 edition = "2021"
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/jsonrpsee-ws-server"
 [dependencies]
 futures-channel = "0.3.14"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
-jsonrpsee-types = { path = "../types", version = "0.14.0" }
-jsonrpsee-core = { path = "../core", version = "0.14.0", features = ["server", "soketto"] }
+jsonrpsee-types = { path = "../types", version = "0.15.0" }
+jsonrpsee-core = { path = "../core", version = "0.15.0", features = ["server", "soketto"] }
 tracing = "0.1.34"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = "0.7.1"


### PR DESCRIPTION
Update changelog and versions. Add generate_changelgo and adapt release steps from subxt so that the process can be a little more mindless. 