### PR TITLE
[Bug Fix] - Incorrect trace caused by use of `Span::enter` in asynchronous code 

### DIFF
--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -189,7 +189,7 @@ impl ClientT for HttpClient {
 		let guard = self.id_manager.next_request_id()?;
 		let id = guard.inner();
 		let request = RequestSer::new(&id, method, params);
-		let trace = RpcTracing::method_call(method, &id);
+		let trace = RpcTracing::method_call(method);
 		let _enter = trace.span().enter();
 
 		let raw = serde_json::to_string(&request).map_err(Error::ParseError)?;

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -189,7 +189,7 @@ impl ClientT for HttpClient {
 		let guard = self.id_manager.next_request_id()?;
 		let id = guard.inner();
 		let request = RequestSer::new(&id, method, params);
-		let trace = RpcTracing::method_call(method);
+		let trace = RpcTracing::method_call(method, &id);
 		let _enter = trace.span().enter();
 
 		let raw = serde_json::to_string(&request).map_err(Error::ParseError)?;

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -179,7 +179,7 @@ impl ClientT for HttpClient {
 				Ok(Err(e)) => Err(Error::Transport(e.into())),
 			}
 		}
-		.instrument(trace.span().clone())
+		.instrument(trace.into_span())
 		.await
 	}
 
@@ -221,7 +221,7 @@ impl ClientT for HttpClient {
 				Err(Error::InvalidRequestId)
 			}
 		}
-		.instrument(trace.span().clone())
+		.instrument(trace.into_span())
 		.await
 	}
 
@@ -271,7 +271,7 @@ impl ClientT for HttpClient {
 			}
 			Ok(responses)
 		}
-		.instrument(trace.span().clone())
+		.instrument(trace.into_span())
 		.await
 	}
 }

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -178,7 +178,9 @@ impl ClientT for HttpClient {
 				Err(_) => Err(Error::RequestTimeout),
 				Ok(Err(e)) => Err(Error::Transport(e.into())),
 			}
-		}.instrument(trace.span().clone()).await
+		}
+		.instrument(trace.span().clone())
+		.await
 	}
 
 	/// Perform a request towards the server.
@@ -218,7 +220,9 @@ impl ClientT for HttpClient {
 			} else {
 				Err(Error::InvalidRequestId)
 			}
-		}.instrument(trace.span().clone()).await
+		}
+		.instrument(trace.span().clone())
+		.await
 	}
 
 	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, Option<ParamsSer<'a>>)>) -> Result<Vec<R>, Error>
@@ -241,9 +245,8 @@ impl ClientT for HttpClient {
 				request_set.insert(&ids[pos], pos);
 			}
 
-			let fut = self
-				.transport
-				.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
+			let fut =
+				self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
 
 			let body = match tokio::time::timeout(self.request_timeout, fut).await {
 				Ok(Ok(body)) => body,
@@ -267,7 +270,9 @@ impl ClientT for HttpClient {
 				responses[pos] = rp.result
 			}
 			Ok(responses)
-		}.instrument(trace.span().clone()).await
+		}
+		.instrument(trace.span().clone())
+		.await
 	}
 }
 

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -243,102 +243,104 @@ impl Drop for Client {
 #[async_trait]
 impl ClientT for Client {
 	async fn notification<'a>(&self, method: &'a str, params: Option<ParamsSer<'a>>) -> Result<(), Error> {
-		// NOTE: we use this to guard against max number of concurrent requests.
-		let _req_id = self.id_manager.next_request_id()?;
-		let notif = NotificationSer::new(method, params);
-		let trace = RpcTracing::batch();
-		let _enter = trace.span().enter();
+        // NOTE: we use this to guard against max number of concurrent requests.
+        let _req_id = self.id_manager.next_request_id()?;
+        let notif = NotificationSer::new(method, params);
+        let trace = RpcTracing::batch();
 
-		let raw = serde_json::to_string(&notif).map_err(Error::ParseError)?;
-		tx_log_from_str(&raw, self.max_log_length);
+        async {
+            let raw = serde_json::to_string(&notif).map_err(Error::ParseError)?;
+            tx_log_from_str(&raw, self.max_log_length);
 
-		let mut sender = self.to_back.clone();
-		let fut = sender.send(FrontToBack::Notification(raw)).in_current_span();
+            let mut sender = self.to_back.clone();
+            let fut = sender.send(FrontToBack::Notification(raw));
 
-		match future::select(fut, Delay::new(self.request_timeout)).await {
-			Either::Left((Ok(()), _)) => Ok(()),
-			Either::Left((Err(_), _)) => Err(self.read_error_from_backend().await),
-			Either::Right((_, _)) => Err(Error::RequestTimeout),
-		}
-	}
+            match future::select(fut, Delay::new(self.request_timeout)).await {
+                Either::Left((Ok(()), _)) => Ok(()),
+                Either::Left((Err(_), _)) => Err(self.read_error_from_backend().await),
+                Either::Right((_, _)) => Err(Error::RequestTimeout),
+            }
+        }.instrument(trace.span().clone()).await
+    }
 
 	async fn request<'a, R>(&self, method: &'a str, params: Option<ParamsSer<'a>>) -> Result<R, Error>
 	where
 		R: DeserializeOwned,
