### PR TITLE
Uniform log messages

### DIFF
--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -199,7 +199,7 @@ impl TransportSenderT for Sender {
 	/// Sends out a ping request. Returns a `Future` that finishes when the request has been
 	/// successfully sent.
 	async fn send_ping(&mut self) -> Result<(), Self::Error> {
-		tracing::debug!("send ping");
+		tracing::debug!("Send ping");
 		// Submit empty slice as "optional" parameter.
 		let slice: &[u8] = &[];
 		// Byte slice fails if the provided slice is larger than 125 bytes.

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -84,7 +84,7 @@ pub(crate) fn process_subscription_response(
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
 		Some(request_id) => request_id,
 		None => {
-			tracing::warn!("Subscription ID: {:?} is not an active subscription", sub_id);
+			tracing::warn!("Subscription {:?} is not active", sub_id);
 			return Err(None);
 		}
 	};
@@ -100,7 +100,7 @@ pub(crate) fn process_subscription_response(
 			}
 		},
 		None => {
-			tracing::warn!("Subscription ID: {:?} is not an active subscription", sub_id);
+			tracing::warn!("Subscription {:?} is not active", sub_id);
 			Err(None)
 		}
 	}
@@ -118,7 +118,7 @@ pub(crate) fn process_subscription_close_response(
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
 		Some(request_id) => request_id,
 		None => {
-			tracing::error!("The server tried to close down an invalid subscription: {:?}", sub_id);
+			tracing::error!("The server tried to close an invalid subscription: {:?}", sub_id);
 			return Err(Error::InvalidSubscriptionId);
 		}
 	};

--- a/core/src/client/async_client/manager.rs
+++ b/core/src/client/async_client/manager.rs
@@ -86,9 +86,9 @@ pub(crate) struct RequestManager {
 	/// Reverse lookup, to find a request ID in constant time by `subscription ID` instead of looking through all
 	/// requests.
 	subscriptions: HashMap<SubscriptionId<'static>, RequestId>,
-	/// Pending batch requests
+	/// Pending batch requests.
 	batches: FxHashMap<Vec<RequestId>, BatchState>,
-	/// Registered Methods for incoming notifications
+	/// Registered Methods for incoming notifications.
 	notification_handlers: HashMap<String, SubscriptionSink>,
 }
 
@@ -98,7 +98,7 @@ impl RequestManager {
 		Self::default()
 	}
 
-	/// Tries to insert a new pending call.
+	/// Tries to insert a new pending request.
 	///
 	/// Returns `Ok` if the pending request was successfully inserted otherwise `Err`.
 	pub(crate) fn insert_pending_call(
@@ -114,7 +114,7 @@ impl RequestManager {
 		}
 	}
 
-	/// Tries to insert a new batch request
+	/// Tries to insert a new batch request.
 	///
 	/// Returns `Ok` if the pending request was successfully inserted otherwise `Err`.
 	pub(crate) fn insert_pending_batch(
@@ -134,6 +134,7 @@ impl RequestManager {
 			Err(send_back)
 		}
 	}
