### PR TITLE
proc-macros/tests: Update test to latest rustc v1.67

### DIFF
--- a/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
@@ -1,15 +1,15 @@
 error[E0277]: the trait bound `<Conf as Config>::Hash: Serialize` is not satisfied
-  --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:10:1
-   |
-10 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `<Conf as Config>::Hash`
-   |
+   --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:10:1
+    |
+10  | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `<Conf as Config>::Hash`
+    |
 note: required by a bound in `RpcModule::<Context>::register_method`
-  --> $WORKSPACE/core/src/server/rpc_module.rs
-   |
-   |         R: Serialize,
-   |            ^^^^^^^^^ required by this bound in `RpcModule::<Context>::register_method`
-   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/core/src/server/rpc_module.rs
+    |
+    |         R: Serialize,
+    |            ^^^^^^^^^ required by this bound in `RpcModule::<Context>::register_method`
+    = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `for<'de> <Conf as Config>::Hash: Deserialize<'de>` is not satisfied
   --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:10:1


### PR DESCRIPTION
This PR fixes the CI check that fails for the UI testing. The failure is related
to a change in the rustc version that reports a different error than the
expected one.

This is similar to the substrate fix: https://github.com/paritytech/substrate/pull/12642.