-	{
-		let (send_back_tx, send_back_rx) = oneshot::channel();
-		let guard = self.id_manager.next_request_id()?;
-		let id = guard.inner();
-		let trace = RpcTracing::method_call(method);
-		let _enter = trace.span().enter();
+    {
+        let (send_back_tx, send_back_rx) = oneshot::channel();
+        let guard = self.id_manager.next_request_id()?;
+        let id = guard.inner();
+        let trace = RpcTracing::method_call(method);
 
-		let raw = serde_json::to_string(&RequestSer::new(&id, method, params)).map_err(Error::ParseError)?;
-		tx_log_from_str(&raw, self.max_log_length);
+        async {
+            let raw = serde_json::to_string(&RequestSer::new(&id, method, params)).map_err(Error::ParseError)?;
+            tx_log_from_str(&raw, self.max_log_length);
 
-		if self
-			.to_back
-			.clone()
-			.send(FrontToBack::Request(RequestMessage { raw, id: id.clone(), send_back: Some(send_back_tx) }))
-			.await
-			.is_err()
-		{
-			return Err(self.read_error_from_backend().await);
-		}
+            if self
+                .to_back
+                .clone()
+                .send(FrontToBack::Request(RequestMessage { raw, id: id.clone(), send_back: Some(send_back_tx) }))
+                .await
+                .is_err()
+            {
+                return Err(self.read_error_from_backend().await);
+            }
 
-		let res = call_with_timeout(self.request_timeout, send_back_rx).in_current_span().await;
-		let json_value = match res {
-			Ok(Ok(v)) => v,
-			Ok(Err(err)) => return Err(err),
-			Err(_) => return Err(self.read_error_from_backend().await),
-		};
+            let res = call_with_timeout(self.request_timeout, send_back_rx).await;
+            let json_value = match res {
+                Ok(Ok(v)) => v,
+                Ok(Err(err)) => return Err(err),
+                Err(_) => return Err(self.read_error_from_backend().await),
+            };
 
-		rx_log_from_json(&Response::new(&json_value, id), self.max_log_length);
+            rx_log_from_json(&Response::new(&json_value, id), self.max_log_length);
 
-		serde_json::from_value(json_value).map_err(Error::ParseError)
-	}
+            serde_json::from_value(json_value).map_err(Error::ParseError)
+        }.instrument(trace.span().clone()).await
+    }
 
 	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, Option<ParamsSer<'a>>)>) -> Result<Vec<R>, Error>
 	where
 		R: DeserializeOwned + Default + Clone,
