### PR TITLE
server: Expose the subscription ID

### DIFF
--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -494,7 +494,6 @@ async fn can_register_modules() {
 	assert_eq!(mod1.method_names().count(), 2);
 }
 
-
 #[tokio::test]
 async fn unsubscribe_twice_should_indicate_error() {
 	init_logger();

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -548,7 +548,9 @@ async fn custom_subscription_id_works() {
 	let mut module = RpcModule::new(());
 	module
 		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, mut sink, _| {
-			sink.accept()?;
+			let sub_id = sink.accept()?;
+			let _expected_sub = SubscriptionId::Str("0xdeadbeef".into());
+			assert!(matches!(sub_id, _expected_sub));
 
 			tokio::spawn(async move {
 				loop {

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -416,7 +416,7 @@ async fn accepted_twice_subscription_without_server() {
 	module
 		.register_subscription("my_sub", "my_sub", "my_unsub", |_, mut sink, _| {
 			let res = sink.accept();
-			assert!(matches!(res, Ok(())));
+			assert!(matches!(res, Ok(_)));
 
 			let res = sink.accept();
 			assert!(matches!(res, Err(_)));


### PR DESCRIPTION
The subscription ID on the server side is required by the new [RPC Spec](https://paritytech.github.io/json-rpc-interface-spec/introduction.html),
specifically by the [archive](https://paritytech.github.io/json-rpc-interface-spec/api/archive.html) class of methods.

The subscription ID generated from the [chainHead_unstable_follow](https://paritytech.github.io/json-rpc-interface-spec/api/chainHead_unstable_follow.html#chainhead_unstable_follow) is passed to
the other archive methods (ie [chainHead_unstable_body](https://paritytech.github.io/json-rpc-interface-spec/api/chainHead_unstable_body.html#chainhead_unstable_body)). The server needs to
keep track of this ID for validity purposes.

This PR exposes the subscription ID via the `SubscriptionSink::accept`.
The `accept` method marks the point of sending the ID to the client.
Although the subscription ID exists on the server side prior to this call,
this information is unusable if it cannot be propagated to the client.

This adds a change to the main `SubscriptionSink` API without breaking 
the current behavior of `SubscriptionSink::pipe_from_stream`.
If the server is interested in the subscription ID, it can simply call the 
`accept` prior to `pipe_from_stream`.


This is part of the https://github.com/paritytech/substrate/issues/12071.
