### PR TITLE
client: parse batch requests with failed calls

### DIFF
--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -249,6 +249,24 @@ async fn batch_request_out_of_order_response() {
 }
 
 #[tokio::test]
+async fn batch_request_with_failed_call_gives_proper_error() {
+	let mut batch_request = BatchRequestBuilder::new();
+	batch_request.insert("say_hello", rpc_params![]).unwrap();
+	batch_request.insert("say_goodbye", rpc_params![0_u64, 1, 2]).unwrap();
+	batch_request.insert("get_swag", rpc_params![]).unwrap();
+	let server_response = r#"[{"jsonrpc":"2.0","result":"hello","id":0}, {"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}, {"jsonrpc":"2.0","error":{"code":-32602,"message":"foo"},"id":2}]"#.to_string();
+	let err = run_batch_request_with_response(batch_request, server_response)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
+	let exp = ErrorObject::from(ErrorCode::MethodNotFound);
+	assert!(matches!(err,
+		Error::Call(CallError::Custom(err)) if err == exp
+	));
+}
+
+#[tokio::test]
 async fn is_connected_works() {
 	tracing_subscriber::FmtSubscriber::builder()
 		.with_env_filter(tracing_subscriber::EnvFilter::from_default_env())

--- a/core/src/client/async_client/manager.rs
+++ b/core/src/client/async_client/manager.rs
@@ -36,7 +36,7 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use crate::Error;
 use futures_channel::{mpsc, oneshot};
-use jsonrpsee_types::{Id, SubscriptionId};
+use jsonrpsee_types::{ErrorObject, Id, SubscriptionId};
 use rustc_hash::FxHashMap;
 use serde_json::value::Value as JsonValue;
 
@@ -61,7 +61,7 @@ pub(crate) enum RequestStatus {
 }
 
 type PendingCallOneshot = Option<oneshot::Sender<Result<JsonValue, Error>>>;
-type PendingBatchOneshot = oneshot::Sender<Result<Vec<JsonValue>, Error>>;
+type PendingBatchOneshot = oneshot::Sender<Result<Vec<Result<JsonValue, ErrorObject<'static>>>, Error>>;
 type PendingSubscriptionOneshot = oneshot::Sender<Result<(mpsc::Receiver<JsonValue>, SubscriptionId<'static>), Error>>;
 type SubscriptionSink = mpsc::Sender<JsonValue>;
 type UnsubscribeMethod = String;

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -32,17 +32,17 @@ use std::sync::Arc;
 use std::task;
 
 use crate::error::Error;
+use crate::params::BatchRequestBuilder;
+use crate::traits::ToRpcParams;
 use async_trait::async_trait;
 use core::marker::PhantomData;
 use futures_channel::{mpsc, oneshot};
 use futures_util::future::FutureExt;
 use futures_util::sink::SinkExt;
 use futures_util::stream::{Stream, StreamExt};
-use jsonrpsee_types::{Id, SubscriptionId};
+use jsonrpsee_types::{ErrorObject, Id, SubscriptionId};
 use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
-use crate::params::BatchRequestBuilder;
-use crate::traits::ToRpcParams;
 
 // Re-exports for the `rpc_params` macro.
 #[doc(hidden)]
@@ -269,7 +269,7 @@ pub struct BatchMessage {
 	/// Request IDs.
 	pub ids: Vec<Id<'static>>,
 	/// One-shot channel over which we send back the result of this request.
-	pub send_back: oneshot::Sender<Result<Vec<JsonValue>, Error>>,
+	pub send_back: oneshot::Sender<Result<Vec<Result<JsonValue, ErrorObject<'static>>>, Error>>,
 }
 
 /// Request message.


### PR DESCRIPTION
This fixes that the first failed call in batch returns an error instead of returning `unparsable response`

I decided to split it because the refactoring the batch request API otherwise becomes quite large to review.