### PR TITLE
gitlab benches: show results on github pages

### DIFF
--- a/.github/workflows/benchmarks_gitlab.yml
+++ b/.github/workflows/benchmarks_gitlab.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set bench file
         id: step_one
         run: |
-          echo "bench_file=$(date "+%d-%m-%Y")/output.txt" >> $GITHUB_ENV
+          echo "bench_file=bench/$(date "+%d-%m-%Y")/output.txt" >> $GITHUB_ENV
 
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1

--- a/.github/workflows/benchmarks_gitlab.yml
+++ b/.github/workflows/benchmarks_gitlab.yml
@@ -1,0 +1,39 @@
+name: Benchmarks gitlab
+
+on:
+  schedule:
+    - cron: "0 18 * * *"
+
+jobs:
+  bench:
+    name: Benchmarks gitlab
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Sources
+        uses: actions/checkout@v3.0.2
+
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Set bench file
+        id: step_one
+        run: |
+          echo "bench_file=$(date "+%d-%m-%Y")/output.txt" >> $GITHUB_ENV
+
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          tool: 'cargo'
+          output-file-path: "${{ env.bench_file }}"
+          benchmark-data-dir-path: "bench/dev2"
+          fail-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: true
+          alert-comment-cc-users: '@niklasad1'
+          auto-push: true
+


### PR DESCRIPTION
Currently, the benches are also executed in gitlab and the results are pushed every day to the branch `gh-pages` at `<dd-mm-yy>/output.txt` which this PR reads and construct displayable results using the `rhysd/github-action-benchmark@v1` GHA.

Similar to what already has but will display the results on https://paritytech.github.io/jsonrpsee/bench/dev2/ if this works  