### PR TITLE
[ci] Additional variables for benchmarks execution

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,7 +110,7 @@ benchmarks:
   <<:                              *docker-env
   <<:                              *collect-artifacts
   <<:                              *schedule-refs
-  timeout:                         12h
+  timeout:                         3h
   variables:
     MEASUREMENT_TIME:              3
     SLOW_MEASUREMENT_TIME:         40

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,7 +113,7 @@ benchmarks:
   timeout:                         3h
   variables:
     MEASUREMENT_TIME:              3
-    SLOW_MEASUREMENT_TIME:         40
+    SLOW_MEASUREMENT_TIME:         60
   script:
     - cargo bench -p jsonrpsee-benchmarks -- --output-format bencher | tee output.txt
     - mkdir artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,6 +110,10 @@ benchmarks:
   <<:                              *docker-env
   <<:                              *collect-artifacts
   <<:                              *schedule-refs
+  timeout:                         12h
+  variables:
+    MEASUREMENT_TIME:              3
+    SLOW_MEASUREMENT_TIME:         40
   script:
     - cargo bench -p jsonrpsee-benchmarks -- --output-format bencher | tee output.txt
     - mkdir artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ benchmarks:
   <<:                              *schedule-refs
   timeout:                         3h
   variables:
-    MEASUREMENT_TIME:              3
+    MEASUREMENT_TIME:              10
     SLOW_MEASUREMENT_TIME:         60
   script:
     - cargo bench -p jsonrpsee-benchmarks -- --output-format bencher | tee output.txt


### PR DESCRIPTION
Added `MEASUREMENT_TIME: 3` and `SLOW_MEASUREMENT_TIME: 40` variables to benchmark job. With these variables it takes ~2h to run benchmarks: https://gitlab.parity.io/parity/mirrors/jsonrpsee/-/jobs/1885548

cc https://github.com/paritytech/ci_cd/issues/302