### PR TITLE
fix server: don't send error on JSON-RPC notifications

### DIFF
--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -283,6 +283,23 @@ async fn batch_with_mixed_calls() {
 }
 
 #[tokio::test]
+async fn batch_notif_without_params_works() {
+	init_logger();
+
+	let (addr, _handle) = server().with_default_timeout().await.unwrap();
+	let uri = to_http_uri(addr);
+	// mixed notifications, method calls and valid json should be valid.
+	let req = r#"[
+			{"jsonrpc": "2.0", "method": "add", "params": [1,2,4], "id": "1"},
+			{"jsonrpc": "2.0", "method": "add"}
+		]"#;
+	let res = r#"[{"jsonrpc":"2.0","result":7,"id":"1"}]"#;
+	let response = http_request(req.into(), uri.clone()).with_default_timeout().await.unwrap().unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	assert_eq!(response.body, res);
+}
+
+#[tokio::test]
 async fn garbage_request_fails() {
 	let (addr, _handle) = server().await;
 	let uri = to_http_uri(addr);

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -768,5 +768,6 @@ async fn notif_is_ignored() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
+	// This call should not be answered and a timeout is regarded as "not answered"
 	assert!(client.send_request_text(r#"{"jsonrpc":"2.0","method":"bar"}"#).with_default_timeout().await.is_err());
 }

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -156,7 +156,7 @@ where
 			.filter_map(|v| {
 				if let Ok(req) = serde_json::from_str::<Request>(v.get()) {
 					Some(Either::Right(execute_call(req, call.clone())))
-				} else if let Ok(_notif) = serde_json::from_str::<Notification<&JsonRawValue>>(v.get()) {
+				} else if let Ok(_notif) = serde_json::from_str::<Notif>(v.get()) {
 					// notifications should not be answered.
 					got_notif = true;
 					None

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -161,7 +161,7 @@ pub(crate) async fn process_single_request<L: Logger>(
 
 	if let Ok(req) = serde_json::from_slice::<Request>(&data) {
 		Some(execute_call_with_tracing(req, call).await)
-	} else if let Ok(_) = serde_json::from_slice::<Notif>(&data) {
+	} else if serde_json::from_slice::<Notif>(&data).is_ok() {
 		None
 	} else {
 		let (id, code) = prepare_error(&data);


### PR DESCRIPTION
After some refactoring I introduced a bug where the notifications were not handled properly and were treated as JSON-RPC errors.

Also in the batch responses `Notification<T>` was used such that `missing params<T>` became a serde decoding error when it was missing and needs to be handled as `Option<serde_json::RawValue>` instead.

Close #1017 