+
 	/// Tries to insert a new pending subscription and reserves a slot for a "potential" unsubscription request.
 	///
 	/// Returns `Ok` if the pending request was successfully inserted otherwise `Err`.

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -576,7 +576,8 @@ async fn handle_frontend_messages<S: TransportSenderT>(
 		// User dropped the sender side of the channel.
 		// There is nothing to do just terminate.
 		None => {
-			return Err(Error::Custom("[backend]: frontend dropped; terminate client".into()));
+			tracing::debug!("[backend]: frontend dropped; terminate client");
+			return Ok(());
 		}
 
 		Some(FrontToBack::Batch(batch)) => {

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -542,7 +542,7 @@ async fn handle_backend_messages<S: TransportSenderT, R: TransportReceiverT>(
 
 	match message {
 		Some(Ok(ReceivedMessage::Pong)) => {
-			tracing::debug!("Received pong frame");
+			tracing::debug!("Received pong");
 		}
 		Some(Ok(ReceivedMessage::Bytes(raw))) => {
 			handle_recv_message(raw.as_ref(), manager, sender, max_notifs_per_subscription).await?;

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -685,7 +685,7 @@ async fn background_task<S, R>(
 				} else {
 					// User dropped the sender side of the channel.
 					// There is nothing to do just terminate.
-					tracing::debug!("[backend]: Frontend receiver dropped");
+					tracing::debug!("[backend]: Client dropped");
 					break;
 				};
 

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -554,7 +554,7 @@ async fn handle_backend_messages<S: TransportSenderT, R: TransportReceiverT>(
 			return Err(Error::Transport(e.into()));
 		}
 		None => {
-			return Err(Error::Custom("WebSocket receiver dropped".into()));
+			return Err(Error::Custom("TransportReceiver dropped".into()));
 		}
 	}
 

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -83,7 +83,7 @@ impl<'a> io::Write for &'a mut BoundedWriter {
 /// Sink that is used to send back the result to the server for a specific method.
 #[derive(Clone, Debug)]
 pub struct MethodSink {
-	/// Channel sender
+	/// Channel sender.
 	tx: mpsc::UnboundedSender<String>,
 	/// Max response size in bytes for a executed call.
 	max_response_size: u32,
@@ -92,12 +92,12 @@ pub struct MethodSink {
 }
 
 impl MethodSink {
-	/// Create a new `MethodSink` with unlimited response size
+	/// Create a new `MethodSink` with unlimited response size.
 	pub fn new(tx: mpsc::UnboundedSender<String>) -> Self {
 		MethodSink { tx, max_response_size: u32::MAX, max_log_length: u32::MAX }
 	}
 
-	/// Create a new `MethodSink` with a limited response size
+	/// Create a new `MethodSink` with a limited response size.
 	pub fn new_with_limit(tx: mpsc::UnboundedSender<String>, max_response_size: u32, max_log_length: u32) -> Self {
 		MethodSink { tx, max_response_size, max_log_length }
 	}
@@ -112,7 +112,7 @@ impl MethodSink {
 		let json = match serde_json::to_string(&ErrorResponse::borrowed(error, id)) {
 			Ok(json) => json,
 			Err(err) => {
-				tracing::error!("Error serializing error message: {:?}", err);
+				tracing::error!("Error serializing response: {:?}", err);
 
 				return false;
 			}
@@ -128,7 +128,7 @@ impl MethodSink {
 		}
 	}
 
-	/// Helper for sending the general purpose `Error` as a JSON-RPC errors to the client
+	/// Helper for sending the general purpose `Error` as a JSON-RPC errors to the client.
 	pub fn send_call_error(&self, id: Id, err: Error) -> bool {
 		self.send_error(id, err.into())
 	}

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -487,12 +487,12 @@ impl<L: Logger> ServiceData<L> {
 		let maybe_origin = http_helpers::read_header_value(request.headers(), "origin");
 
 		if let Err(e) = acl.verify_host(host) {
-			tracing::warn!("Denied request: {:?}", e);
+			tracing::warn!("Denied request: {}", e);
 			return response::host_not_allowed();
 		}
 
 		if let Err(e) = acl.verify_origin(maybe_origin, host) {
-			tracing::warn!("Denied request: {:?}", e);
+			tracing::warn!("Denied request: {}", e);
 			return response::origin_rejected(maybe_origin);
 		}
 

--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -936,7 +936,7 @@ async fn execute_call<L: Logger>(c: Call<'_, L>) -> MethodResponse {
 						r
 					}
 					Err(err) => {
-						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {:?}", err);
+						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {}", err);
 						MethodResponse::error(id, ErrorObject::from(ErrorCode::ServerIsBusy))
 					}
 				}
@@ -951,7 +951,7 @@ async fn execute_call<L: Logger>(c: Call<'_, L>) -> MethodResponse {
 						(callback)(id, params, conn_id, max_response_body_size as usize, Some(guard)).await
 					}
 					Err(err) => {
-						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {:?}", err);
+						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {}", err);
 						MethodResponse::error(id, ErrorObject::from(ErrorCode::ServerIsBusy))
 					}
 				}

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -506,10 +506,10 @@ async fn ws_server_notify_client_on_disconnect() {
 	server_handle.stop().unwrap().await;
 
 	// The `on_disconnect()` method returned.
-	let _ = dis_rx.await.unwrap();
+	dis_rx.await.unwrap();
 
 	// Multiple `on_disconnect()` calls did not block.
-	let _ = multiple_rx.await.unwrap();
+	multiple_rx.await.unwrap();
 }
 
 #[tokio::test]

--- a/ws-server/src/server.rs
+++ b/ws-server/src/server.rs
@@ -424,7 +424,7 @@ async fn background_task<L: Logger>(input: BackgroundTask<'_, L>) -> Result<(), 
 					}
 					MonitoredError::Selector(SokettoError::MessageTooLarge { current, maximum }) => {
 						tracing::warn!(
-							"WS transport error: outgoing message is too big error ({} bytes, max is {})",
+							"WS transport error: Request length: {} exceeded max limit: {} bytes",
 							current,
 							maximum
 						);
@@ -433,7 +433,7 @@ async fn background_task<L: Logger>(input: BackgroundTask<'_, L>) -> Result<(), 
 					}
 					// These errors can not be gracefully handled, so just log them and terminate the connection.
 					MonitoredError::Selector(err) => {
-						tracing::debug!("Terminate connection {}: WS error: {}", conn_id, err);
+						tracing::error!("Terminate connection {}: WS error: {}", conn_id, err);
 						sink.close();
 						break Err(err.into());
 					}
@@ -950,7 +950,7 @@ async fn execute_call<L: Logger>(c: Call<'_, L>) -> MethodResult {
 						MethodResult::SendAndLogger(r)
 					}
 					Err(err) => {
-						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {:?}", err);
+						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {}", err);
 						let response = MethodResponse::error(id, ErrorObject::from(ErrorCode::ServerIsBusy));
 						MethodResult::SendAndLogger(response)
 					}
@@ -969,7 +969,7 @@ async fn execute_call<L: Logger>(c: Call<'_, L>) -> MethodResult {
 						MethodResult::SendAndLogger(response)
 					}
 					Err(err) => {
-						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {:?}", err);
+						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {}", err);
 						let response = MethodResponse::error(id, ErrorObject::from(ErrorCode::ServerIsBusy));
 						MethodResult::SendAndLogger(response)
 					}
@@ -991,7 +991,7 @@ async fn execute_call<L: Logger>(c: Call<'_, L>) -> MethodResult {
 						}
 					}
 					Err(err) => {
-						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {:?}", err);
+						tracing::error!("[Methods::execute_with_resources] failed to lock resources: {}", err);
 						let response = MethodResponse::error(id, ErrorObject::from(ErrorCode::ServerIsBusy));
 						MethodResult::SendAndLogger(response)
 					}


### PR DESCRIPTION
This PR normalizes the published log messages.

Errors are logged for any unrecoverable issues (ie, terminating a client/server
connection caused via error exit paths).

While at it, clean up some comments and documentation.