### PR TITLE
fix: disable clippy for tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ clippy:
   <<:                              *docker-env
   <<:                              *common-refs
   script:
-    - cargo clippy --all-targets
+    - cargo clippy
 
 check-rustdoc-links:
   stage:                           lint

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", default-features = false, features = ["extra-traits", "full", "visit", "parsing"] }
+syn = { version = "1.0", default-features = false, features = ["extra-traits", "full", "visit", "parsing", "printing", "clone-impls", "proc-macro"] }
 proc-macro-crate = "1"
 heck = "0.4.0"
 


### PR DESCRIPTION
Because of https://github.com/rust-lang/rust-clippy/issues/9922 let's disable clippy for tests until that is fixed.