-	{
-		let guard = self.id_manager.next_request_ids(batch.len())?;
-		let batch_ids: Vec<Id> = guard.inner();
-		let mut batches = Vec::with_capacity(batch.len());
-		let log = RpcTracing::batch();
-		let _enter = log.span().enter();
+    {
+        let trace = RpcTracing::batch();
+        async {
+			let guard = self.id_manager.next_request_ids(batch.len())?;
+			let batch_ids: Vec<Id> = guard.inner();
+			let mut batches = Vec::with_capacity(batch.len());
+			for (idx, (method, params)) in batch.into_iter().enumerate() {
+                batches.push(RequestSer::new(&batch_ids[idx], method, params));
+            }
 
-		for (idx, (method, params)) in batch.into_iter().enumerate() {
-			batches.push(RequestSer::new(&batch_ids[idx], method, params));
-		}
+            let (send_back_tx, send_back_rx) = oneshot::channel();
 
-		let (send_back_tx, send_back_rx) = oneshot::channel();
+            let raw = serde_json::to_string(&batches).map_err(Error::ParseError)?;
 
-		let raw = serde_json::to_string(&batches).map_err(Error::ParseError)?;
+            tx_log_from_str(&raw, self.max_log_length);
 
-		tx_log_from_str(&raw, self.max_log_length);
+            if self
+                .to_back
+                .clone()
+                .send(FrontToBack::Batch(BatchMessage { raw, ids: batch_ids, send_back: send_back_tx }))
+                .await
+                .is_err()
+            {
+                return Err(self.read_error_from_backend().await);
+            }
 
-		if self
-			.to_back
-			.clone()
-			.send(FrontToBack::Batch(BatchMessage { raw, ids: batch_ids, send_back: send_back_tx }))
-			.await
-			.is_err()
-		{
-			return Err(self.read_error_from_backend().await);
-		}
+            let res = call_with_timeout(self.request_timeout, send_back_rx).await;
+            let json_values = match res {
+                Ok(Ok(v)) => v,
+                Ok(Err(err)) => return Err(err),
+                Err(_) => return Err(self.read_error_from_backend().await),
+            };
 
-		let res = call_with_timeout(self.request_timeout, send_back_rx).in_current_span().await;
-		let json_values = match res {
-			Ok(Ok(v)) => v,
-			Ok(Err(err)) => return Err(err),
-			Err(_) => return Err(self.read_error_from_backend().await),
-		};
+            rx_log_from_json(&json_values, self.max_log_length);
 
-		rx_log_from_json(&json_values, self.max_log_length);
-
-		let values: Result<_, _> =
-			json_values.into_iter().map(|val| serde_json::from_value(val).map_err(Error::ParseError)).collect();
-		Ok(values?)
+            let values: Result<_, _> =
+                json_values.into_iter().map(|val| serde_json::from_value(val).map_err(Error::ParseError)).collect();
+            Ok(values?)
+        }.instrument(trace.span().clone()).await
 	}
 }
 
@@ -356,51 +358,52 @@ impl SubscriptionClientT for Client {
 	) -> Result<Subscription<N>, Error>
 	where
 		N: DeserializeOwned,
-	{
-		if subscribe_method == unsubscribe_method {
-			return Err(Error::SubscriptionNameConflict(unsubscribe_method.to_owned()));
-		}
+    {
+        if subscribe_method == unsubscribe_method {
+            return Err(Error::SubscriptionNameConflict(unsubscribe_method.to_owned()));
+        }
 
-		let guard = self.id_manager.next_request_ids(2)?;
-		let mut ids: Vec<Id> = guard.inner();
-		let trace = RpcTracing::method_call(subscribe_method);
-		let _enter = trace.span().enter();
+        let guard = self.id_manager.next_request_ids(2)?;
+        let mut ids: Vec<Id> = guard.inner();
+        let trace = RpcTracing::method_call(subscribe_method);
 
-		let id = ids[0].clone();
+        async {
+            let id = ids[0].clone();
 
-		let raw = serde_json::to_string(&RequestSer::new(&id, subscribe_method, params)).map_err(Error::ParseError)?;
+            let raw = serde_json::to_string(&RequestSer::new(&id, subscribe_method, params)).map_err(Error::ParseError)?;
 
-		tx_log_from_str(&raw, self.max_log_length);
+            tx_log_from_str(&raw, self.max_log_length);
 
-		let (send_back_tx, send_back_rx) = oneshot::channel();
-		if self
-			.to_back
-			.clone()
-			.send(FrontToBack::Subscribe(SubscriptionMessage {
-				raw,
-				subscribe_id: ids.swap_remove(0),
-				unsubscribe_id: ids.swap_remove(0),
-				unsubscribe_method: unsubscribe_method.to_owned(),
-				send_back: send_back_tx,
-			}))
-			.await
-			.is_err()
-		{
-			return Err(self.read_error_from_backend().await);
-		}
+            let (send_back_tx, send_back_rx) = oneshot::channel();
+            if self
+                .to_back
+                .clone()
+                .send(FrontToBack::Subscribe(SubscriptionMessage {
+                    raw,
+                    subscribe_id: ids.swap_remove(0),
+                    unsubscribe_id: ids.swap_remove(0),
+                    unsubscribe_method: unsubscribe_method.to_owned(),
+                    send_back: send_back_tx,
+                }))
+                .await
+                .is_err()
+            {
+                return Err(self.read_error_from_backend().await);
+            }
 
-		let res = call_with_timeout(self.request_timeout, send_back_rx).in_current_span().await;
+            let res = call_with_timeout(self.request_timeout, send_back_rx).await;
 
-		let (notifs_rx, sub_id) = match res {
-			Ok(Ok(val)) => val,
-			Ok(Err(err)) => return Err(err),
-			Err(_) => return Err(self.read_error_from_backend().await),
-		};
+            let (notifs_rx, sub_id) = match res {
+                Ok(Ok(val)) => val,
+                Ok(Err(err)) => return Err(err),
+                Err(_) => return Err(self.read_error_from_backend().await),
+            };
 
-		rx_log_from_json(&Response::new(&sub_id, id), self.max_log_length);
+            rx_log_from_json(&Response::new(&sub_id, id), self.max_log_length);
 
-		Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id)))
-	}
+            Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id)))
+        }.instrument(trace.span().clone()).await
+    }
 
 	/// Subscribe to a specific method.
 	async fn subscribe_to_method<'a, N>(&self, method: &'a str) -> Result<Subscription<N>, Error>

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -260,7 +260,7 @@ impl ClientT for Client {
                 Either::Left((Err(_), _)) => Err(self.read_error_from_backend().await),
                 Either::Right((_, _)) => Err(Error::RequestTimeout),
             }
