### PR TITLE
rpc module: remove `SubscriptionAnswer`

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -152,8 +152,9 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::se
 			UNSUB_METHOD_NAME,
 			|_params, pending, _ctx| async move {
 				let sink = pending.accept().await?;
-				let msg = SubscriptionMessage::from_json(&"Hello")?;
+				let msg = SubscriptionMessage::from("Hello");
 				sink.send(msg).await?;
+
 				Ok(())
 			},
 		)

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -153,7 +153,7 @@ pub(crate) async fn process_batch_request<L: Logger>(b: Batch<'_, L>) -> Option<
 	}
 }
 
-pub(crate) async fn process_single_request<'a, L: Logger>(
+pub(crate) async fn process_single_request<L: Logger>(
 	data: Vec<u8>,
 	call: CallData<'_, L>,
 ) -> Option<CallOrSubscription> {


### PR DESCRIPTION
This abstraction is not very nice and I think it's more readable with Result<MethodResult, Id> anyway so let's remove it.