### PR TITLE
client: use tokio channels

### DIFF
--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -213,8 +213,7 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 	// don't poll the notification stream for 2 seconds, should be full now.
 	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-	// Capacity is `num_sender` + `capacity`
-	for _ in 0..5 {
+	for _ in 0..4 {
 		assert!(nh.next().with_default_timeout().await.unwrap().unwrap().is_ok());
 	}
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 anyhow = "1"
 async-trait = "0.1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
-futures-channel = "0.3.14"
 jsonrpsee-types = { path = "../types", version = "0.16.2" }
 thiserror = "1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -28,9 +27,11 @@ soketto = { version = "0.7.1", optional = true }
 parking_lot = { version = "0.12", optional = true }
 tokio = { version = "1.16", optional = true }
 wasm-bindgen-futures = { version = "0.4.19", optional = true }
+futures-channel = { version = "0.3.14", optional = true }
 futures-timer = { version = "3", optional = true }
 globset = { version = "0.4", optional = true }
 http = { version = "0.2.7", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 
 [features]
 default = []
@@ -44,15 +45,16 @@ server = [
 	"rand",
 	"tokio/rt",
 	"tokio/sync",
+	"futures-channel",
 ]
-client = ["futures-util/sink", "futures-channel/sink", "futures-channel/std"]
+client = ["futures-util/sink", "tokio/sync"]
 async-client = [
 	"async-lock",
 	"client",
 	"rustc-hash",
 	"tokio/macros",
 	"tokio/rt",
-	"tokio/sync",
+	"tokio-stream",
 	"futures-timer",
 ]
 async-wasm-client = [
@@ -61,6 +63,7 @@ async-wasm-client = [
 	"wasm-bindgen-futures",
 	"rustc-hash/std",
 	"futures-timer/wasm-bindgen",
+	"tokio-stream",
 ]
 
 [dev-dependencies]

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -32,7 +32,7 @@ use crate::Error;
 
 use futures_timer::Delay;
 use futures_util::future::{self, Either};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use jsonrpsee_types::error::CallError;
 use jsonrpsee_types::response::SubscriptionError;
@@ -274,8 +274,8 @@ pub(crate) fn process_error_response(manager: &mut RequestManager, err: ErrorRes
 /// Wait for a stream to complete within the given timeout.
 pub(crate) async fn call_with_timeout<T>(
 	timeout: std::time::Duration,
-	rx: tokio::sync::oneshot::Receiver<Result<T, Error>>,
-) -> Result<Result<T, Error>, tokio::sync::oneshot::error::RecvError> {
+	rx: oneshot::Receiver<Result<T, Error>>,
+) -> Result<Result<T, Error>, oneshot::error::RecvError> {
 	match future::select(rx, Delay::new(timeout)).await {
 		Either::Left((res, _)) => res,
 		Either::Right((_, _)) => Ok(Err(Error::RequestTimeout)),

--- a/core/src/client/async_client/manager.rs
+++ b/core/src/client/async_client/manager.rs
@@ -38,10 +38,10 @@ use std::{
 };
 
 use crate::{client::BatchEntry, Error};
-use futures_channel::{mpsc, oneshot};
 use jsonrpsee_types::{Id, SubscriptionId};
 use rustc_hash::FxHashMap;
 use serde_json::value::Value as JsonValue;
+use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug)]
 enum Kind {
@@ -312,9 +312,9 @@ impl RequestManager {
 #[cfg(test)]
 mod tests {
 	use super::{Error, RequestManager};
-	use futures_channel::{mpsc, oneshot};
 	use jsonrpsee_types::{Id, SubscriptionId};
 	use serde_json::Value as JsonValue;
+	use tokio::sync::{mpsc, oneshot};
 
 	#[test]
 	fn insert_remove_pending_request_works() {

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -225,7 +225,7 @@ impl ClientBuilder {
 #[derive(Debug)]
 pub struct Client {
 	/// Channel to send requests to the background task.
-	to_back: tokio::sync::mpsc::Sender<FrontToBack>,
+	to_back: mpsc::Sender<FrontToBack>,
 	/// If the background thread terminates the error is sent to this channel.
 	// NOTE(niklasad1): This is a Mutex to circumvent that the async fns takes immutable references.
 	error: Mutex<ErrorFromBack>,

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -203,10 +203,10 @@ impl ClientBuilder {
 		let (to_back, from_front) = mpsc::channel(self.max_concurrent_requests);
 		let (err_tx, err_rx) = oneshot::channel();
 		let max_notifs_per_subscription = self.max_notifs_per_subscription;
-		let (on_close_tx, on_close_rx) = oneshot::channel();
+		let (on_exit_tx, on_exit_rx) = oneshot::channel();
 
 		wasm_bindgen_futures::spawn_local(async move {
-			background_task(sender, receiver, from_front, err_tx, max_notifs_per_subscription, None, on_close_tx).await;
+			background_task(sender, receiver, from_front, err_tx, max_notifs_per_subscription, None, on_exit_rx).await;
 		});
 		Client {
 			to_back,
@@ -214,7 +214,7 @@ impl ClientBuilder {
 			error: Mutex::new(ErrorFromBack::Unread(err_rx)),
 			id_manager: RequestIdManager::new(self.max_concurrent_requests, self.id_kind),
 			max_log_length: self.max_log_length,
-			notify: Mutex::new(Some(on_close_rx)),
+			on_exit: Some(on_exit_tx),
 		}
 	}
 }

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -788,7 +788,7 @@ async fn background_task<S, R>(
 	}
 
 	// Wake the `on_disconnect` method.
-	let _ = frontend.close();
+	frontend.close();
 	// Send close message to the server.
 	let _ = sender.close().await;
 }

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -114,8 +114,10 @@ impl ClientBuilder {
 	/// [`Subscription::next()`](../../jsonrpsee_core/client/struct.Subscription.html#method.next) such that
 	/// it can keep with the rate as server produces new items on the subscription.
 	///
-	/// **Note**: The actual capacity is `num_senders + max_subscription_capacity`
-	/// because it is passed to [`futures_channel::mpsc::channel`].
+	///
+	/// # Panics
+	///
+	/// This function panics if `max` is 0.
 	pub fn max_notifs_per_subscription(mut self, max: usize) -> Self {
 		self.max_notifs_per_subscription = max;
 		self
@@ -235,7 +237,7 @@ pub struct Client {
 	///
 	/// Entries bigger than this limit will be truncated.
 	max_log_length: u32,
-	/// When the client is dropped a message is sent to be background thread.
+	/// When the client is dropped a message is sent to the background thread.
 	on_exit: Option<tokio::sync::oneshot::Sender<()>>,
 }
 

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -790,7 +790,7 @@ async fn background_task<S, R>(
 	// Wake the `on_disconnect` method.
 	_ = frontend.close();
 	// Send close message to the server.
-	let _ = sender.close().await;
+	_ = sender.close().await;
 }
 
 fn unparse_error(raw: &[u8]) -> Error {

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -788,7 +788,7 @@ async fn background_task<S, R>(
 	}
 
 	// Wake the `on_disconnect` method.
-	let _ = frontend.close();
+	_ = frontend.close();
 	// Send close message to the server.
 	let _ = sender.close().await;
 }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -237,8 +237,8 @@ impl<Notif> std::marker::Unpin for Subscription<Notif> {}
 impl<Notif> Subscription<Notif> {
 	/// Create a new subscription.
 	pub fn new(
-		to_back: tokio::sync::mpsc::Sender<FrontToBack>,
-		notifs_rx: tokio::sync::mpsc::Receiver<JsonValue>,
+		to_back: mpsc::Sender<FrontToBack>,
+		notifs_rx: mpsc::Receiver<JsonValue>,
 		kind: SubscriptionKind,
 	) -> Self {
 		Self { to_back, notifs_rx, kind: Some(kind), marker: PhantomData }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -255,7 +255,8 @@ impl<Notif> Subscription<Notif> {
 			SubscriptionKind::Method(notif) => FrontToBack::UnregisterNotification(notif),
 			SubscriptionKind::Subscription(sub_id) => FrontToBack::SubscriptionClosed(sub_id),
 		};
-		self.to_back.send(msg).await.unwrap();
+		// If this fails the connection was already closed i.e, already "unsubscribed".
+		let _ = self.to_back.send(msg).await;
 
 		// wait until notif channel is closed then the subscription was closed.
 		while self.notifs_rx.recv().await.is_some() {}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -63,9 +63,6 @@ pub enum Error {
 	/// Networking error or error on the low-level protocol layer.
 	#[error("Networking or low-level protocol error: {0}")]
 	Transport(#[source] anyhow::Error),
-	/// Send error.
-	#[error("Send error: {0}")]
-	SendError(String),
 	/// Invalid response,
 	#[error("Invalid response: {0}")]
 	InvalidResponse(Mismatch<String>),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -63,9 +63,9 @@ pub enum Error {
 	/// Networking error or error on the low-level protocol layer.
 	#[error("Networking or low-level protocol error: {0}")]
 	Transport(#[source] anyhow::Error),
-	/// Frontend/backend channel error.
-	#[error("Frontend/backend channel error: {0}")]
-	Internal(#[from] futures_channel::mpsc::SendError),
+	/// Send error.
+	#[error("Send error: {0}")]
+	SendError(String),
 	/// Invalid response,
 	#[error("Invalid response: {0}")]
 	InvalidResponse(Mismatch<String>),

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -261,8 +261,7 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 	// don't poll the subscription stream for 2 seconds, should be full now.
 	tokio::time::sleep(Duration::from_secs(2)).await;
 
-	// Capacity is `num_sender` + `capacity`
-	for _ in 0..5 {
+	for _ in 0..4 {
 		assert!(hello_sub.next().await.unwrap().is_ok());
 	}
 


### PR DESCRIPTION
This PR replaces the future channels with tokio because the APIs fit our use-cases better.

In addition #962 will migrate to tokio channels as well. 