-        }.instrument(trace.span().clone()).await
+        }.instrument(trace.into_span()).await
     }
 
 	async fn request<'a, R>(&self, method: &'a str, params: Option<ParamsSer<'a>>) -> Result<R, Error>
@@ -296,7 +296,7 @@ impl ClientT for Client {
             rx_log_from_json(&Response::new(&json_value, id), self.max_log_length);
 
             serde_json::from_value(json_value).map_err(Error::ParseError)
-        }.instrument(trace.span().clone()).await
+        }.instrument(trace.into_span()).await
     }
 
 	async fn batch_request<'a, R>(&self, batch: Vec<(&'a str, Option<ParamsSer<'a>>)>) -> Result<Vec<R>, Error>
@@ -340,7 +340,7 @@ impl ClientT for Client {
             let values: Result<_, _> =
                 json_values.into_iter().map(|val| serde_json::from_value(val).map_err(Error::ParseError)).collect();
             Ok(values?)
-        }.instrument(trace.span().clone()).await
+        }.instrument(trace.into_span()).await
 	}
 }
 
@@ -402,7 +402,7 @@ impl SubscriptionClientT for Client {
             rx_log_from_json(&Response::new(&sub_id, id), self.max_log_length);
 
             Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id)))
-        }.instrument(trace.span().clone()).await
+        }.instrument(trace.into_span()).await
     }
 
 	/// Subscribe to a specific method.

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -269,7 +269,7 @@ impl ClientT for Client {
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		let guard = self.id_manager.next_request_id()?;
 		let id = guard.inner();
-		let trace = RpcTracing::method_call(method, &id);
+		let trace = RpcTracing::method_call(method);
 		let _enter = trace.span().enter();
 
 		let raw = serde_json::to_string(&RequestSer::new(&id, method, params)).map_err(Error::ParseError)?;
@@ -363,11 +363,10 @@ impl SubscriptionClientT for Client {
 
 		let guard = self.id_manager.next_request_ids(2)?;
 		let mut ids: Vec<Id> = guard.inner();
-		let id = ids[0].clone();
-
-		let trace = RpcTracing::method_call(subscribe_method, &id);
+		let trace = RpcTracing::method_call(subscribe_method);
 		let _enter = trace.span().enter();
 
+		let id = ids[0].clone();
 
 		let raw = serde_json::to_string(&RequestSer::new(&id, subscribe_method, params)).map_err(Error::ParseError)?;
 

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -269,7 +269,7 @@ impl ClientT for Client {
 		let (send_back_tx, send_back_rx) = oneshot::channel();
 		let guard = self.id_manager.next_request_id()?;
 		let id = guard.inner();
-		let trace = RpcTracing::method_call(method);
+		let trace = RpcTracing::method_call(method, &id);
 		let _enter = trace.span().enter();
 
 		let raw = serde_json::to_string(&RequestSer::new(&id, method, params)).map_err(Error::ParseError)?;
@@ -363,10 +363,11 @@ impl SubscriptionClientT for Client {
 
 		let guard = self.id_manager.next_request_ids(2)?;
 		let mut ids: Vec<Id> = guard.inner();
-		let trace = RpcTracing::method_call(subscribe_method);
+		let id = ids[0].clone();
+
+		let trace = RpcTracing::method_call(subscribe_method, &id);
 		let _enter = trace.span().enter();
 
-		let id = ids[0].clone();
 
 		let raw = serde_json::to_string(&RequestSer::new(&id, subscribe_method, params)).map_err(Error::ParseError)?;
 

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use tracing::Level;
+use jsonrpsee_types::Id;
 
 #[derive(Debug)]
 /// Wrapper over [`tracing::Span`] to trace individual method calls, notifications and similar.
@@ -9,8 +10,8 @@ impl RpcTracing {
 	/// Create a `method_call` tracing target.
 	///
 	/// To enable this you need to call `RpcTracing::method_call("some_method").span().enable()`.
-	pub fn method_call(method: &str) -> Self {
-		Self(tracing::span!(tracing::Level::DEBUG, "method_call", %method))
+	pub fn method_call(method: &str, id:&Id) -> Self {
+		Self(tracing::span!(tracing::Level::DEBUG, "method_call", %method, id =? id))
 	}
 
 	/// Create a `notification` tracing target.

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -31,6 +31,11 @@ impl RpcTracing {
 	pub fn span(&self) -> &tracing::Span {
 		&self.0
 	}
+
+	/// Get the inner span.
+	pub fn into_span(self) -> tracing::Span {
+		self.0
+	}
 }
 
 /// Helper for writing trace logs from str.

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -31,11 +31,6 @@ impl RpcTracing {
 	pub fn span(&self) -> &tracing::Span {
 		&self.0
 	}
-
-	/// Get the inner span.
-	pub fn into_span(self) -> tracing::Span {
-		self.0
-	}
 }
 
 /// Helper for writing trace logs from str.

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -1,6 +1,5 @@
 use serde::Serialize;
 use tracing::Level;
-use jsonrpsee_types::Id;
 
 #[derive(Debug)]
 /// Wrapper over [`tracing::Span`] to trace individual method calls, notifications and similar.
@@ -10,8 +9,8 @@ impl RpcTracing {
 	/// Create a `method_call` tracing target.
 	///
 	/// To enable this you need to call `RpcTracing::method_call("some_method").span().enable()`.
-	pub fn method_call(method: &str, id:&Id) -> Self {
-		Self(tracing::span!(tracing::Level::DEBUG, "method_call", %method, id =? id))
+	pub fn method_call(method: &str) -> Self {
+		Self(tracing::span!(tracing::Level::DEBUG, "method_call", %method))
 	}
 
 	/// Create a `notification` tracing target.

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -28,8 +28,8 @@ impl RpcTracing {
 	}
 
 	/// Get the inner span.
-	pub fn span(&self) -> &tracing::Span {
-		&self.0
+	pub fn into_span(self) -> tracing::Span {
+		self.0
 	}
 }
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -685,8 +685,7 @@ async fn process_health_request<M: Middleware>(
 	request_start: M::Instant,
 	max_log_length: u32,
 ) -> Result<hyper::Response<hyper::Body>, HyperError> {
-	let id = Id::Number(100);
-	let trace = RpcTracing::method_call(&health_api.method, &id);
+	let trace = RpcTracing::method_call(&health_api.method);
 	let _enter = trace.span().enter();
 
 	tx_log_from_str("HTTP health API", max_log_length);
@@ -806,7 +805,7 @@ where
 
 async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_, M>) -> MethodResponse {
 	if let Ok(req) = serde_json::from_slice::<Request>(&data) {
-		let trace = RpcTracing::method_call(&req.method, &req.id);
+		let trace = RpcTracing::method_call(&req.method);
 		let _enter = trace.span().enter();
 
 		rx_log_from_json(&req, call.max_log_length);

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -721,7 +721,7 @@ async fn process_health_request<M: Middleware>(
 			Ok(response::internal_error())
 		}
 	}
-	.instrument(trace.span().clone())
+	.instrument(trace.into_span())
 	.await
 }
 
@@ -783,7 +783,7 @@ where
 				Err(batch_err) => batch_err,
 			}
 		}
-		.instrument(trace.span().clone())
+		.instrument(trace.into_span())
 		.await;
 	}
 
@@ -812,12 +812,12 @@ async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_,
 			let id = req.id;
 			execute_call(Call { name, params, id, call }).await
 		}
-		.instrument(trace.span().clone())
+		.instrument(trace.into_span())
 		.await
 	} else if let Ok(req) = serde_json::from_slice::<Notif>(&data) {
 		let trace = RpcTracing::notification(&req.method);
-		let _enter = trace.span().enter();
-
+		let span = trace.into_span();
+		let _enter = span.enter();
 		rx_log_from_json(&req, call.max_log_length);
 
 		MethodResponse { result: String::new(), success: true }

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -685,7 +685,8 @@ async fn process_health_request<M: Middleware>(
 	request_start: M::Instant,
 	max_log_length: u32,
 ) -> Result<hyper::Response<hyper::Body>, HyperError> {
-	let trace = RpcTracing::method_call(&health_api.method);
+	let id = Id::Number(100);
+	let trace = RpcTracing::method_call(&health_api.method, &id);
 	let _enter = trace.span().enter();
 
 	tx_log_from_str("HTTP health API", max_log_length);
@@ -805,7 +806,7 @@ where
 
 async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_, M>) -> MethodResponse {
 	if let Ok(req) = serde_json::from_slice::<Request>(&data) {
-		let trace = RpcTracing::method_call(&req.method);
+		let trace = RpcTracing::method_call(&req.method, &req.id);
 		let _enter = trace.span().enter();
 
 		rx_log_from_json(&req, call.max_log_length);

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -691,7 +691,9 @@ async fn process_health_request<M: Middleware>(
 		let response = match methods.method_with_name(&health_api.method) {
 			None => MethodResponse::error(Id::Null, ErrorObject::from(ErrorCode::MethodNotFound)),
 			Some((_name, method_callback)) => match method_callback.inner() {
-				MethodKind::Sync(callback) => (callback)(Id::Number(0), Params::new(None), max_response_body_size as usize),
+				MethodKind::Sync(callback) => {
+					(callback)(Id::Number(0), Params::new(None), max_response_body_size as usize)
+				}
 				MethodKind::Async(callback) => {
 					(callback)(Id::Number(0), Params::new(None), 0, max_response_body_size as usize, None).await
 				}
@@ -718,7 +720,9 @@ async fn process_health_request<M: Middleware>(
 		} else {
 			Ok(response::internal_error())
 		}
-	}.instrument(trace.span().clone()).await
+	}
+	.instrument(trace.span().clone())
+	.await
 }
 
 #[derive(Debug, Clone)]
@@ -778,7 +782,9 @@ where
 				Ok(batch) => batch.finish(),
 				Err(batch_err) => batch_err,
 			}
-		}.instrument(trace.span().clone()).await;
+		}
+		.instrument(trace.span().clone())
+		.await;
 	}
 
 	if let Ok(batch) = serde_json::from_slice::<Vec<Notif>>(&data) {
@@ -805,7 +811,9 @@ async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_,
 			let name = &req.method;
 			let id = req.id;
 			execute_call(Call { name, params, id, call }).await
-		}.instrument(trace.span().clone()).await
+		}
+		.instrument(trace.span().clone())
+		.await
 	} else if let Ok(req) = serde_json::from_slice::<Notif>(&data) {
 		let trace = RpcTracing::notification(&req.method);
 		let _enter = trace.span().enter();

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -686,41 +686,39 @@ async fn process_health_request<M: Middleware>(
 	max_log_length: u32,
 ) -> Result<hyper::Response<hyper::Body>, HyperError> {
 	let trace = RpcTracing::method_call(&health_api.method);
-	let response = async {
+	async {
 		tx_log_from_str("HTTP health API", max_log_length);
-		match methods.method_with_name(&health_api.method) {
-		None => MethodResponse::error(Id::Null, ErrorObject::from(ErrorCode::MethodNotFound)),
-		Some((_name, method_callback)) => match method_callback.inner() {
-			MethodKind::Sync(callback) => (callback)(Id::Number(0), Params::new(None), max_response_body_size as usize),
-			MethodKind::Async(callback) => {
-				(callback)(Id::Number(0), Params::new(None), 0, max_response_body_size as usize, None)
-					.in_current_span()
-					.await
+		let response = match methods.method_with_name(&health_api.method) {
+			None => MethodResponse::error(Id::Null, ErrorObject::from(ErrorCode::MethodNotFound)),
+			Some((_name, method_callback)) => match method_callback.inner() {
+				MethodKind::Sync(callback) => (callback)(Id::Number(0), Params::new(None), max_response_body_size as usize),
+				MethodKind::Async(callback) => {
+					(callback)(Id::Number(0), Params::new(None), 0, max_response_body_size as usize, None).await
+				}
+				MethodKind::Subscription(_) | MethodKind::Unsubscription(_) => {
+					MethodResponse::error(Id::Null, ErrorObject::from(ErrorCode::InternalError))
+				}
+			},
+		};
+
+		rx_log_from_str(&response.result, max_log_length);
+		middleware.on_result(&health_api.method, response.success, request_start);
+		middleware.on_response(&response.result, request_start);
+
+		if response.success {
+			#[derive(serde::Deserialize)]
+			struct RpcPayload<'a> {
+				#[serde(borrow)]
+				result: &'a serde_json::value::RawValue,
 			}
 
-			MethodKind::Subscription(_) | MethodKind::Unsubscription(_) => {
-				MethodResponse::error(Id::Null, ErrorObject::from(ErrorCode::InternalError))
-			}
-		},
-	}}.instrument(trace.into_span()).await;
-
-	rx_log_from_str(&response.result, max_log_length);
-	middleware.on_result(&health_api.method, response.success, request_start);
-	middleware.on_response(&response.result, request_start);
-
-	if response.success {
-		#[derive(serde::Deserialize)]
-		struct RpcPayload<'a> {
-			#[serde(borrow)]
-			result: &'a serde_json::value::RawValue,
+			let payload: RpcPayload = serde_json::from_str(&response.result)
+				.expect("valid JSON-RPC response must have a result field and be valid JSON; qed");
+			Ok(response::ok_response(payload.result.to_string()))
+		} else {
+			Ok(response::internal_error())
 		}
-
-		let payload: RpcPayload = serde_json::from_str(&response.result)
-			.expect("valid JSON-RPC response must have a result field and be valid JSON; qed");
-		Ok(response::ok_response(payload.result.to_string()))
-	} else {
-		Ok(response::internal_error())
-	}
+	}.instrument(trace.span().clone()).await
 }
 
 #[derive(Debug, Clone)]
@@ -764,8 +762,8 @@ where
 		let batch_stream = futures_util::stream::iter(batch);
 
 		let trace = RpcTracing::batch();
-		let batch_response = async{
-			batch_stream
+		return async {
+			let batch_response = batch_stream
 				.try_fold(
 					BatchResponseBuilder::new_with_limit(max_response_size as usize),
 					|batch_response, (req, call)| async move {
@@ -774,13 +772,13 @@ where
 						batch_response.append(&response)
 					},
 				)
-				.await
-		}.instrument(trace.into_span()).await;
+				.await;
 
-		return match batch_response {
-			Ok(batch) => batch.finish(),
-			Err(batch_err) => batch_err,
-		};
+			match batch_response {
+				Ok(batch) => batch.finish(),
+				Err(batch_err) => batch_err,
+			}
+		}.instrument(trace.span().clone()).await;
 	}
 
 	if let Ok(batch) = serde_json::from_slice::<Vec<Notif>>(&data) {
@@ -801,13 +799,13 @@ where
 async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_, M>) -> MethodResponse {
 	if let Ok(req) = serde_json::from_slice::<Request>(&data) {
 		let trace = RpcTracing::method_call(&req.method);
-		async{
+		async {
 			rx_log_from_json(&req, call.max_log_length);
 			let params = Params::new(req.params.map(|params| params.get()));
 			let name = &req.method;
 			let id = req.id;
 			execute_call(Call { name, params, id, call }).await
-		}.instrument(trace.into_span()).await
+		}.instrument(trace.span().clone()).await
 	} else if let Ok(req) = serde_json::from_slice::<Notif>(&data) {
 		let trace = RpcTracing::notification(&req.method);
 		let _enter = trace.span().enter();

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -881,7 +881,7 @@ where
 					Err(batch_err) => batch_err,
 				}
 			}
