### PR TITLE
Add HTTP(S) proxy support

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 rustc-hash = "1"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.23", optional = true }
-hyper-proxy = { version = "0", default-features = false, features = ["rustls"] }
+hyper-proxy = { version = "0.9", default-features = false }
 jsonrpsee-types = { path = "../../types", version = "0.16.2" }
 jsonrpsee-core = { path = "../../core", version = "0.16.2", features = ["client", "http-helpers"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -22,6 +22,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["time"] }
 tracing = "0.1.34"
+anyhow = "1.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
@@ -30,7 +31,7 @@ tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["tls"]
-tls = ["hyper-rustls/webpki-tokio"]
+tls = ["hyper-rustls/webpki-tokio", "hyper-proxy/rustls"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["time"] }
 tracing = "0.1.34"
-anyhow = "1.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1"
 rustc-hash = "1"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.23", optional = true }
+hyper-proxy = { version = "0", default-features = false, features = ["rustls"] }
 jsonrpsee-types = { path = "../../types", version = "0.16.2" }
 jsonrpsee-core = { path = "../../core", version = "0.16.2", features = ["client", "http-helpers"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 rustc-hash = "1"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.23", optional = true }
-hyper-proxy = { version = "0.9", default-features = false }
+hyper-proxy = { version = "0.9", default-features = false, optional = true }
 jsonrpsee-types = { path = "../../types", version = "0.16.2" }
 jsonrpsee-core = { path = "../../core", version = "0.16.2", features = ["client", "http-helpers"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -29,8 +29,9 @@ jsonrpsee-test-utils = { path = "../../test-utils" }
 tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros"] }
 
 [features]
-default = ["tls"]
-tls = ["hyper-rustls/webpki-tokio", "hyper-proxy/rustls"]
+default = ["tls", "proxy"]
+tls = ["hyper-rustls/webpki-tokio"]
+proxy = ["hyper-proxy/rustls", "tls"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -142,7 +142,7 @@ impl HttpClientBuilder {
 	pub fn set_proxy(mut self, proxy: String) -> Result<Self, Error> {
 		let result = proxy
 			.parse()
-			.map_err(|_| Error::Transport(anyhow::Error::msg(format!("Invalid proxy URL: {}", proxy.to_string()))));
+			.map_err(|_| Error::Transport(anyhow::Error::msg(format!("Invalid proxy URL: {}", proxy))));
 		match result {
 			Ok(uri) => {
 				self.proxy = Some(uri);

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -149,7 +149,7 @@ impl HttpClientBuilder {
 	/// Set the HTTP(S) proxy that will proxy every HTTP request (default is none).
 	///
 	/// The proxy should be of the form <http://host_or_ip:port> (without the brackets).
-	#[cfg(feature = "proxy")]
+	#[cfg(all(feature = "proxy", feature = "tls"))]
 	pub fn set_proxy(mut self, proxy: impl AsRef<str>) -> Result<Self, Error> {
 		let result =
 			proxy.as_ref().parse().map_err(|_| Error::Transport(InvalidProxyUrl(proxy.as_ref().to_owned()).into()))?;

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -149,6 +149,7 @@ impl HttpClientBuilder {
 	/// Set the HTTP(S) proxy that will proxy every HTTP request (default is none).
 	///
 	/// The proxy should be of the form <http://host_or_ip:port> (without the brackets).
+	#[cfg(feature = "proxy")]
 	pub fn set_proxy(mut self, proxy: impl AsRef<str>) -> Result<Self, Error> {
 		let result =
 			proxy.as_ref().parse().map_err(|_| Error::Transport(InvalidProxyUrl(proxy.as_ref().to_owned()).into()))?;

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -32,8 +32,8 @@ use std::time::Duration;
 use crate::transport::HttpTransportClient;
 use crate::types::{ErrorResponse, NotificationSer, RequestSer, Response};
 use async_trait::async_trait;
-use hyper::Uri;
 use hyper::http::HeaderMap;
+use hyper::Uri;
 use jsonrpsee_core::client::{
 	generate_batch_id_range, BatchResponse, CertificateStore, ClientT, IdKind, RequestIdManager, Subscription,
 	SubscriptionClientT,
@@ -137,16 +137,18 @@ impl HttpClientBuilder {
 	}
 
 	/// Set the HTTP(S) proxy that will proxy every HTTP request (default is none).
-	/// 
+	///
 	/// The proxy should be of the form <http://host_or_ip:port> (without the brackets).
 	pub fn set_proxy(mut self, proxy: String) -> Result<Self, Error> {
-		let result = proxy.parse().map_err(|_| Error::Transport(anyhow::Error::msg(format!("Invalid proxy URL: {}", proxy.to_string()))));
+		let result = proxy
+			.parse()
+			.map_err(|_| Error::Transport(anyhow::Error::msg(format!("Invalid proxy URL: {}", proxy.to_string()))));
 		match result {
 			Ok(uri) => {
 				self.proxy = Some(uri);
 				Ok(self)
-			},
-			Err(e) => Err(e)
+			}
+			Err(e) => Err(e),
 		}
 	}
 
@@ -171,7 +173,7 @@ impl HttpClientBuilder {
 			certificate_store,
 			max_log_length,
 			headers,
-			proxy
+			proxy,
 		)
 		.map_err(|e| Error::Transport(e.into()))?;
 		Ok(HttpClient {
@@ -193,7 +195,7 @@ impl Default for HttpClientBuilder {
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
 			headers: HeaderMap::new(),
-			proxy: None
+			proxy: None,
 		}
 	}
 }

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -79,6 +79,7 @@ pub struct HttpClientBuilder {
 	id_kind: IdKind,
 	max_log_length: u32,
 	headers: HeaderMap,
+	proxy: Option<String>,
 }
 
 impl HttpClientBuilder {
@@ -134,6 +135,14 @@ impl HttpClientBuilder {
 		self
 	}
 
+	/// Set the HTTP(S) proxy that will proxy every HTTP request (default is none).
+	/// 
+	/// The proxy should be of the form <http[s]://host_or_ip:port> (without the brackets).
+	pub fn set_proxy(mut self, proxy: String) -> Self {
+		self.proxy = Some(proxy);
+		self
+	}
+
 	/// Build the HTTP client with target to connect to.
 	pub fn build(self, target: impl AsRef<str>) -> Result<HttpClient, Error> {
 		let Self {
@@ -145,6 +154,7 @@ impl HttpClientBuilder {
 			id_kind,
 			headers,
 			max_log_length,
+			proxy,
 		} = self;
 
 		let transport = HttpTransportClient::new(
@@ -154,6 +164,7 @@ impl HttpClientBuilder {
 			certificate_store,
 			max_log_length,
 			headers,
+			proxy
 		)
 		.map_err(|e| Error::Transport(e.into()))?;
 		Ok(HttpClient {
@@ -175,6 +186,7 @@ impl Default for HttpClientBuilder {
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
 			headers: HeaderMap::new(),
+			proxy: None
 		}
 	}
 }

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -140,9 +140,8 @@ impl HttpClientBuilder {
 	///
 	/// The proxy should be of the form <http://host_or_ip:port> (without the brackets).
 	pub fn set_proxy(mut self, proxy: String) -> Result<Self, Error> {
-		let result = proxy
-			.parse()
-			.map_err(|_| Error::Transport(anyhow::Error::msg(format!("Invalid proxy URL: {}", proxy))));
+		let result =
+			proxy.parse().map_err(|_| Error::Transport(anyhow::Error::msg(format!("Invalid proxy URL: {}", proxy))));
 		match result {
 			Ok(uri) => {
 				self.proxy = Some(uri);

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -96,7 +96,7 @@ impl HttpTransportClient {
 					Some(pr) => {
 						let proxy_obj = Proxy::new(Intercept::All, pr.clone());
 						let proxy_connector = ProxyConnector::from_proxy(connector, proxy_obj)
-							.map_err(|_| Error::Url(format!("Invalid URL: {}", pr.to_string())))?;
+							.map_err(|_| Error::Url(format!("Invalid URL: {}", pr)))?;
 						HyperClient::Proxy(Client::builder().build::<_, hyper::Body>(proxy_connector))
 					}
 					None => HyperClient::Https(Client::builder().build::<_, hyper::Body>(connector)),
@@ -232,7 +232,7 @@ mod tests {
 	#[test]
 	fn invalid_http_url_rejected() {
 		let err =
-			HttpTransportClient::new(80, "ws://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new())
+			HttpTransportClient::new(80, "ws://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
 				.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
@@ -241,7 +241,7 @@ mod tests {
 	#[test]
 	fn https_works() {
 		let client =
-			HttpTransportClient::new(80, "https://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new())
+			HttpTransportClient::new(80, "https://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
 				.unwrap();
 		assert_target(&client, "localhost", "https", "/", 9933, 80);
 	}
@@ -258,11 +258,11 @@ mod tests {
 	#[test]
 	fn faulty_port() {
 		let err =
-			HttpTransportClient::new(80, "http://localhost:-43", 80, CertificateStore::Native, 80, HeaderMap::new())
+			HttpTransportClient::new(80, "http://localhost:-43", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
 				.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 		let err =
-			HttpTransportClient::new(80, "http://localhost:-99999", 80, CertificateStore::Native, 80, HeaderMap::new())
+			HttpTransportClient::new(80, "http://localhost:-99999", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
 				.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
@@ -276,6 +276,7 @@ mod tests {
 			CertificateStore::Native,
 			80,
 			HeaderMap::new(),
+			None,
 		)
 		.unwrap();
 		assert_target(&client, "localhost", "http", "/my-special-path", 9944, 1337);
@@ -290,6 +291,7 @@ mod tests {
 			CertificateStore::WebPki,
 			80,
 			HeaderMap::new(),
+			None,
 		)
 		.unwrap();
 		assert_target(&client, "127.0.0.1", "http", "/my?name1=value1&name2=value2", 9999, u32::MAX);
@@ -304,6 +306,7 @@ mod tests {
 			CertificateStore::Native,
 			80,
 			HeaderMap::new(),
+			None,
 		)
 		.unwrap();
 		assert_target(&client, "127.0.0.1", "http", "/my.htm", 9944, 999);
@@ -321,6 +324,7 @@ mod tests {
 			CertificateStore::WebPki,
 			99,
 			HeaderMap::new(),
+			None,
 		)
 		.unwrap();
 		assert_eq!(client.max_request_size, eighty_bytes_limit);

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -37,7 +37,7 @@ impl HyperClient {
 			Self::Http(client) => client.request(req),
 			#[cfg(feature = "tls")]
 			Self::Https(client) => client.request(req),
-			#[cfg(feature = "proxy")]
+			#[cfg(all(feature = "proxy", feature = "tls"))]
 			Self::Proxy(client) => client.request(req),
 		}
 	}

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -231,18 +231,32 @@ mod tests {
 
 	#[test]
 	fn invalid_http_url_rejected() {
-		let err =
-			HttpTransportClient::new(80, "ws://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
-				.unwrap_err();
+		let err = HttpTransportClient::new(
+			80,
+			"ws://localhost:9933",
+			80,
+			CertificateStore::Native,
+			80,
+			HeaderMap::new(),
+			None,
+		)
+		.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 
 	#[cfg(feature = "tls")]
 	#[test]
 	fn https_works() {
-		let client =
-			HttpTransportClient::new(80, "https://localhost:9933", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
-				.unwrap();
+		let client = HttpTransportClient::new(
+			80,
+			"https://localhost:9933",
+			80,
+			CertificateStore::Native,
+			80,
+			HeaderMap::new(),
+			None,
+		)
+		.unwrap();
 		assert_target(&client, "localhost", "https", "/", 9933, 80);
 	}
 
@@ -257,13 +271,27 @@ mod tests {
 
 	#[test]
 	fn faulty_port() {
-		let err =
-			HttpTransportClient::new(80, "http://localhost:-43", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
-				.unwrap_err();
+		let err = HttpTransportClient::new(
+			80,
+			"http://localhost:-43",
+			80,
+			CertificateStore::Native,
+			80,
+			HeaderMap::new(),
+			None,
+		)
+		.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
-		let err =
-			HttpTransportClient::new(80, "http://localhost:-99999", 80, CertificateStore::Native, 80, HeaderMap::new(), None)
-				.unwrap_err();
+		let err = HttpTransportClient::new(
+			80,
+			"http://localhost:-99999",
+			80,
+			CertificateStore::Native,
+			80,
+			HeaderMap::new(),
+			None,
+		)
+		.unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 	}
 


### PR DESCRIPTION
This seems to work with both HTTP and HTTPS sites when using the jsonrpsee_http_client crate, allowing you to put a proxy in between your client and the endpoint. Very useful for debugging. Works with Proxyman, the proxy I'm using.