### PR TITLE
server: add `transport protocol details` to the logger trait

### DIFF
--- a/examples/examples/logger.rs
+++ b/examples/examples/logger.rs
@@ -28,7 +28,7 @@ use std::net::SocketAddr;
 use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::server::logger::{self, HttpRequest, MethodKind, Params};
+use jsonrpsee::server::logger::{self, HttpRequest, MethodKind, Params, TransportProtocol};
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, RpcModule};
@@ -39,28 +39,28 @@ struct Timings;
 impl logger::Logger for Timings {
 	type Instant = Instant;
 
-	fn on_connect(&self, remote_addr: SocketAddr, request: &HttpRequest) {
+	fn on_connect(&self, remote_addr: SocketAddr, request: &HttpRequest, _t: TransportProtocol) {
 		println!("[Logger::on_connect] remote_addr {:?}, headers: {:?}", remote_addr, request);
 	}
 
-	fn on_request(&self) -> Self::Instant {
+	fn on_request(&self, _t: TransportProtocol) -> Self::Instant {
 		println!("[Logger::on_request]");
 		Instant::now()
 	}
 
-	fn on_call(&self, name: &str, params: Params, kind: MethodKind) {
+	fn on_call(&self, name: &str, params: Params, kind: MethodKind, _t: TransportProtocol) {
 		println!("[Logger::on_call] method: '{}', params: {:?}, kind: {}", name, params, kind);
 	}
 
-	fn on_result(&self, name: &str, succeess: bool, started_at: Self::Instant) {
+	fn on_result(&self, name: &str, succeess: bool, started_at: Self::Instant, _t: TransportProtocol) {
 		println!("[Logger::on_result] '{}', worked? {}, time elapsed {:?}", name, succeess, started_at.elapsed());
 	}
 
-	fn on_response(&self, result: &str, started_at: Self::Instant) {
+	fn on_response(&self, result: &str, started_at: Self::Instant, _t: TransportProtocol) {
 		println!("[Logger::on_response] result: {}, time elapsed {:?}", result, started_at.elapsed());
 	}
 
-	fn on_disconnect(&self, remote_addr: SocketAddr) {
+	fn on_disconnect(&self, remote_addr: SocketAddr, _t: TransportProtocol) {
 		println!("[Logger::on_disconnect] remote_addr: {:?}", remote_addr);
 	}
 }

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -32,7 +32,7 @@ use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::logger::{HttpRequest, MethodKind};
+use jsonrpsee::server::logger::{HttpRequest, MethodKind, TransportProtocol};
 use jsonrpsee::server::{logger, RpcModule, ServerBuilder};
 use jsonrpsee::types::Params;
 use jsonrpsee::ws_client::WsClientBuilder;
@@ -44,27 +44,27 @@ struct Timings;
 impl logger::Logger for Timings {
 	type Instant = Instant;
 
-	fn on_connect(&self, remote_addr: SocketAddr, req: &HttpRequest) {
+	fn on_connect(&self, remote_addr: SocketAddr, req: &HttpRequest, _t: TransportProtocol) {
 		println!("[Timings::on_connect] remote_addr {:?}, req: {:?}", remote_addr, req);
 	}
 
-	fn on_request(&self) -> Self::Instant {
+	fn on_request(&self, _t: TransportProtocol) -> Self::Instant {
 		Instant::now()
 	}
 
-	fn on_call(&self, name: &str, params: Params, kind: MethodKind) {
+	fn on_call(&self, name: &str, params: Params, kind: MethodKind, _t: TransportProtocol) {
 		println!("[Timings:on_call] method: '{}', params: {:?}, kind: {}", name, params, kind);
 	}
 
-	fn on_result(&self, name: &str, success: bool, started_at: Self::Instant) {
+	fn on_result(&self, name: &str, success: bool, started_at: Self::Instant, _t: TransportProtocol) {
 		println!("[Timings] call={}, worked? {}, duration {:?}", name, success, started_at.elapsed());
 	}
 
-	fn on_response(&self, _result: &str, started_at: Self::Instant) {
+	fn on_response(&self, _result: &str, started_at: Self::Instant, _t: TransportProtocol) {
 		println!("[Timings] Response duration {:?}", started_at.elapsed());
 	}
 
-	fn on_disconnect(&self, remote_addr: SocketAddr) {
+	fn on_disconnect(&self, remote_addr: SocketAddr, _t: TransportProtocol) {
 		println!("[Timings::on_disconnect] remote_addr: {:?}", remote_addr);
 	}
 }
@@ -91,32 +91,32 @@ impl ThreadWatcher {
 impl logger::Logger for ThreadWatcher {
 	type Instant = isize;
 
-	fn on_connect(&self, remote_addr: SocketAddr, headers: &HttpRequest) {
+	fn on_connect(&self, remote_addr: SocketAddr, headers: &HttpRequest, _t: TransportProtocol) {
 		println!("[ThreadWatcher::on_connect] remote_addr {:?}, headers: {:?}", remote_addr, headers);
 	}
 
-	fn on_call(&self, _method: &str, _params: Params, _kind: MethodKind) {
+	fn on_call(&self, _method: &str, _params: Params, _kind: MethodKind, _t: TransportProtocol) {
 		let threads = Self::count_threads();
 		println!("[ThreadWatcher::on_call] Threads running on the machine at the start of a call: {}", threads);
 	}
 
-	fn on_request(&self) -> Self::Instant {
+	fn on_request(&self, _t: TransportProtocol) -> Self::Instant {
 		let threads = Self::count_threads();
 		println!("[ThreadWatcher::on_request] Threads running on the machine at the start of a call: {}", threads);
 		threads as isize
 	}
 
-	fn on_result(&self, _name: &str, _succees: bool, started_at: Self::Instant) {
+	fn on_result(&self, _name: &str, _succees: bool, started_at: Self::Instant, _t: TransportProtocol) {
 		let current_nr_threads = Self::count_threads() as isize;
 		println!("[ThreadWatcher::on_result] {} threads", current_nr_threads - started_at);
 	}
 
-	fn on_response(&self, _result: &str, started_at: Self::Instant) {
+	fn on_response(&self, _result: &str, started_at: Self::Instant, _t: TransportProtocol) {
 		let current_nr_threads = Self::count_threads() as isize;
 		println!("[ThreadWatcher::on_response] {} threads", current_nr_threads - started_at);
 	}
 
-	fn on_disconnect(&self, remote_addr: SocketAddr) {
+	fn on_disconnect(&self, remote_addr: SocketAddr, _t: TransportProtocol) {
 		println!("[ThreadWatcher::on_disconnect] remote_addr: {:?}", remote_addr);
 	}
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -315,7 +315,7 @@ impl<B, L> Builder<B, L> {
 	/// ```
 	/// use std::{time::Instant, net::SocketAddr};
 	///
-	/// use jsonrpsee_server::logger::{Logger, HttpRequest, MethodKind, Params};
+	/// use jsonrpsee_server::logger::{Logger, HttpRequest, MethodKind, Params, TransportProtocol};
 	/// use jsonrpsee_server::ServerBuilder;
 	///
 	/// #[derive(Clone)]
@@ -324,28 +324,28 @@ impl<B, L> Builder<B, L> {
 	/// impl Logger for MyLogger {
 	///     type Instant = Instant;
 	///
-	///     fn on_connect(&self, remote_addr: SocketAddr, request: &HttpRequest) {
-	///          println!("[MyLogger::on_call] remote_addr: {:?}, headers: {:?}", remote_addr, request);
+	///     fn on_connect(&self, remote_addr: SocketAddr, request: &HttpRequest, transport: TransportProtocol) {
+	///          println!("[MyLogger::on_call] remote_addr: {:?}, headers: {:?}, transport: {}", remote_addr, request, transport);
 	///     }
 	///
-	///     fn on_request(&self) -> Self::Instant {
+	///     fn on_request(&self, transport: TransportProtocol) -> Self::Instant {
 	///          Instant::now()
 	///     }
 	///
-	///     fn on_call(&self, method_name: &str, params: Params, kind: MethodKind) {
-	///          println!("[MyLogger::on_call] method: '{}' params: {:?}, kind: {:?}", method_name, params, kind);
+	///     fn on_call(&self, method_name: &str, params: Params, kind: MethodKind, transport: TransportProtocol) {
+	///          println!("[MyLogger::on_call] method: '{}' params: {:?}, kind: {:?}, transport: {}", method_name, params, kind, transport);
 	///     }
 	///
-	///     fn on_result(&self, method_name: &str, success: bool, started_at: Self::Instant) {
-	///          println!("[MyLogger::on_result] '{}', worked? {}, time elapsed {:?}", method_name, success, started_at.elapsed());
+	///     fn on_result(&self, method_name: &str, success: bool, started_at: Self::Instant, transport: TransportProtocol) {
+	///          println!("[MyLogger::on_result] '{}', worked? {}, time elapsed {:?}, transport: {}", method_name, success, started_at.elapsed(), transport);
 	///     }
 	///
-	///     fn on_response(&self, result: &str, started_at: Self::Instant) {
-	///          println!("[MyLogger::on_response] result: {}, time elapsed {:?}", result, started_at.elapsed());
+	///     fn on_response(&self, result: &str, started_at: Self::Instant, transport: TransportProtocol) {
+	///          println!("[MyLogger::on_response] result: {}, time elapsed {:?}, transport: {}", result, started_at.elapsed(), transport);
 	///     }
 	///
-	///     fn on_disconnect(&self, remote_addr: SocketAddr) {
-	///          println!("[MyLogger::on_disconnect] remote_addr: {:?}", remote_addr);
+	///     fn on_disconnect(&self, remote_addr: SocketAddr, transport: TransportProtocol) {
+	///          println!("[MyLogger::on_disconnect] remote_addr: {:?}, transport: {}", remote_addr, transport);
 	///     }
 	/// }
 	///


### PR DESCRIPTION
Close https://github.com/paritytech/jsonrpsee/issues/882

In addition I added that `http` also calls `Logger::on_connect` and `Logger::on_disconnect`, these could also be fetched via middleware but someone wants to have a metrics for that let's provide it for a consistent API.

companion: https://github.com/paritytech/substrate/compare/na-jsonrpsee-v0.16-comp?expand=1