### PR TITLE
chore: update gloo-net ^0.2.6

### DIFF
--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -32,7 +32,7 @@ futures-timer = { version = "3", optional = true }
 soketto = { version = "0.7.1", optional = true }
 
 # web-sys
-gloo-net = { version = "0.2.0", default-features = false, features = ["json", "websocket"], optional = true }
+gloo-net = { version = "0.2.6", default-features = false, features = ["json", "websocket"], optional = true }
 
 [features]
 tls = ["tokio-rustls", "webpki-roots", "rustls-native-certs"]


### PR DESCRIPTION
Close #971 

It will work for users to update the crate manually as well but as there was a bug with timer in crate let's force v0.2.6 for gloo-net