### PR TITLE
fix(http_server): in http2 host is not passed in headers

### DIFF
--- a/http-server/src/server.rs
+++ b/http-server/src/server.rs
@@ -449,6 +449,10 @@ impl<L: Logger> ServiceData<L> {
 
 		let host = match http_helpers::read_header_value(request.headers(), "host") {
 			Some(origin) => origin,
+			None if request.version() == hyper::Version::HTTP_2 => match request.uri().host() {
+				Some(origin) => origin,
+				None => return response::malformed(),
+			},
 			None => return response::malformed(),
 		};
 		let maybe_origin = http_helpers::read_header_value(request.headers(), "origin");


### PR DESCRIPTION
In http2 host is not passed in headers which leads to this function always returning None and all http2 requests erroring with `Parse error`.