### PR TITLE
use awk to parse text columns instead of cut

### DIFF
--- a/scripts/ci/push_bench_results.sh
+++ b/scripts/ci/push_bench_results.sh
@@ -17,13 +17,16 @@ INPUT="output_redacted.txt"
 
 while IFS= read -r line
 do
-  BENCH_NAME=$(echo "${line}" | cut -f 2 -d ' ')
-  BENCH_RESULT=$(echo "${line}" | cut -f 5 -d ' ')
+  BENCH_NAME=$(awk '{ print $2 }' <<< "${line}")
+  BENCH_RESULT=$(awk '{ print $5 }' <<< "${line}")
+   
   # send metric with common results
+  echo 'parity_benchmark_common_result_ns{project="'${CI_PROJECT_NAME}'",benchmark="'${BENCH_NAME}'"} '${BENCH_RESULT}''
   echo 'parity_benchmark_common_result_ns{project="'${CI_PROJECT_NAME}'",benchmark="'${BENCH_NAME}'"} '${BENCH_RESULT}'' \
     | curl --data-binary @- "https://pushgateway.parity-build.parity.io/metrics/job/${BENCH_NAME}"
 
   # send metric with detailed results
+  echo 'parity_benchmark_specific_result_ns{project="'${CI_PROJECT_NAME}'",benchmark="'${BENCH_NAME}'",commit="'${CI_COMMIT_SHORT_SHA}'",cirunner="'${RUNNER_NAME}'"} '${BENCH_RESULT}''
   echo 'parity_benchmark_specific_result_ns{project="'${CI_PROJECT_NAME}'",benchmark="'${BENCH_NAME}'",commit="'${CI_COMMIT_SHORT_SHA}'",cirunner="'${RUNNER_NAME}'"} '${BENCH_RESULT}'' \
     | curl --data-binary @- "https://pushgateway.parity-build.parity.io/metrics/job/${BENCH_NAME}"
 


### PR DESCRIPTION
current implementation of the script to extract the 5th column using cut does not work properly;  see the job for more details
replaced this with more stale awk cmd


https://gitlab.parity.io/parity/mirrors/jsonrpsee/-/jobs/1959392


added also echo-ing of metrics 

```
/push_bench_results.sh out.txt 
parity_benchmark_common_result_ns{project="",benchmark="jsonrpsee_types_array_params_baseline"} 288
parity_benchmark_specific_result_ns{project="",benchmark="jsonrpsee_types_array_params_baseline",commit="",cirunner=""} 288
parity_benchmark_common_result_ns{project="",benchmark="jsonrpsee_types_array_params"} 421
parity_benchmark_specific_result_ns{project="",benchmark="jsonrpsee_types_array_params",commit="",cirunner=""} 421
parity_benchmark_common_result_ns{project="",benchmark="jsonrpsee_types_object_params_baseline"} 291
parity_benchmark_common_result_ns{project="",benchmark="sync/http_custom_headers_round_trip/100kb"} 386885
parity_benchmark_specific_result_ns{project="",benchmark="sync/http_custom_headers_round_trip/100kb",commit="",cirunner=""} 386885
parity_benchmark_common_result_ns{project="",benchmark="sync/http_concurrent_conn_calls/fast_call/2"} 485905
odd number of components in label string "/http_concurrent_conn_calls/fast_call/2"
parity_benchmark_specific_result_ns{project="",benchmark="sync/http_concurrent_conn_calls/fast_call/2",commit="",cirunner=""} 485905
odd number of components in label string "/http_concurrent_conn_calls/fast_call/2"
parity_benchmark_common_result_ns{project="",benchmark="sync/http_concurrent_conn_calls
```

I think this increase the visibility of which metrics and labels are being pushed.