### PR TITLE
fix(server): log accepted conns properly

### DIFF
--- a/server/src/future.rs
+++ b/server/src/future.rs
@@ -196,6 +196,7 @@ impl ServerHandle {
 }
 
 /// Limits the number of connections.
+#[derive(Debug, Clone)]
 pub(crate) struct ConnectionGuard(Arc<Semaphore>);
 
 impl ConnectionGuard {


### PR DESCRIPTION
This PR fixes that the connection count is read after a connection has been accepted and not before which may cause this log to wrong/out of order when actual connection is accepted.