### PR TITLE
Enable `cargo-nextest` for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-nextest
+          locked: true
           version: 0.9
 
       - name: Rust Cache
@@ -135,6 +136,7 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-nextest
+          locked: true
           version: 0.9
 
       - name: Rust Cache
@@ -161,6 +163,7 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-nextest
+          locked: true
           version: 0.9
 
       - name: Rust Cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,29 +91,6 @@ jobs:
       - name: Cargo check all targets and features
         run: cargo hack check --workspace --each-feature --all-targets
 
-  tests_ubuntu:
-    name: Run tests Ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3.0.2
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Install latest nextest release
-        uses: taiki-e/install-action@nextest
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.0.0
-
-      - name: Cargo nextest
-        run: cargo nextest run --workspace
-
   tests_macos:
     name: Run tests macos
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,17 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          version: 0.9
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.0.0
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --workspace
+      - name: Cargo nextest
+        run: cargo nextest run --workspace
 
   tests_macos:
     name: Run tests macos
@@ -128,14 +131,17 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          version: 0.9
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.0.0
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --workspace
+      - name: Cargo nextest
+        run: cargo nextest run --workspace
 
   tests_windows:
     name: Run tests Windows
@@ -151,14 +157,17 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          version: 0.9
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.0.0
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --workspace
+      - name: Cargo nextest
+        run: cargo nextest run --workspace
 
   wasm_tests:
     name: Test wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-nextest
-          locked: true
-          version: 0.9
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.0.0
@@ -132,12 +128,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-nextest
-          locked: true
-          version: 0.9
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.0.0
@@ -159,12 +151,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-nextest
-          locked: true
-          version: 0.9
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.0.0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,9 @@ test:
   <<:                              *docker-env
   <<:                              *common-refs
   script:
-    - cargo test
+    - cargo install cargo-nextest --locked
+    - cargo nextest run --workspace
+    - cargo test --doc
 
 benchmarks:
   stage:                           benchmark

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,6 @@ test:
   <<:                              *docker-env
   <<:                              *common-refs
   script:
-    - cargo install cargo-nextest --locked
     - cargo nextest run --workspace
     - cargo test --doc
 


### PR DESCRIPTION
To avoid issues with the CI, the nextest was replaced with `cargo test`.

This PR ensures we utilize it again the `cargo nextest` functionality, via
installing it locked ([commit](https://github.com/nextest-rs/nextest/commit/f8fc8ae820524f6171868c384654f94e5655d79a))

Issue reference: https://github.com/nextest-rs/nextest/issues/306

## Time Delta

Location | Sample 1 | Sample 2 | After  1 | After 2 | 
|----|----|----|----|----|
CI (ubuntu) | 3m 10s | 3m 1s | 4m 47s | 3m 23s |
Windows | 9m 33s |  10m 15s  |  11m 18s | 11m 34s |
MacOS | 8m 18s | 5m 43s   | 8m 36s  | 9m 48s |

_Sample 1: https://github.com/paritytech/jsonrpsee/commit/6fdb67f99324ff50b8f629a3eb563fd314af9aae
Sample 2: https://github.com/paritytech/jsonrpsee/commit/bd31557da8246dcc45555bf2dcbb65585a834bbb._