-			.instrument(trace.span().clone())
+			.instrument(trace.into_span())
 			.await;
 		} else {
 			BatchResponse::error(Id::Null, ErrorObject::from(ErrorCode::InvalidRequest))
@@ -905,7 +905,7 @@ async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_,
 
 			execute_call(Call { name, params, id, call }).await
 		}
-		.instrument(trace.span().clone())
+		.instrument(trace.into_span())
 		.await
 	} else {
 		let (id, code) = prepare_error(&data);

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -893,7 +893,7 @@ where
 
 async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_, M>) -> MethodResult {
 	if let Ok(req) = serde_json::from_slice::<Request>(&data) {
-		let trace = RpcTracing::method_call(&req.method, &req.id);
+		let trace = RpcTracing::method_call(&req.method);
 		let _enter = trace.span().enter();
 
 		rx_log_from_json(&req, call.max_log_length);

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -861,27 +861,29 @@ where
 			let batch_stream = futures_util::stream::iter(batch);
 
 			let trace = RpcTracing::batch();
-			let _enter = trace.span().enter();
-			let max_response_size = call.max_response_body_size;
 
-			let batch_response = batch_stream
-				.try_fold(
-					BatchResponseBuilder::new_with_limit(max_response_size as usize),
-					|batch_response, (req, call)| async move {
-						let params = Params::new(req.params.map(|params| params.get()));
+			return async {
+				let max_response_size = call.max_response_body_size;
 
-						let response =
-							execute_call(Call { name: &req.method, params, id: req.id, call }).in_current_span().await;
+				let batch_response = batch_stream
+					.try_fold(
+						BatchResponseBuilder::new_with_limit(max_response_size as usize),
+						|batch_response, (req, call)| async move {
+							let params = Params::new(req.params.map(|params| params.get()));
 
-						batch_response.append(response.as_inner())
-					},
-				)
-				.await;
+							let response =
+								execute_call(Call { name: &req.method, params, id: req.id, call }).await;
 
-			return match batch_response {
-				Ok(batch) => batch.finish(),
-				Err(batch_err) => batch_err,
-			};
+							batch_response.append(response.as_inner())
+						},
+					)
+					.await;
+
+				match batch_response {
+					Ok(batch) => batch.finish(),
+					Err(batch_err) => batch_err,
+				}
+			}.instrument(trace.span().clone()).await
 		} else {
 			BatchResponse::error(Id::Null, ErrorObject::from(ErrorCode::InvalidRequest))
 		};
@@ -894,15 +896,16 @@ where
 async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_, M>) -> MethodResult {
 	if let Ok(req) = serde_json::from_slice::<Request>(&data) {
 		let trace = RpcTracing::method_call(&req.method);
-		let _enter = trace.span().enter();
 
-		rx_log_from_json(&req, call.max_log_length);
+		async {
+			rx_log_from_json(&req, call.max_log_length);
 
-		let params = Params::new(req.params.map(|params| params.get()));
-		let name = &req.method;
-		let id = req.id;
+			let params = Params::new(req.params.map(|params| params.get()));
+			let name = &req.method;
+			let id = req.id;
 
-		execute_call(Call { name, params, id, call }).in_current_span().await
+			execute_call(Call { name, params, id, call }).in_current_span().await
+		}.instrument(trace.span().clone()).await
 	} else {
 		let (id, code) = prepare_error(&data);
 		MethodResult::SendAndMiddleware(MethodResponse::error(id, ErrorObject::from(code)))

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -893,7 +893,7 @@ where
 
 async fn process_single_request<M: Middleware>(data: Vec<u8>, call: CallData<'_, M>) -> MethodResult {
 	if let Ok(req) = serde_json::from_slice::<Request>(&data) {
-		let trace = RpcTracing::method_call(&req.method);
+		let trace = RpcTracing::method_call(&req.method, &req.id);
 		let _enter = trace.span().enter();
 
 		rx_log_from_json(&req, call.max_log_length);


### PR DESCRIPTION
jsonrpsee is emitting incorrect trace because of incorrect use of `Span::enter` in async code

### Symtoms:
logs are very spammy as the trace is entering incorrect span 
```
_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_transferObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_getObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_transferObject}:method_call{method=sui_transferObject}:method_call{method=sui_transferObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_splitCoin}:method_call{method=sui_transferObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_syncAccountState}:method_call{method=sui_getObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_transferObject}:method_call{method=sui_splitCoin}:method_call{method=sui_transferObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_executeTransaction}:method_call{method=sui_executeTransaction}:method_call{method=sui_transferObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_executeTransaction}:method_call{method=sui_transferObject}:method_call{method=sui_executeTransaction}:method_call{method=sui_transferSui}:method_call{method=sui_executeTransaction}:method_call{method=sui_executeTransaction}:method_call{method=sui_executeTransaction}:method_call{method=sui_executeTransaction}:gateway_execute_transaction{tx_digest=VXrf5dF9bFPlPQsyxOXhvXRZ+5zZneS2t90nhI+6WCM= tx_kind="Single"}:execute_transaction{tx_digest=VXrf5dF9bFPlPQsyxOXhvXRZ+5zZneS2t90nhI+6WCM= tx_kind="Single"}:process_tx: sui_core::safe_client: Client error error=PairwiseSyncFailed { xsource: k#e97638a9e10b9cc46d85b81191a60a6a6fcae63dacd811c07502db9c5cfc55b5, destination: k#89cafd721eeb1b13483d5fb0968500e78103e8146b45edb30d93781d946d0aeb, tx_digest: VXrf5dF9bFPlPQsyxOXhvXRZ+5zZneS2t90nhI+6WCM=, error: RpcError("Timeout expired") } authority=k#e97638a9e10b9cc46d85b81191a60a6a6fcae63dacd811c07502db9c5cfc55b5
```

this PR replace the use of `Span::enter` with `async {...}.instrument(span).await` as suggested by the tracing doc
https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code