### PR TITLE
[ci] Change runners for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,11 +14,10 @@ stages:
   - check_benchmark
   - publish
 
-variables:                         &default-vars
+variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
-  CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CI_IMAGE:                        "paritytech/ci-linux:production"
 
 .common-refs:                      &common-refs
@@ -49,7 +48,7 @@ variables:                         &default-vars
     - *rust-info-script
     - sccache -s
   tags:
-    - linux-docker
+    - linux-docker-vm-c2
 
 .kubernetes-env:                   &kubernetes-env
   image:                           "${CI_IMAGE}"
@@ -60,7 +59,7 @@ variables:                         &default-vars
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     when:                          on_success
-    expire_in:                     28 days
+    expire_in:                     3 days
     paths:
       - ./artifacts/
     reports:
@@ -121,7 +120,7 @@ benchmarks:
     - echo ${CI_RUNNER_DESCRIPTION}
     - echo "RUNNER_NAME=${CI_RUNNER_DESCRIPTION}" > runner.env
   tags:
-    - ci5
+    - benchmark
 
 check_bench:
   stage:                           check_benchmark

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,13 +40,11 @@ variables:
   - rustup +nightly show
   - cargo +nightly --version
   - bash --version
-  - sccache -s
 
 .docker-env:                       &docker-env
   image:                           "${CI_IMAGE}"
   before_script:
     - *rust-info-script
-    - sccache -s
   tags:
     - linux-docker-vm-c2
 


### PR DESCRIPTION
PR changes ci runners for dynamically created ones. Also it changes runner for benchmark, so the next run will have different results and a new baseline.

cc https://github.com/paritytech/ci_cd/issues/730