### PR TITLE
fix: proper error on invalid batches

### DIFF
--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -245,15 +245,13 @@ async fn invalid_batched_method_calls() {
 	let req = r#"[123]"#;
 	let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	// Note: according to the spec the `id` should be `null` here, not 123.
-	assert_eq!(response.body, invalid_request(Id::Num(123)));
+	assert_eq!(response.body, invalid_batch(vec![Id::Null]));
 
 	// batch with invalid request
 	let req = r#"[1, 2, 3]"#;
 	let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	// Note: according to the spec this should return an array of three `Invalid Request`s
-	assert_eq!(response.body, parse_error(Id::Null));
+	assert_eq!(response.body, invalid_batch(vec![Id::Null, Id::Null, Id::Null]));
 
 	// invalid JSON in batch
 	let req = r#"[

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -97,6 +97,23 @@ pub fn invalid_request(id: Id) -> String {
 	)
 }
 
+pub fn invalid_batch(ids: Vec<Id>) -> String {
+	use std::fmt::Write;
+	let mut result = String::new();
+	result.push_str("[");
+	for (i, id) in ids.iter().enumerate() {
+		write!(
+			result,
+			r#"{{"jsonrpc":"2.0","error":{{"code":-32600,"message":"Invalid request"}},"id":{}}}{}"#,
+			serde_json::to_string(&id).unwrap(),
+			if i + 1 == ids.len() { "" } else { "," }
+		)
+		.unwrap();
+	}
+	result.push_str("]");
+	result
+}
+
 pub fn invalid_params(id: Id) -> String {
 	format!(
 		r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid params"}},"id":{}}}"#,


### PR DESCRIPTION
Currently, if batch requests fails to parse inner requests, it returns a single object:

```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32700,
    "message": "Parse error"
  },
  "id": null
}
```

But according to spec (see below) it should return an array:
```
[
  {
    "jsonrpc": "2.0",
    "error": {
      "code": -32600,
      "message": "Invalid request"
    },
    "id": "kek"
  },
  {
    "jsonrpc": "2.0",
    "error": {
      "code": -32600,
      "message": "Invalid request"
    },
    "id": null
  }
]
```

From spec:

> The Server should respond with an Array containing the corresponding Response objects, after all of the batch Request objects have been processed. A Response object SHOULD exist for each Request object, except that there SHOULD NOT be any Response objects for notifications. The Server MAY process a batch rpc call as a set of concurrent tasks, processing them in any order and with any width of parallelism.
> 
> The Response objects being returned from a batch call MAY be returned in any order within the Array. The Client SHOULD match contexts between the set of Request objects and the resulting set of Response objects based on the id member within each Object.
> 
> If the batch rpc call itself fails to be recognized as an valid JSON or as an Array with at least one value, the response from the Server MUST be a single Response object.