### PR TITLE
client: rename `max_notifs_per_subscription` to `max_buffer_capacity_per_subscription`

### DIFF
--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -83,7 +83,7 @@ pub struct WsClientBuilder {
 	ping_interval: Option<Duration>,
 	headers: http::HeaderMap,
 	max_concurrent_requests: usize,
-	max_notifs_per_subscription: usize,
+	max_buffer_capacity_per_subscription: usize,
 	max_redirections: usize,
 	id_kind: IdKind,
 	max_log_length: u32,
@@ -100,7 +100,7 @@ impl Default for WsClientBuilder {
 			ping_interval: None,
 			headers: HeaderMap::new(),
 			max_concurrent_requests: 256,
-			max_notifs_per_subscription: 1024,
+			max_buffer_capacity_per_subscription: 1024,
 			max_redirections: 5,
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
@@ -181,9 +181,9 @@ impl WsClientBuilder {
 		self
 	}
 
-	/// See documentation [`ClientBuilder::max_notifs_per_subscription`] (default is 1024).
-	pub fn max_notifs_per_subscription(mut self, max: usize) -> Self {
-		self.max_notifs_per_subscription = max;
+	/// See documentation [`ClientBuilder::max_buffer_capacity_per_subscription`] (default is 1024).
+	pub fn max_buffer_capacity_per_subscription(mut self, max: usize) -> Self {
+		self.max_buffer_capacity_per_subscription = max;
 		self
 	}
 
@@ -224,7 +224,7 @@ impl WsClientBuilder {
 			ping_interval,
 			headers,
 			max_redirections,
-			max_notifs_per_subscription,
+			max_buffer_capacity_per_subscription,
 			id_kind,
 			max_log_length,
 		} = self;
@@ -242,7 +242,7 @@ impl WsClientBuilder {
 		let (sender, receiver) = transport_builder.build(uri).await.map_err(|e| Error::Transport(e.into()))?;
 
 		let mut client = ClientBuilder::default()
-			.max_notifs_per_subscription(max_notifs_per_subscription)
+			.max_buffer_capacity_per_subscription(max_buffer_capacity_per_subscription)
 			.request_timeout(request_timeout)
 			.max_concurrent_requests(max_concurrent_requests)
 			.id_format(id_kind)

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -201,7 +201,7 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 
 	let uri = to_ws_uri_string(server.local_addr());
 	let client = WsClientBuilder::default()
-		.max_notifs_per_subscription(4)
+		.max_buffer_capacity_per_subscription(4)
 		.build(&uri)
 		.with_default_timeout()
 		.await

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -217,7 +217,7 @@ pub enum SubscriptionKind {
 ///
 /// It will try to `unsubscribe` in the drop implementation
 /// but it may fail if the underlying buffer is full.
-/// Thus, if you want to ensure it's actually unsubscribe then
+/// Thus, if you want to ensure it's actually unsubscribed then
 /// [`Subscription::unsubscribe`] is recommended to use.
 #[derive(Debug)]
 pub struct Subscription<Notif> {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -38,7 +38,6 @@ use crate::params::BatchRequestBuilder;
 use crate::traits::ToRpcParams;
 use async_trait::async_trait;
 use core::marker::PhantomData;
-use futures_util::future::FutureExt;
 use futures_util::stream::{Stream, StreamExt};
 use jsonrpsee_types::{ErrorObject, Id, SubscriptionId};
 use serde::de::DeserializeOwned;
@@ -216,8 +215,10 @@ pub enum SubscriptionKind {
 
 /// Active subscription on the client.
 ///
-/// It will automatically unsubscribe in the [`Subscription::drop`] so no need to explicitly call
-/// the `unsubscribe method` if it is an an subscription based on [`SubscriptionId`].
+/// It will try to `unsubscribe` in the drop implementation
+/// but it may fail if the underlying buffer is full.
+/// Thus, if you want to ensure it's actually unsubscribe then
+/// [`Subscription::unsubscribe`] is recommended to use.
 #[derive(Debug)]
 pub struct Subscription<Notif> {
 	/// Channel to send requests to the background task.
@@ -381,7 +382,7 @@ impl<Notif> Drop for Subscription<Notif> {
 			Some(SubscriptionKind::Subscription(sub_id)) => FrontToBack::SubscriptionClosed(sub_id),
 			None => return,
 		};
-		let _ = self.to_back.send(msg).now_or_never();
+		let _ = self.to_back.try_send(msg);
 	}
 }
 

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -207,8 +207,11 @@ async fn ws_subscription_several_clients_with_drop() {
 
 	let mut clients = Vec::with_capacity(10);
 	for _ in 0..10 {
-		let client =
-			WsClientBuilder::default().max_notifs_per_subscription(u32::MAX as usize).build(&server_url).await.unwrap();
+		let client = WsClientBuilder::default()
+			.max_buffer_capacity_per_subscription(u32::MAX as usize)
+			.build(&server_url)
+			.await
+			.unwrap();
 		let hello_sub: Subscription<String> =
 			client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
 		let foo_sub: Subscription<u64> =
@@ -254,7 +257,7 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
 
-	let client = WsClientBuilder::default().max_notifs_per_subscription(4).build(&server_url).await.unwrap();
+	let client = WsClientBuilder::default().max_buffer_capacity_per_subscription(4).build(&server_url).await.unwrap();
 	let mut hello_sub: Subscription<JsonValue> =
 		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
 


### PR DESCRIPTION
I had a look again at client after the recent changes in the server and concluded that `max_notifs_per_subscription` is a bad name. It only applies to the capacity so I think this is a good change