### PR TITLE
[server] proper handling of batch errors and mixed calls

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -531,6 +531,13 @@ impl MethodResult {
 			Self::SendAndLogger(r) => r,
 		}
 	}
+
+	pub(crate) fn into_inner(self) -> MethodResponse {
+		match self {
+			Self::JustLogger(r) => r,
+			Self::SendAndLogger(r) => r,
+		}
+	}
 }
 
 /// Data required by the server to handle requests.

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -229,7 +229,7 @@ async fn batched_notifications() {
 }
 
 #[tokio::test]
-async fn invalid_batched_method_calls() {
+async fn invalid_batch_calls() {
 	init_logger();
 
 	let (addr, _handle) = server().with_default_timeout().await.unwrap();
@@ -261,6 +261,25 @@ async fn invalid_batched_method_calls() {
 	let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, parse_error(Id::Null));
+}
+
+#[tokio::test]
+async fn batch_with_mixed_calls() {
+	init_logger();
+
+	let (addr, _handle) = server().with_default_timeout().await.unwrap();
+	let uri = to_http_uri(addr);
+	// mixed notifications, method calls and valid json should be valid.
+	let req = r#"[
+			{"jsonrpc": "2.0", "method": "add", "params": [1,2,4], "id": "1"},
+			{"jsonrpc": "2.0", "method": "add", "params": [7]},
+			{"foo": "boo"},
+			{"jsonrpc": "2.0", "method": "foo.get", "params": {"name": "myself"}, "id": "5"}
+		]"#;
+	let res = r#"[{"jsonrpc":"2.0","result":7,"id":"1"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request"},"id":null},{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":"5"}]"#;
+	let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, res);
 }
 
 #[tokio::test]

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -245,15 +245,13 @@ async fn invalid_batched_method_calls() {
 	let req = r#"[123]"#;
 	let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	// Note: according to the spec the `id` should be `null` here, not 123.
-	assert_eq!(response.body, invalid_request(Id::Num(123)));
+	assert_eq!(response.body, invalid_batch(vec![Id::Null]));
 
 	// batch with invalid request
 	let req = r#"[1, 2, 3]"#;
 	let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	// Note: according to the spec this should return an array of three `Invalid Request`s
-	assert_eq!(response.body, parse_error(Id::Null));
+	assert_eq!(response.body, invalid_batch(vec![Id::Null, Id::Null, Id::Null]));
 
 	// invalid JSON in batch
 	let req = r#"[

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -598,3 +598,52 @@ async fn disabled_batches() {
 	server_handle.stop().unwrap();
 	server_handle.stopped().await;
 }
+
+#[tokio::test]
+async fn invalid_batch_calls() {
+	init_logger();
+
+	let addr = server().await;
+	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
+
+	// batch with no requests
+	let req = r#"[]"#;
+	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response, invalid_request(Id::Null));
+
+	// batch with invalid request
+	let req = r#"[123]"#;
+	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response, invalid_batch(vec![Id::Null]));
+
+	// batch with invalid request
+	let req = r#"[1, 2, 3]"#;
+	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response, invalid_batch(vec![Id::Null, Id::Null, Id::Null]));
+
+	// invalid JSON in batch
+	let req = r#"[
+		{"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
+		{"jsonrpc": "2.0", "method"
+	  ]"#;
+	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response, parse_error(Id::Null));
+}
+
+#[tokio::test]
+async fn batch_with_mixed_calls() {
+	init_logger();
+
+	let addr = server().with_default_timeout().await.unwrap();
+	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
+	// mixed notifications, method calls and valid json should be valid.
+	let req = r#"[
+			{"jsonrpc": "2.0", "method": "add", "params": [1,2,4], "id": "1"},
+			{"jsonrpc": "2.0", "method": "add", "params": [7]},
+			{"foo": "boo"},
+			{"jsonrpc": "2.0", "method": "foo.get", "params": {"name": "myself"}, "id": "5"}
+		]"#;
+	let res = r#"[{"jsonrpc":"2.0","result":7,"id":"1"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request"},"id":null},{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":"5"}]"#;
+	let response = client.send_request_text(req.to_string()).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response, res);
+}

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -112,30 +112,30 @@ pub(crate) async fn process_batch_request<L: Logger>(b: Batch<'_, L>) -> Option<
 
 	if let Ok(batch) = serde_json::from_slice::<Vec<&JsonRawValue>>(&data) {
 		let mut got_notif = false;
-		let mut pending_calls = FuturesOrdered::new();
 		let mut batch_response = BatchResponseBuilder::new_with_limit(call.max_response_body_size as usize);
 
-		for val in batch {
-			if let Ok(req) = serde_json::from_str::<Request>(val.get()) {
-				let call = call.clone();
-				let fut = async move { execute_call(req, call.clone()).await.into_inner() };
+		let mut pending_calls: FuturesOrdered<_> = batch
+			.into_iter()
+			.filter_map(|v| {
+				if let Ok(req) = serde_json::from_str::<Request>(v.get()) {
+					Some(Either::Right(async { execute_call(req, call.clone()).await.into_inner() }))
+				} else if let Ok(_notif) = serde_json::from_str::<Notification<&JsonRawValue>>(v.get()) {
+					// notifications should not be answered.
+					got_notif = true;
+					None
+				} else {
+					// valid JSON but could be not parsable as `InvalidRequest`
+					let id = match serde_json::from_str::<InvalidRequest>(v.get()) {
+						Ok(err) => err.id,
+						Err(_) => Id::Null,
+					};
 
-				pending_calls.push_back(fut.boxed());
-			} else if let Ok(_notif) = serde_json::from_str::<Notification<&JsonRawValue>>(val.get()) {
-				// notifications should not be answered.
-				got_notif = true;
-			} else {
-				// valid JSON but could be not parsable as `InvalidRequest`
-				let id = match serde_json::from_str::<InvalidRequest>(val.get()) {
-					Ok(err) => err.id,
-					Err(_) => Id::Null,
-				};
-
-				pending_calls.push_back(
-					async { MethodResponse::error(id, ErrorObject::from(ErrorCode::InvalidRequest)) }.boxed(),
-				);
-			}
-		}
+					Some(Either::Left(async {
+						MethodResponse::error(id, ErrorObject::from(ErrorCode::InvalidRequest))
+					}))
+				}
+			})
+			.collect();
 
 		while let Some(response) = pending_calls.next().await {
 			if let Err(too_large) = batch_response.append(&response) {

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -9,7 +9,7 @@ use crate::server::{MethodResult, ServiceData};
 use futures_channel::mpsc;
 use futures_util::future::{self, Either};
 use futures_util::io::{BufReader, BufWriter};
-use futures_util::{Future, FutureExt, StreamExt, TryStreamExt};
+use futures_util::{Future, FutureExt, StreamExt};
 use hyper::upgrade::Upgraded;
 use jsonrpsee_core::server::helpers::{
 	prepare_error, BatchResponse, BatchResponseBuilder, BoundedSubscriptions, MethodResponse, MethodSink,
@@ -18,12 +18,12 @@ use jsonrpsee_core::server::resource_limiting::Resources;
 use jsonrpsee_core::server::rpc_module::{ConnState, MethodKind, Methods};
 use jsonrpsee_core::tracing::{rx_log_from_json, tx_log_from_str};
 use jsonrpsee_core::traits::IdProvider;
-use jsonrpsee_core::Error;
+use jsonrpsee_core::{Error, JsonRawValue};
 use jsonrpsee_types::error::{
 	reject_too_big_request, reject_too_many_subscriptions, ErrorCode, BATCHES_NOT_SUPPORTED_CODE,
 	BATCHES_NOT_SUPPORTED_MSG,
 };
-use jsonrpsee_types::{ErrorObject, Id, Params, Request};
+use jsonrpsee_types::{ErrorObject, Id, InvalidRequest, Notification, Params, Request};
 use soketto::connection::Error as SokettoError;
 use soketto::data::ByteSlice125;
 use tokio_stream::wrappers::IntervalStream;
@@ -106,37 +106,44 @@ where
 // request in the batch and read the results off of a new channel, `rx_batch`, and then send the
 // complete batch response back to the client over `tx`.
 #[instrument(name = "batch", skip(b), level = "TRACE")]
-pub(crate) async fn process_batch_request<L: Logger>(b: Batch<'_, L>) -> BatchResponse {
+pub(crate) async fn process_batch_request<L: Logger>(b: Batch<'_, L>) -> Option<BatchResponse> {
 	let Batch { data, call } = b;
 
-	if let Ok(batch) = serde_json::from_slice::<Vec<Request>>(&data) {
-		return if !batch.is_empty() {
-			let batch = batch.into_iter().map(|req| Ok((req, call.clone())));
-			let batch_stream = futures_util::stream::iter(batch);
+	if let Ok(batch) = serde_json::from_slice::<Vec<&JsonRawValue>>(&data) {
+		let mut batch_response = BatchResponseBuilder::new_with_limit(call.max_response_body_size as usize);
+		let mut got_notif = false;
 
-			let max_response_size = call.max_response_body_size;
-
-			let batch_response = batch_stream
-				.try_fold(
-					BatchResponseBuilder::new_with_limit(max_response_size as usize),
-					|batch_response, (req, call)| async move {
-						let response = execute_call(req, call).await;
-						batch_response.append(response.as_inner())
-					},
-				)
-				.await;
-
-			match batch_response {
-				Ok(batch) => batch.finish(),
-				Err(batch_err) => batch_err,
+		for val in batch {
+			if let Ok(req) = serde_json::from_str::<Request>(val.get()) {
+				let response = execute_call(req, call.clone()).await;
+				if let Err(batch_err) = batch_response.append(response.as_inner()) {
+					return Some(batch_err);
+				}
+			} else if let Ok(_notif) = serde_json::from_str::<Notification<&JsonRawValue>>(val.get()) {
+				// notifications should not be answered.
+				got_notif = true;
+			} else {
+				// valid JSON but could be not parsable as `InvalidRequest`
+				let id = match serde_json::from_str::<InvalidRequest>(val.get()) {
+					Ok(err) => err.id,
+					Err(_) => Id::Null,
+				};
+				if let Err(batch_err) =
+					batch_response.append(&MethodResponse::error(id, ErrorObject::from(ErrorCode::InvalidRequest)))
+				{
+					return Some(batch_err);
+				}
 			}
-		} else {
-			BatchResponse::error(Id::Null, ErrorObject::from(ErrorCode::InvalidRequest))
-		};
-	}
+		}
 
-	let (id, code) = prepare_error(&data);
-	BatchResponse::error(id, ErrorObject::from(code))
+		if got_notif && batch_response.is_empty() {
+			None
+		} else {
+			Some(batch_response.finish())
+		}
+	} else {
+		Some(BatchResponse::error(Id::Null, ErrorObject::from(ErrorCode::ParseError)))
+	}
 }
 
 pub(crate) async fn process_single_request<L: Logger>(data: Vec<u8>, call: CallData<'_, L>) -> MethodResult {
@@ -416,9 +423,11 @@ pub(crate) async fn background_task<L: Logger>(
 					})
 					.await;
 
-					tx_log_from_str(&response.result, max_log_length);
-					logger.on_response(&response.result, request_start, TransportProtocol::WebSocket);
-					let _ = sink.send_raw(response.result);
+					if let Some(response) = response {
+						tx_log_from_str(&response.result, max_log_length);
+						logger.on_response(&response.result, request_start, TransportProtocol::WebSocket);
+						let _ = sink.send_raw(response.result);
+					}
 				};
 
 				method_executors.add(Box::pin(fut));

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -100,7 +100,7 @@ pub fn invalid_request(id: Id) -> String {
 pub fn invalid_batch(ids: Vec<Id>) -> String {
 	use std::fmt::Write;
 	let mut result = String::new();
-	result.push_str("[");
+	result.push('[');
 	for (i, id) in ids.iter().enumerate() {
 		write!(
 			result,
@@ -110,7 +110,7 @@ pub fn invalid_batch(ids: Vec<Id>) -> String {
 		)
 		.unwrap();
 	}
-	result.push_str("]");
+	result.push(']');
 	result
 }
 

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -97,6 +97,23 @@ pub fn invalid_request(id: Id) -> String {
 	)
 }
 
+pub fn invalid_batch(ids: Vec<Id>) -> String {
+	use std::fmt::Write;
+	let mut result = String::new();
+	result.push_str("[");
+	for (i, id) in ids.iter().enumerate() {
+		write!(
+			result,
+			r#"{{"jsonrpc":"2.0","error":{{"code":-32600,"message":"Invalid request"}},"id":{}}}{}"#,
+			serde_json::to_string(&id).unwrap(),
+			if i + 1 == ids.len() { "" } else { "," }
+		)
+		.unwrap();
+	}
+	result.push_str("]");
+	result
+}
+
 pub fn invalid_params(id: Id) -> String {
 	format!(
 		r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid params"}},"id":{}}}"#,


### PR DESCRIPTION
Builds on top of https://github.com/paritytech/jsonrpsee/pull/896, kudos to @polachok for starting this.
As he hasn't responded on my feedback then I fixed it myself.

So before we just checked if the batches was `Vec<Request>` or `Vec<Notification` which doesn't work for errors and batches with mixed calls and notifications which this fixes.

In addition I removed the empty message that are we sent on batches with only notifications on `WS` for HTTP we are still doing it to ACK to HTTP request itself.