### PR TITLE
add tokio-console support for benches

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -19,6 +19,7 @@ jsonrpc-pubsub = { version = "18.0.0", optional = true }
 num_cpus = "1"
 serde_json = "1"
 tokio = { version = "1.16", features = ["rt-multi-thread"] }
+console-subscriber = "0.1.8"
 
 [[bench]]
 name = "bench"

--- a/benches/README.md
+++ b/benches/README.md
@@ -38,3 +38,13 @@ This will generate a flamegraph for the specific benchmark in `./target/criterio
 It's also possible to run profiling on individual benchmarks by:
 
 `$ cargo bench --bench bench -- --profile-time=60 sync/http_concurrent_conn_calls/1024`
+
+## Run tokio console on the benchmarks
+
+Install and run `tokio-console`.
+
+`$ cargo install --locked tokio-console && tokio-console`
+
+Run benchmarks with tokio-console support.
+
+`$ RUSTFLAGS="--cfg tokio_unstable" cargo bench`

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -65,6 +65,9 @@ fn v2_serialize(req: RequestSer<'_>) -> String {
 }
 
 pub fn jsonrpsee_types_v2(crit: &mut Criterion) {
+	#[cfg(feature = "tokio_unstable")]
+	console_subscriber::init();
+
 	// Construct the serialized array request using the `RawValue` directly.
 	crit.bench_function("jsonrpsee_types_array_params_baseline", |b| {
 		b.iter(|| {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = { version = "1" }
 tower-http = { version = "0.3.4", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 hyper = "0.14.20"
+console-subscriber = "0.1.8"

--- a/examples/examples/tokio_console.rs
+++ b/examples/examples/tokio_console.rs
@@ -61,7 +61,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let addr = server.local_addr()?;
 	let handle = server.start(module)?;
 
-	// In this example we don't care about doing shutdown so let's it run forever.
+	// In this example we don't care about doing a stopping the server so let it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.
 	tokio::spawn(handle.stopped());
 

--- a/examples/examples/tokio_console.rs
+++ b/examples/examples/tokio_console.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// Copyright 2022 Parity Technologies (UK) Ltd.
 //
 // Permission is hereby granted, free of charge, to any
 // person obtaining a copy of this software and associated

--- a/examples/examples/tokio_console.rs
+++ b/examples/examples/tokio_console.rs
@@ -1,0 +1,69 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Example how to use `tokio-console` to debug async tasks `jsonrpsee`.
+//! For further information see https://docs.rs/console-subscriber.
+//!
+//! To run it:
+//! `$ cargo install --locked tokio-console`
+//! `$ RUSTFLAGS="--cfg tokio_unstable" cargo run --example tokio_console`
+//! `$ tokio-console`
+//!
+//! It will start a server on http://127.0.0.1:6669 for `tokio-console` to connect to.
+
+use std::net::SocketAddr;
+
+use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::RpcModule;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	console_subscriber::init();
+
+	let _ = run_server().await?;
+
+	futures::future::pending().await
+}
+
+async fn run_server() -> anyhow::Result<SocketAddr> {
+	let server = ServerBuilder::default().build("127.0.0.1:9944").await?;
+	let mut module = RpcModule::new(());
+	module.register_method("say_hello", |_, _| Ok("lo"))?;
+	module.register_method("memory_call", |_, _| Ok("A".repeat(1024 * 1024)))?;
+	module.register_async_method("sleep", |_, _| async {
+		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+		Ok("lo")
+	})?;
+
+	let addr = server.local_addr()?;
+	let handle = server.start(module)?;
+
+	// In this example we don't care about doing shutdown so let's it run forever.
+	// You may use the `ServerHandle` to shut it down or manage it yourself.
+	tokio::spawn(handle.stopped());
+
+	Ok(addr)
+}


### PR DESCRIPTION
This is useful for debugging futures and so on, I think it can come in handy to debug async related issues