### PR TITLE
TowerService should be clone-able for handling concurrent request

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -585,7 +585,7 @@ pub(crate) struct ServiceData<L: Logger> {
 ///
 /// # Note
 /// This is similar to [`hyper::service::service_fn`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TowerService<L: Logger> {
 	inner: ServiceData<L>,
 }


### PR DESCRIPTION
## Summary 
`TowerService` should be cloneable like tower's `ServiceFn`

It is difficult to use the service in async block. e.g. when implementing middleware layer service, `self.inner.call(req)` cannot be called inside the async block, making it impossible to examine the request body before calling the inner service.