### PR TITLE
Update format rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
 
       - uses: actions/checkout@v3.3.0
 
-      - name: Install Rust stable toolchain
+      - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly-2023-02-11
           override: true
           components: clippy, rustfmt
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,11 +1,14 @@
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use criterion::*;
-use futures_util::future::{join_all, FutureExt};
-use futures_util::stream::FuturesUnordered;
-use helpers::fixed_client::{http_client, ws_client, ws_handshake, ClientT, HeaderMap, SubscriptionClientT};
-use helpers::{KIB, SUB_METHOD_NAME, UNSUB_METHOD_NAME};
+use futures_util::{
+	future::{join_all, FutureExt},
+	stream::FuturesUnordered,
+};
+use helpers::{
+	fixed_client::{http_client, ws_client, ws_handshake, ClientT, HeaderMap, SubscriptionClientT},
+	KIB, SUB_METHOD_NAME, UNSUB_METHOD_NAME,
+};
 use jsonrpsee::types::{Id, RequestSer};
 use pprof::criterion::{Output, PProfProfiler};
 use tokio::runtime::Runtime as TokioRuntime;
@@ -265,10 +268,10 @@ fn sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Subs
 			},
 			|mut sub| async move {
 				black_box(sub.next().await.transpose().unwrap());
-				// Note that this benchmark will include costs for measuring `drop` for subscription,
-				// since it's not possible to combine both `iter_with_setup` and `iter_with_large_drop`.
-				// To estimate pure cost of method, one should subtract the result of `unsub` bench
-				// from this one.
+				// Note that this benchmark will include costs for measuring `drop` for
+				// subscription, since it's not possible to combine both `iter_with_setup` and
+				// `iter_with_large_drop`. To estimate pure cost of method, one should subtract the
+				// result of `unsub` bench from this one.
 			},
 		)
 	});

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -252,7 +252,12 @@ fn sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Subs
 	let mut group = crit.benchmark_group(name);
 	group.bench_function("subscribe", |b| {
 		b.to_async(rt).iter_with_large_drop(|| async {
-			black_box(client.subscribe::<String>(SUB_METHOD_NAME, None, UNSUB_METHOD_NAME).await.unwrap());
+			black_box(
+				client
+					.subscribe::<String>(SUB_METHOD_NAME, None, UNSUB_METHOD_NAME)
+					.await
+					.unwrap(),
+			);
 		})
 	});
 	group.bench_function("subscribe_response", |b| {
@@ -262,7 +267,10 @@ fn sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Subs
 				// runtime context and simply calling `block_on` here will cause the code to panic.
 				tokio::task::block_in_place(|| {
 					tokio::runtime::Handle::current().block_on(async {
-						client.subscribe::<String>(SUB_METHOD_NAME, None, UNSUB_METHOD_NAME).await.unwrap()
+						client
+							.subscribe::<String>(SUB_METHOD_NAME, None, UNSUB_METHOD_NAME)
+							.await
+							.unwrap()
 					})
 				})
 			},
@@ -279,7 +287,10 @@ fn sub_round_trip(rt: &TokioRuntime, crit: &mut Criterion, client: Arc<impl Subs
 		b.iter_with_setup(
 			|| {
 				rt.block_on(async {
-					client.subscribe::<String>(SUB_METHOD_NAME, None, UNSUB_METHOD_NAME).await.unwrap()
+					client
+						.subscribe::<String>(SUB_METHOD_NAME, None, UNSUB_METHOD_NAME)
+						.await
+						.unwrap()
 				})
 			},
 			|sub| {
@@ -310,7 +321,8 @@ fn batch_round_trip(
 
 		group.throughput(Throughput::Elements(*batch_size as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(batch_size), batch_size, |b, _| {
-			b.to_async(rt).iter(|| async { client.batch_request::<String>(batch.clone()).await.unwrap() })
+			b.to_async(rt)
+				.iter(|| async { client.batch_request::<String>(batch.clone()).await.unwrap() })
 		});
 	}
 	group.finish();

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -20,8 +20,7 @@ pub(crate) const SLOW_CALL: Duration = Duration::from_millis(1);
 /// Run jsonrpc HTTP server for benchmarks.
 #[cfg(feature = "jsonrpc-crate")]
 pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpc_http_server::Server) {
-	use jsonrpc_http_server::jsonrpc_core::*;
-	use jsonrpc_http_server::*;
+	use jsonrpc_http_server::{jsonrpc_core::*, *};
 
 	let mut io = IoHandler::new();
 	io.add_sync_method(SYNC_FAST_CALL, |_| Ok(Value::String("lo".to_string())));
@@ -53,8 +52,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpc_ws_se
 	use std::sync::atomic::{AtomicU64, Ordering};
 
 	use jsonrpc_pubsub::{PubSubHandler, Session, Subscriber, SubscriptionId};
-	use jsonrpc_ws_server::jsonrpc_core::*;
-	use jsonrpc_ws_server::*;
+	use jsonrpc_ws_server::{jsonrpc_core::*, *};
 
 	const ID: AtomicU64 = AtomicU64::new(0);
 
@@ -200,13 +198,17 @@ fn gen_rpc_module() -> jsonrpsee::RpcModule<()> {
 }
 
 pub mod fixed_client {
-	use jsonrpsee_v0_15::client_transport::ws::{Uri, WsTransportClientBuilder};
-	use jsonrpsee_v0_15::http_client::{HttpClient, HttpClientBuilder};
-	use jsonrpsee_v0_15::ws_client::{WsClient, WsClientBuilder};
+	use jsonrpsee_v0_15::{
+		client_transport::ws::{Uri, WsTransportClientBuilder},
+		http_client::{HttpClient, HttpClientBuilder},
+		ws_client::{WsClient, WsClientBuilder},
+	};
 
-	pub use jsonrpsee_v0_15::core::client::{ClientT, SubscriptionClientT};
-	pub use jsonrpsee_v0_15::http_client::HeaderMap;
-	pub use jsonrpsee_v0_15::rpc_params;
+	pub use jsonrpsee_v0_15::{
+		core::client::{ClientT, SubscriptionClientT},
+		http_client::HeaderMap,
+		rpc_params,
+	};
 
 	pub(crate) fn http_client(url: &str, headers: HeaderMap) -> HttpClient {
 		HttpClientBuilder::default()

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -287,11 +287,11 @@ where
 		let body = match tokio::time::timeout(self.request_timeout, fut).await {
 			Ok(Ok(body)) => body,
 			Err(_e) => {
-				return Err(Error::RequestTimeout);
-			}
+				return Err(Error::RequestTimeout)
+			},
 			Ok(Err(e)) => {
-				return Err(Error::Transport(e.into()));
-			}
+				return Err(Error::Transport(e.into()))
+			},
 		};
 
 		// NOTE: it's decoded first to `JsonRawValue` and then to `R` below to get
@@ -300,8 +300,8 @@ where
 			Ok(response) => response,
 			Err(_) => {
 				let err: ErrorResponse = serde_json::from_slice(&body).map_err(Error::ParseError)?;
-				return Err(Error::Call(CallError::Custom(err.error_object().clone().into_owned())));
-			}
+				return Err(Error::Call(CallError::Custom(err.error_object().clone().into_owned())))
+			},
 		};
 
 		let result = serde_json::from_str(response.result.get()).map_err(Error::ParseError)?;
@@ -333,7 +333,9 @@ where
 			});
 		}
 
-		let fut = self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
+		let fut = self
+			.transport
+			.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);
 
 		let body = match tokio::time::timeout(self.request_timeout, fut).await {
 			Ok(Ok(body)) => body,
@@ -357,16 +359,16 @@ where
 					let id = r.id.try_parse_inner_as_number().ok_or(Error::InvalidRequestId)?;
 					successful_calls += 1;
 					(id, Ok(r.result))
-				}
+				},
 				Err(err) => match serde_json::from_str::<ErrorResponse>(rp.get()).map_err(Error::ParseError) {
 					Ok(err) => {
 						let id = err.id().try_parse_inner_as_number().ok_or(Error::InvalidRequestId)?;
 						failed_calls += 1;
 						(id, Err(err.error_object().clone().into_owned()))
-					}
+					},
 					Err(_) => {
-						return Err(err);
-					}
+						return Err(err)
+					},
 				},
 			};
 
@@ -378,7 +380,7 @@ where
 			if let Some(elem) = maybe_elem {
 				*elem = res;
 			} else {
-				return Err(Error::InvalidRequestId);
+				return Err(Error::InvalidRequestId)
 			}
 		}
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -286,12 +286,8 @@ where
 		let fut = self.transport.send_and_read_body(raw);
 		let body = match tokio::time::timeout(self.request_timeout, fut).await {
 			Ok(Ok(body)) => body,
-			Err(_e) => {
-				return Err(Error::RequestTimeout)
-			},
-			Ok(Err(e)) => {
-				return Err(Error::Transport(e.into()))
-			},
+			Err(_e) => return Err(Error::RequestTimeout),
+			Ok(Err(e)) => return Err(Error::Transport(e.into())),
 		};
 
 		// NOTE: it's decoded first to `JsonRawValue` and then to `R` below to get
@@ -366,9 +362,7 @@ where
 						failed_calls += 1;
 						(id, Err(err.error_object().clone().into_owned()))
 					},
-					Err(_) => {
-						return Err(err)
-					},
+					Err(_) => return Err(err),
 				},
 			};
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -24,30 +24,26 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::borrow::Cow as StdCow;
-use std::error::Error as StdError;
-use std::fmt;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{borrow::Cow as StdCow, error::Error as StdError, fmt, sync::Arc, time::Duration};
 
-use crate::transport::{self, Error as TransportError, HttpTransportClient};
-use crate::types::{ErrorResponse, NotificationSer, RequestSer, Response};
-use async_trait::async_trait;
-use hyper::body::HttpBody;
-use hyper::http::HeaderMap;
-use hyper::Body;
-use jsonrpsee_core::client::{
-	generate_batch_id_range, BatchResponse, CertificateStore, ClientT, IdKind, RequestIdManager, Subscription,
-	SubscriptionClientT,
+use crate::{
+	transport::{self, Error as TransportError, HttpTransportClient},
+	types::{ErrorResponse, NotificationSer, RequestSer, Response},
 };
-use jsonrpsee_core::params::BatchRequestBuilder;
-use jsonrpsee_core::traits::ToRpcParams;
-use jsonrpsee_core::{Error, JsonRawValue, TEN_MB_SIZE_BYTES};
-use jsonrpsee_types::error::CallError;
-use jsonrpsee_types::{ErrorObject, TwoPointZero};
+use async_trait::async_trait;
+use hyper::{body::HttpBody, http::HeaderMap, Body};
+use jsonrpsee_core::{
+	client::{
+		generate_batch_id_range, BatchResponse, CertificateStore, ClientT, IdKind, RequestIdManager, Subscription,
+		SubscriptionClientT,
+	},
+	params::BatchRequestBuilder,
+	traits::ToRpcParams,
+	Error, JsonRawValue, TEN_MB_SIZE_BYTES,
+};
+use jsonrpsee_types::{error::CallError, ErrorObject, TwoPointZero};
 use serde::de::DeserializeOwned;
-use tower::layer::util::Identity;
-use tower::{Layer, Service};
+use tower::{layer::util::Identity, Layer, Service};
 use tracing::instrument;
 
 /// Http Client Builder.
@@ -55,7 +51,7 @@ use tracing::instrument;
 /// # Examples
 ///
 /// ```no_run
-///
+/// 
 /// use jsonrpsee_http_client::{HttpClientBuilder, HeaderMap, HeaderValue};
 ///
 /// #[tokio::main]
@@ -72,7 +68,6 @@ use tracing::instrument;
 ///
 ///     // use client....
 /// }
-///
 /// ```
 #[derive(Debug)]
 pub struct HttpClientBuilder<L = Identity> {
@@ -400,7 +395,8 @@ where
 	B::Data: Send,
 	B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
-	/// Send a subscription request to the server. Not implemented for HTTP; will always return [`Error::HttpNotImplemented`].
+	/// Send a subscription request to the server. Not implemented for HTTP; will always return
+	/// [`Error::HttpNotImplemented`].
 	#[instrument(name = "subscription", fields(method = _subscribe_method), skip(self, _params, _subscribe_method, _unsubscribe_method), level = "trace")]
 	async fn subscribe<'a, N, Params>(
 		&self,
@@ -415,7 +411,8 @@ where
 		Err(Error::HttpNotImplemented)
 	}
 
-	/// Subscribe to a specific method. Not implemented for HTTP; will always return [`Error::HttpNotImplemented`].
+	/// Subscribe to a specific method. Not implemented for HTTP; will always return
+	/// [`Error::HttpNotImplemented`].
 	#[instrument(name = "subscribe_method", fields(method = _method), skip(self, _method), level = "trace")]
 	async fn subscribe_to_method<'a, N>(&self, _method: &'a str) -> Result<Subscription<N>, Error>
 	where

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -54,8 +54,10 @@ async fn method_call_works() {
 #[tokio::test]
 async fn method_call_with_wrong_id_kind() {
 	let exp = "id as string";
-	let server_addr =
-		http_server_with_hardcoded_response(ok_response(exp.into(), Id::Num(0))).with_default_timeout().await.unwrap();
+	let server_addr = http_server_with_hardcoded_response(ok_response(exp.into(), Id::Num(0)))
+		.with_default_timeout()
+		.await
+		.unwrap();
 	let uri = format!("http://{server_addr}");
 	let client = HttpClientBuilder::default().id_format(IdKind::String).build(&uri).unwrap();
 	let res: Result<String, Error> = client.request("o", rpc_params![]).with_default_timeout().await.unwrap();
@@ -71,13 +73,21 @@ async fn method_call_with_id_str() {
 		.unwrap();
 	let uri = format!("http://{server_addr}");
 	let client = HttpClientBuilder::default().id_format(IdKind::String).build(&uri).unwrap();
-	let response: String = client.request("o", rpc_params![]).with_default_timeout().await.unwrap().unwrap();
+	let response: String = client
+		.request("o", rpc_params![])
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(&response, exp);
 }
 
 #[tokio::test]
 async fn notification_works() {
-	let server_addr = http_server_with_hardcoded_response(String::new()).with_default_timeout().await.unwrap();
+	let server_addr = http_server_with_hardcoded_response(String::new())
+		.with_default_timeout()
+		.await
+		.unwrap();
 	let uri = format!("http://{server_addr}");
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
 	client
@@ -100,42 +110,62 @@ async fn response_with_wrong_id() {
 
 #[tokio::test]
 async fn response_method_not_found() {
-	let err =
-		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(method_not_found(Id::Num(0)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).into_owned());
 }
 
 #[tokio::test]
 async fn response_parse_error() {
-	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(parse_error(Id::Num(0)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::ParseError).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
-	let err =
-		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(invalid_request(Id::Num(0_u64)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
-	let err =
-		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(invalid_params(Id::Num(0_u64)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).into_owned());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
-	let err =
-		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(internal_error(Id::Num(0_u64)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_jsonrpc_error_response(err, ErrorObject::from(ErrorCode::InternalError).into_owned());
 }
 
 #[tokio::test]
 async fn subscription_response_to_request() {
 	let req = r#"{"jsonrpc":"2.0","method":"subscribe_hello","params":{"subscription":"3px4FrtxSYQ1zBKW154NoVnrDhrq764yQNCXEgZyM6Mu","result":"hello my friend"}}"#.to_string();
-	let err = run_request_with_response(req).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(req)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert!(matches!(err, Error::ParseError(_)));
 }
 
@@ -261,14 +291,20 @@ async fn run_batch_request_with_response<T: Send + DeserializeOwned + std::fmt::
 	batch: BatchRequestBuilder<'_>,
 	response: String,
 ) -> Result<BatchResponse<T>, Error> {
-	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
+	let server_addr = http_server_with_hardcoded_response(response)
+		.with_default_timeout()
+		.await
+		.unwrap();
 	let uri = format!("http://{server_addr}");
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
 	client.batch_request(batch).with_default_timeout().await.unwrap()
 }
 
 async fn run_request_with_response(response: String) -> Result<String, Error> {
-	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
+	let server_addr = http_server_with_hardcoded_response(response)
+		.with_default_timeout()
+		.await
+		.unwrap();
 	let uri = format!("http://{server_addr}");
 	let client = HttpClientBuilder::default().build(&uri).unwrap();
 	client.request("say_hello", rpc_params![]).with_default_timeout().await.unwrap()
@@ -279,7 +315,7 @@ fn assert_jsonrpc_error_response(err: Error, exp: ErrorObjectOwned) {
 	match &err {
 		Error::Call(err) => {
 			assert_eq!(err.to_string(), exp.to_string());
-		}
+		},
 		e => panic!("Expected error: \"{err}\", got: {e:?}"),
 	};
 }

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -27,13 +27,12 @@
 use crate::types::error::{ErrorCode, ErrorObject};
 
 use crate::HttpClientBuilder;
-use jsonrpsee_core::client::{BatchResponse, ClientT, IdKind};
-use jsonrpsee_core::params::BatchRequestBuilder;
-use jsonrpsee_core::Error;
-use jsonrpsee_core::{rpc_params, DeserializeOwned};
-use jsonrpsee_test_utils::helpers::*;
-use jsonrpsee_test_utils::mocks::Id;
-use jsonrpsee_test_utils::TimeoutFutureExt;
+use jsonrpsee_core::{
+	client::{BatchResponse, ClientT, IdKind},
+	params::BatchRequestBuilder,
+	rpc_params, DeserializeOwned, Error,
+};
+use jsonrpsee_test_utils::{helpers::*, mocks::Id, TimeoutFutureExt};
 use jsonrpsee_types::error::{CallError, ErrorObjectOwned};
 
 fn init_logger() {

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -6,18 +6,24 @@
 // that we need to be guaranteed that hyper doesn't re-use an existing connection if we ever reset
 // the JSON-RPC request id to a value that might have already been used.
 
-use hyper::body::{Body, HttpBody};
-use hyper::client::{Client, HttpConnector};
-use hyper::http::{HeaderMap, HeaderValue};
-use hyper::Uri;
-use jsonrpsee_core::client::CertificateStore;
-use jsonrpsee_core::error::GenericTransportError;
-use jsonrpsee_core::http_helpers;
-use jsonrpsee_core::tracing::{rx_log_from_bytes, tx_log_from_str};
-use std::error::Error as StdError;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use hyper::{
+	body::{Body, HttpBody},
+	client::{Client, HttpConnector},
+	http::{HeaderMap, HeaderValue},
+	Uri,
+};
+use jsonrpsee_core::{
+	client::CertificateStore,
+	error::GenericTransportError,
+	http_helpers,
+	tracing::{rx_log_from_bytes, tx_log_from_str},
+};
+use std::{
+	error::Error as StdError,
+	future::Future,
+	pin::Pin,
+	task::{Context, Poll},
+};
 use thiserror::Error;
 use tower::{Layer, Service, ServiceExt};
 

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -138,14 +138,14 @@ where
 					_ => return Err(Error::InvalidCertficateStore),
 				};
 				HttpBackend::Https(Client::builder().build::<_, hyper::Body>(connector))
-			}
+			},
 			_ => {
 				#[cfg(feature = "__tls")]
 				let err = "URL scheme not supported, expects 'http' or 'https'";
 				#[cfg(not(feature = "__tls"))]
 				let err = "URL scheme not supported, expects 'http'";
-				return Err(Error::Url(err.into()));
-			}
+				return Err(Error::Url(err.into()))
+			},
 		};
 
 		// Cache request headers: 2 default headers, followed by user custom headers.
@@ -174,7 +174,7 @@ where
 		tx_log_from_str(&body, self.max_log_length);
 
 		if body.len() > self.max_request_size as usize {
-			return Err(Error::RequestTooLarge);
+			return Err(Error::RequestTooLarge)
 		}
 
 		let mut req = hyper::Request::post(&self.target.0);

--- a/client/transport/src/lib.rs
+++ b/client/transport/src/lib.rs
@@ -28,7 +28,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # jsonrpsee-client-transports
-//!
 
 /// Websocket transport
 #[cfg(feature = "ws")]

--- a/client/transport/src/web.rs
+++ b/client/transport/src/web.rs
@@ -1,11 +1,15 @@
 use core::fmt;
 
 use futures_channel::mpsc;
-use futures_util::sink::SinkExt;
-use futures_util::stream::{SplitSink, SplitStream, StreamExt};
+use futures_util::{
+	sink::SinkExt,
+	stream::{SplitSink, SplitStream, StreamExt},
+};
 use gloo_net::websocket::{futures::WebSocket, Message, WebSocketError};
-use jsonrpsee_core::async_trait;
-use jsonrpsee_core::client::{ReceivedMessage, TransportReceiverT, TransportSenderT};
+use jsonrpsee_core::{
+	async_trait,
+	client::{ReceivedMessage, TransportReceiverT, TransportSenderT},
+};
 
 /// Web-sys transport error that can occur.
 #[derive(Debug, thiserror::Error)]

--- a/client/transport/src/web.rs
+++ b/client/transport/src/web.rs
@@ -73,7 +73,7 @@ impl TransportReceiverT for Receiver {
 					Message::Bytes(bytes) => Ok(ReceivedMessage::Bytes(bytes)),
 					Message::Text(txt) => Ok(ReceivedMessage::Text(txt)),
 				}
-			}
+			},
 			Some(Err(err)) => Err(Error::WebSocket(err)),
 			None => Err(Error::SenderDisconnected),
 		}

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -26,18 +26,25 @@
 
 mod stream;
 
-use std::io;
-use std::net::{SocketAddr, ToSocketAddrs};
-use std::time::Duration;
+use std::{
+	io,
+	net::{SocketAddr, ToSocketAddrs},
+	time::Duration,
+};
 
 use futures_util::io::{BufReader, BufWriter};
-use jsonrpsee_core::client::{CertificateStore, ReceivedMessage, TransportReceiverT, TransportSenderT};
-use jsonrpsee_core::TEN_MB_SIZE_BYTES;
-use jsonrpsee_core::{async_trait, Cow};
-use soketto::connection::Error::Utf8;
-use soketto::data::ByteSlice125;
-use soketto::handshake::client::{Client as WsHandshakeClient, ServerResponse};
-use soketto::{connection, Data, Incoming};
+use jsonrpsee_core::{
+	async_trait,
+	client::{CertificateStore, ReceivedMessage, TransportReceiverT, TransportSenderT},
+	Cow, TEN_MB_SIZE_BYTES,
+};
+use soketto::{
+	connection,
+	connection::Error::Utf8,
+	data::ByteSlice125,
+	handshake::client::{Client as WsHandshakeClient, ServerResponse},
+	Data, Incoming,
+};
 use stream::EitherStream;
 use thiserror::Error;
 use tokio::net::TcpStream;
@@ -492,7 +499,8 @@ pub struct Target {
 	sockaddrs: Vec<SocketAddr>,
 	/// The host name (domain or IP address).
 	host: String,
-	/// The Host request header specifies the host and port number of the server to which the request is being sent.
+	/// The Host request header specifies the host and port number of the server to which the
+	/// request is being sent.
 	host_header: String,
 	/// WebSocket stream mode, see [`Mode`] for further documentation.
 	_mode: Mode,

--- a/client/transport/src/ws/stream.rs
+++ b/client/transport/src/ws/stream.rs
@@ -59,13 +59,13 @@ impl AsyncRead for EitherStream {
 				let compat = s.compat();
 				futures_util::pin_mut!(compat);
 				AsyncRead::poll_read(compat, cx, buf)
-			}
+			},
 			#[cfg(feature = "__tls")]
 			EitherStreamProj::Tls(t) => {
 				let compat = t.compat();
 				futures_util::pin_mut!(compat);
 				AsyncRead::poll_read(compat, cx, buf)
-			}
+			},
 		}
 	}
 
@@ -79,13 +79,13 @@ impl AsyncRead for EitherStream {
 				let compat = s.compat();
 				futures_util::pin_mut!(compat);
 				AsyncRead::poll_read_vectored(compat, cx, bufs)
-			}
+			},
 			#[cfg(feature = "__tls")]
 			EitherStreamProj::Tls(t) => {
 				let compat = t.compat();
 				futures_util::pin_mut!(compat);
 				AsyncRead::poll_read_vectored(compat, cx, bufs)
-			}
+			},
 		}
 	}
 }
@@ -97,13 +97,13 @@ impl AsyncWrite for EitherStream {
 				let compat = s.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_write(compat, cx, buf)
-			}
+			},
 			#[cfg(feature = "__tls")]
 			EitherStreamProj::Tls(t) => {
 				let compat = t.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_write(compat, cx, buf)
-			}
+			},
 		}
 	}
 
@@ -113,13 +113,13 @@ impl AsyncWrite for EitherStream {
 				let compat = s.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_write_vectored(compat, cx, bufs)
-			}
+			},
 			#[cfg(feature = "__tls")]
 			EitherStreamProj::Tls(t) => {
 				let compat = t.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_write_vectored(compat, cx, bufs)
-			}
+			},
 		}
 	}
 
@@ -129,13 +129,13 @@ impl AsyncWrite for EitherStream {
 				let compat = s.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_flush(compat, cx)
-			}
+			},
 			#[cfg(feature = "__tls")]
 			EitherStreamProj::Tls(t) => {
 				let compat = t.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_flush(compat, cx)
-			}
+			},
 		}
 	}
 
@@ -145,13 +145,13 @@ impl AsyncWrite for EitherStream {
 				let compat = s.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_close(compat, cx)
-			}
+			},
 			#[cfg(feature = "__tls")]
 			EitherStreamProj::Tls(t) => {
 				let compat = t.compat_write();
 				futures_util::pin_mut!(compat);
 				AsyncWrite::poll_close(compat, cx)
-			}
+			},
 		}
 	}
 }

--- a/client/transport/src/ws/stream.rs
+++ b/client/transport/src/ws/stream.rs
@@ -26,13 +26,16 @@
 
 //! Convenience wrapper for a stream (AsyncRead + AsyncWrite) which can either be plain TCP or TLS.
 
-use std::io::Error as IoError;
-use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
+use std::{
+	io::Error as IoError,
+	pin::Pin,
+	task::{Context, Poll},
+};
 
-use futures_util::io::{IoSlice, IoSliceMut};
-use futures_util::*;
+use futures_util::{
+	io::{IoSlice, IoSliceMut},
+	*,
+};
 use pin_project::pin_project;
 use tokio::net::TcpStream;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};

--- a/client/wasm-client/src/lib.rs
+++ b/client/wasm-client/src/lib.rs
@@ -36,15 +36,17 @@ pub use jsonrpsee_types as types;
 use std::time::Duration;
 
 use jsonrpsee_client_transport::web;
-use jsonrpsee_core::client::{ClientBuilder, IdKind};
-use jsonrpsee_core::Error;
+use jsonrpsee_core::{
+	client::{ClientBuilder, IdKind},
+	Error,
+};
 
 /// Builder for [`Client`].
 ///
 /// # Examples
 ///
 /// ```no_run
-///
+/// 
 /// use jsonrpsee_wasm_client::WasmClientBuilder;
 ///
 /// #[tokio::main]
@@ -57,7 +59,6 @@ use jsonrpsee_core::Error;
 ///
 ///     // use client....
 /// }
-///
 /// ```
 #[derive(Copy, Clone, Debug)]
 pub struct WasmClientBuilder {

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -45,15 +45,17 @@ pub use http::{HeaderMap, HeaderValue};
 use std::time::Duration;
 
 use jsonrpsee_client_transport::ws::{InvalidUri, Uri, WsTransportClientBuilder};
-use jsonrpsee_core::client::{CertificateStore, ClientBuilder, IdKind};
-use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
+use jsonrpsee_core::{
+	client::{CertificateStore, ClientBuilder, IdKind},
+	Error, TEN_MB_SIZE_BYTES,
+};
 
 /// Builder for [`WsClient`].
 ///
 /// # Examples
 ///
 /// ```no_run
-///
+/// 
 /// use jsonrpsee_ws_client::{WsClientBuilder, HeaderMap, HeaderValue};
 ///
 /// #[tokio::main]
@@ -71,7 +73,6 @@ use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 ///
 ///     // use client....
 /// }
-///
 /// ```
 #[derive(Clone, Debug)]
 pub struct WsClientBuilder {

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -28,13 +28,16 @@
 use crate::types::error::{ErrorCode, ErrorObject};
 
 use crate::WsClientBuilder;
-use jsonrpsee_core::client::{BatchResponse, ClientT, SubscriptionClientT};
-use jsonrpsee_core::client::{IdKind, Subscription};
-use jsonrpsee_core::params::BatchRequestBuilder;
-use jsonrpsee_core::{rpc_params, DeserializeOwned, Error};
-use jsonrpsee_test_utils::helpers::*;
-use jsonrpsee_test_utils::mocks::{Id, WebSocketTestServer};
-use jsonrpsee_test_utils::TimeoutFutureExt;
+use jsonrpsee_core::{
+	client::{BatchResponse, ClientT, IdKind, Subscription, SubscriptionClientT},
+	params::BatchRequestBuilder,
+	rpc_params, DeserializeOwned, Error,
+};
+use jsonrpsee_test_utils::{
+	helpers::*,
+	mocks::{Id, WebSocketTestServer},
+	TimeoutFutureExt,
+};
 use jsonrpsee_types::error::{CallError, ErrorObjectOwned};
 use serde_json::Value as JsonValue;
 

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -68,8 +68,13 @@ async fn method_call_with_wrong_id_kind() {
 	.await
 	.unwrap();
 	let uri = format!("ws://{}", server.local_addr());
-	let client =
-		WsClientBuilder::default().id_format(IdKind::String).build(&uri).with_default_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.id_format(IdKind::String)
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 
 	let err: Result<String, Error> = client.request("o", rpc_params![]).with_default_timeout().await.unwrap();
 	assert!(matches!(err, Err(Error::RestartNeeded(e)) if e == "Invalid request ID"));
@@ -86,9 +91,19 @@ async fn method_call_with_id_str() {
 	.await
 	.unwrap();
 	let uri = format!("ws://{}", server.local_addr());
-	let client =
-		WsClientBuilder::default().id_format(IdKind::String).build(&uri).with_default_timeout().await.unwrap().unwrap();
-	let response: String = client.request("o", rpc_params![]).with_default_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.id_format(IdKind::String)
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
+	let response: String = client
+		.request("o", rpc_params![])
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(&response, exp);
 }
 
@@ -100,8 +115,18 @@ async fn notif_works() {
 		.await
 		.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
-	assert!(client.notification("notif", rpc_params![]).with_default_timeout().await.unwrap().is_ok());
+	let client = WsClientBuilder::default()
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
+	assert!(client
+		.notification("notif", rpc_params![])
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.is_ok());
 }
 
 #[tokio::test]
@@ -116,35 +141,51 @@ async fn response_with_wrong_id() {
 
 #[tokio::test]
 async fn response_method_not_found() {
-	let err =
-		run_request_with_response(method_not_found(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(method_not_found(Id::Num(0)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_error_response(err, ErrorObject::from(ErrorCode::MethodNotFound).into_owned());
 }
 
 #[tokio::test]
 async fn parse_error_works() {
-	let err = run_request_with_response(parse_error(Id::Num(0))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(parse_error(Id::Num(0)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_error_response(err, ErrorObject::from(ErrorCode::ParseError).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_request_works() {
-	let err =
-		run_request_with_response(invalid_request(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(invalid_request(Id::Num(0_u64)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidRequest).into_owned());
 }
 
 #[tokio::test]
 async fn invalid_params_works() {
-	let err =
-		run_request_with_response(invalid_params(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(invalid_params(Id::Num(0_u64)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_error_response(err, ErrorObject::from(ErrorCode::InvalidParams).into_owned());
 }
 
 #[tokio::test]
 async fn internal_error_works() {
-	let err =
-		run_request_with_response(internal_error(Id::Num(0_u64))).with_default_timeout().await.unwrap().unwrap_err();
+	let err = run_request_with_response(internal_error(Id::Num(0_u64)))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert_error_response(err, ErrorObject::from(ErrorCode::InternalError).into_owned());
 }
 
@@ -159,7 +200,12 @@ async fn subscription_works() {
 	.await
 	.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	{
 		let mut sub: Subscription<String> = client
 			.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
@@ -183,10 +229,19 @@ async fn notification_handler_works() {
 	.unwrap();
 
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	{
-		let mut nh: Subscription<String> =
-			client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
+		let mut nh: Subscription<String> = client
+			.subscribe_to_method("test")
+			.with_default_timeout()
+			.await
+			.unwrap()
+			.unwrap();
 		let response: String = nh.next().with_default_timeout().await.unwrap().unwrap().unwrap();
 		assert_eq!("server originated notification works".to_owned(), response);
 	}
@@ -210,8 +265,12 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 		.await
 		.unwrap()
 		.unwrap();
-	let mut nh: Subscription<String> =
-		client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
+	let mut nh: Subscription<String> = client
+		.subscribe_to_method("test")
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 
 	// don't poll the notification stream for 2 seconds, should be full now.
 	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -224,8 +283,12 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 	assert!(nh.next().with_default_timeout().await.unwrap().is_none());
 
 	// The same subscription should be possible to register again.
-	let mut other_nh: Subscription<String> =
-		client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
+	let mut other_nh: Subscription<String> = client
+		.subscribe_to_method("test")
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 
 	// check that the new subscription works.
 	assert!(other_nh.next().with_default_timeout().await.unwrap().unwrap().is_ok());
@@ -361,7 +424,12 @@ async fn is_connected_works() {
 	.await
 	.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert!(client.is_connected());
 
 	let res: Result<String, Error> = client.request("say_hello", rpc_params![]).with_default_timeout().await.unwrap();
@@ -381,7 +449,12 @@ async fn run_batch_request_with_response<T: Send + DeserializeOwned + std::fmt::
 		.await
 		.unwrap();
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	client.batch_request(batch).with_default_timeout().await.unwrap()
 }
 
@@ -391,7 +464,12 @@ async fn run_request_with_response(response: String) -> Result<String, Error> {
 		.await
 		.unwrap();
 	let uri = format!("ws://{}", server.local_addr());
-	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	let client = WsClientBuilder::default()
+		.build(&uri)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	client.request("say_hello", rpc_params![]).with_default_timeout().await.unwrap()
 }
 
@@ -400,7 +478,7 @@ fn assert_error_response(err: Error, exp: ErrorObjectOwned) {
 	match &err {
 		Error::Call(e) => {
 			assert_eq!(e.to_string(), exp.to_string());
-		}
+		},
 		e => panic!("Expected error: \"{err}\", got: {e:?}"),
 	};
 }
@@ -431,6 +509,11 @@ async fn redirections() {
 	// It's connected
 	assert!(client.is_connected());
 	// It works
-	let response: String = client.request("anything", rpc_params![]).with_default_timeout().await.unwrap().unwrap();
+	let response: String = client
+		.request("anything", rpc_params![])
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(response, String::from(expected));
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -134,12 +134,10 @@ impl From<Error> for ErrorObjectOwned {
 	fn from(err: Error) -> Self {
 		match err {
 			Error::Call(CallError::Custom(err)) => err,
-			Error::Call(CallError::InvalidParams(e)) => {
-				ErrorObject::owned(INVALID_PARAMS_CODE, e.to_string(), None::<()>)
-			}
-			Error::Call(CallError::Failed(e)) => {
-				ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, e.to_string(), None::<()>)
-			}
+			Error::Call(CallError::InvalidParams(e)) =>
+				ErrorObject::owned(INVALID_PARAMS_CODE, e.to_string(), None::<()>),
+			Error::Call(CallError::Failed(e)) =>
+				ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, e.to_string(), None::<()>),
 			_ => ErrorObject::owned(UNKNOWN_ERROR_CODE, err.to_string(), None::<()>),
 		}
 	}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -45,8 +45,8 @@ impl<T: fmt::Display> fmt::Display for Mismatch<T> {
 	}
 }
 
-// NOTE(niklasad1): this `From` impl is a bit opinionated to regard all generic errors as `CallError`.
-// In practice this should be the most common use case for users of this library.
+// NOTE(niklasad1): this `From` impl is a bit opinionated to regard all generic errors as
+// `CallError`. In practice this should be the most common use case for users of this library.
 impl From<anyhow::Error> for Error {
 	fn from(err: anyhow::Error) -> Self {
 		Error::Call(CallError::Failed(err))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -83,7 +83,8 @@ pub mod __reexports {
 pub use beef::Cow;
 pub use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json::{
-	to_value as to_json_value, value::to_raw_value as to_json_raw_value, value::RawValue as JsonRawValue,
+	to_value as to_json_value,
+	value::{to_raw_value as to_json_raw_value, RawValue as JsonRawValue},
 	Value as JsonValue,
 };
 

--- a/core/src/params.rs
+++ b/core/src/params.rs
@@ -26,8 +26,7 @@
 
 //! RPC parameters.
 
-use crate::traits::ToRpcParams;
-use crate::Error;
+use crate::{traits::ToRpcParams, Error};
 use serde::Serialize;
 use serde_json::value::RawValue;
 
@@ -60,7 +59,8 @@ mod params_builder {
 			ParamsBuilder { bytes: Vec::new(), start, end }
 		}
 
-		/// Construct a new [`ParamsBuilder`] for positional parameters equivalent to a JSON array object.
+		/// Construct a new [`ParamsBuilder`] for positional parameters equivalent to a JSON array
+		/// object.
 		pub(crate) fn positional() -> Self {
 			Self::new('[', ']')
 		}
@@ -132,7 +132,7 @@ mod params_builder {
 /// # Examples
 ///
 /// ```rust
-///
+/// 
 /// use jsonrpsee_core::params::ObjectParams;
 ///
 /// let mut builder = ObjectParams::new();
@@ -179,7 +179,7 @@ impl ToRpcParams for ObjectParams {
 /// # Examples
 ///
 /// ```rust
-///
+/// 
 /// use jsonrpsee_core::params::ArrayParams;
 ///
 /// let mut builder = ArrayParams::new();

--- a/core/src/params.rs
+++ b/core/src/params.rs
@@ -110,7 +110,7 @@ mod params_builder {
 		/// Finish the building process and return a JSON compatible string.
 		pub(crate) fn build(mut self) -> Option<String> {
 			if self.bytes.is_empty() {
-				return None;
+				return None
 			}
 
 			let idx = self.bytes.len() - 1;

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -46,7 +46,7 @@ pub fn rx_log_from_bytes(bytes: &[u8], max: u32) {
 /// Find the next char boundary to truncate at.
 fn truncate_at_char_boundary(s: &str, max: usize) -> &str {
 	if s.len() < max {
-		return s;
+		return s
 	}
 
 	match s.char_indices().nth(max) {

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -35,8 +35,8 @@ use serde_json::value::RawValue;
 ///
 /// # Note
 ///
-/// Please consider using the [`crate::params::ArrayParams`] and [`crate::params::ObjectParams`] than
-/// implementing this trait.
+/// Please consider using the [`crate::params::ArrayParams`] and [`crate::params::ObjectParams`]
+/// than implementing this trait.
 ///
 /// # Examples
 ///

--- a/examples/examples/core_client.rs
+++ b/examples/examples/core_client.rs
@@ -26,10 +26,12 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::client_transport::ws::{Uri, WsTransportClientBuilder};
-use jsonrpsee::core::client::{Client, ClientBuilder, ClientT};
-use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::{
+	client_transport::ws::{Uri, WsTransportClientBuilder},
+	core::client::{Client, ClientBuilder, ClientT},
+	rpc_params,
+	server::{RpcModule, ServerBuilder},
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -24,16 +24,19 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
 use hyper::body::Bytes;
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
-use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
-use tower_http::LatencyUnit;
+use jsonrpsee::{
+	core::client::ClientT,
+	http_client::HttpClientBuilder,
+	rpc_params,
+	server::{RpcModule, ServerBuilder},
+};
+use tower_http::{
+	trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
+	LatencyUnit,
+};
 use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::main]

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -43,7 +43,10 @@ use tracing_subscriber::util::SubscriberInitExt;
 async fn main() -> anyhow::Result<()> {
 	let filter = tracing_subscriber::EnvFilter::try_from_default_env()?
 		.add_directive("jsonrpsee[method_call{name = \"say_hello\"}]=trace".parse()?);
-	tracing_subscriber::FmtSubscriber::builder().with_env_filter(filter).finish().try_init()?;
+	tracing_subscriber::FmtSubscriber::builder()
+		.with_env_filter(filter)
+		.finish()
+		.try_init()?;
 
 	let server_addr = run_server().await?;
 	let url = format!("http://{}", server_addr);

--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -87,14 +87,18 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		.layer(ProxyGetRequestLayer::new("/health", "system_health")?)
 		.timeout(Duration::from_secs(2));
 
-	let server =
-		ServerBuilder::new().set_middleware(service_builder).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
+	let server = ServerBuilder::new()
+		.set_middleware(service_builder)
+		.build("127.0.0.1:0".parse::<SocketAddr>()?)
+		.await?;
 
 	let addr = server.local_addr()?;
 
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("lo")).unwrap();
-	module.register_method("system_health", |_, _| Ok(serde_json::json!({ "health": true }))).unwrap();
+	module
+		.register_method("system_health", |_, _| Ok(serde_json::json!({ "health": true })))
+		.unwrap();
 
 	let handle = server.start(module)?;
 

--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -38,14 +38,14 @@
 //! like to query a certain `URI` path for statistics.
 
 use hyper::{Body, Client, Request};
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::rpc_params;
-use jsonrpsee::server::middleware::proxy_get_request::ProxyGetRequestLayer;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::{
+	core::client::ClientT,
+	http_client::HttpClientBuilder,
+	rpc_params,
+	server::{middleware::proxy_get_request::ProxyGetRequestLayer, RpcModule, ServerBuilder},
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/examples/logger.rs
+++ b/examples/examples/logger.rs
@@ -24,14 +24,18 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::net::SocketAddr;
-use std::time::Instant;
+use std::{net::SocketAddr, time::Instant};
 
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::server::logger::{self, HttpRequest, MethodKind, Params, TransportProtocol};
-use jsonrpsee::server::ServerBuilder;
-use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::{rpc_params, RpcModule};
+use jsonrpsee::{
+	core::client::ClientT,
+	rpc_params,
+	server::{
+		logger::{self, HttpRequest, MethodKind, Params, TransportProtocol},
+		ServerBuilder,
+	},
+	ws_client::WsClientBuilder,
+	RpcModule,
+};
 
 #[derive(Clone)]
 struct Timings;

--- a/examples/examples/middleware.rs
+++ b/examples/examples/middleware.rs
@@ -28,22 +28,22 @@
 //!
 //! It works with both `WebSocket` and `HTTP` which is done in the example.
 
-use hyper::body::Bytes;
-use hyper::http::HeaderValue;
-use hyper::Method;
+use hyper::{body::Bytes, http::HeaderValue, Method};
 use jsonrpsee::rpc_params;
-use std::iter::once;
-use std::net::SocketAddr;
-use std::time::Duration;
-use tower_http::cors::CorsLayer;
-use tower_http::sensitive_headers::SetSensitiveRequestHeadersLayer;
-use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
-use tower_http::LatencyUnit;
+use std::{iter::once, net::SocketAddr, time::Duration};
+use tower_http::{
+	cors::CorsLayer,
+	sensitive_headers::SetSensitiveRequestHeadersLayer,
+	trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
+	LatencyUnit,
+};
 
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
-use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::{
+	core::client::ClientT,
+	http_client::HttpClientBuilder,
+	server::{RpcModule, ServerBuilder},
+	ws_client::WsClientBuilder,
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/examples/middleware.rs
+++ b/examples/examples/middleware.rs
@@ -104,8 +104,10 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		.layer(cors)
 		.timeout(Duration::from_secs(2));
 
-	let server =
-		ServerBuilder::new().set_middleware(service_builder).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
+	let server = ServerBuilder::new()
+		.set_middleware(service_builder)
+		.build("127.0.0.1:0".parse::<SocketAddr>()?)
+		.await?;
 
 	let addr = server.local_addr()?;
 

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -26,16 +26,19 @@
 
 //! Example showing how to add multiple loggers to the same server.
 
-use std::net::SocketAddr;
-use std::process::Command;
-use std::time::Instant;
+use std::{net::SocketAddr, process::Command, time::Instant};
 
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::rpc_params;
-use jsonrpsee::server::logger::{HttpRequest, MethodKind, TransportProtocol};
-use jsonrpsee::server::{logger, RpcModule, ServerBuilder};
-use jsonrpsee::types::Params;
-use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::{
+	core::client::ClientT,
+	rpc_params,
+	server::{
+		logger,
+		logger::{HttpRequest, MethodKind, TransportProtocol},
+		RpcModule, ServerBuilder,
+	},
+	types::Params,
+	ws_client::WsClientBuilder,
+};
 
 /// Example logger to measure call execution time.
 #[derive(Clone)]
@@ -74,8 +77,8 @@ impl logger::Logger for Timings {
 struct ThreadWatcher;
 
 impl ThreadWatcher {
-	// Count the number of threads visible to this process. Counts the lines of `ps -eL` and equivalent minus one (the header).
-	// Cribbed from the `palaver` crate.
+	// Count the number of threads visible to this process. Counts the lines of `ps -eL` and equivalent
+	// minus one (the header). Cribbed from the `palaver` crate.
 	fn count_threads() -> usize {
 		let out = if cfg!(any(target_os = "linux", target_os = "android")) {
 			Command::new("ps").arg("-eL").output().expect("failed to execute process")

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -145,7 +145,10 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::new().set_logger((Timings, ThreadWatcher)).build("127.0.0.1:0").await?;
+	let server = ServerBuilder::new()
+		.set_logger((Timings, ThreadWatcher))
+		.build("127.0.0.1:0")
+		.await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| Ok("lo"))?;
 	module.register_method("thready", |params, _| {

--- a/examples/examples/proc_macro.rs
+++ b/examples/examples/proc_macro.rs
@@ -26,11 +26,12 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::server::rpc_module::SubscriptionMessage;
-use jsonrpsee::core::{async_trait, client::Subscription, Error, SubscriptionResult};
-use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{PendingSubscriptionSink, ServerBuilder};
-use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::{
+	core::{async_trait, client::Subscription, server::rpc_module::SubscriptionMessage, Error, SubscriptionResult},
+	proc_macros::rpc,
+	server::{PendingSubscriptionSink, ServerBuilder},
+	ws_client::WsClientBuilder,
+};
 
 type ExampleHash = [u8; 32];
 type ExampleStorageKey = Vec<u8>;

--- a/examples/examples/proc_macro.rs
+++ b/examples/examples/proc_macro.rs
@@ -89,7 +89,9 @@ async fn main() -> anyhow::Result<()> {
 	assert_eq!(client.storage_keys(vec![1, 2, 3, 4], None::<ExampleHash>).await.unwrap(), vec![vec![1, 2, 3, 4]]);
 
 	let mut sub: Subscription<Vec<ExampleHash>> =
-		RpcClient::<ExampleHash, ExampleStorageKey>::subscribe_storage(&client, None).await.unwrap();
+		RpcClient::<ExampleHash, ExampleStorageKey>::subscribe_storage(&client, None)
+			.await
+			.unwrap();
 	assert_eq!(Some(vec![[0; 32]]), sub.next().await.transpose().unwrap());
 
 	Ok(())

--- a/examples/examples/proc_macro_bounds.rs
+++ b/examples/examples/proc_macro_bounds.rs
@@ -26,10 +26,12 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, Error};
-use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::ServerBuilder;
-use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::{
+	core::{async_trait, Error},
+	proc_macros::rpc,
+	server::ServerBuilder,
+	ws_client::WsClientBuilder,
+};
 
 type ExampleHash = [u8; 32];
 
@@ -41,15 +43,15 @@ impl Config for ExampleHash {
 	type Hash = Self;
 }
 
-/// The RPC macro requires `DeserializeOwned` for output types for the client implementation, while the
-/// server implementation requires output types to be bounded by `Serialize`.
+/// The RPC macro requires `DeserializeOwned` for output types for the client implementation, while
+/// the server implementation requires output types to be bounded by `Serialize`.
 ///
 /// In this example, we don't want the `Conf` to be bounded by default to
 /// `Conf : Send + Sync + 'static + jsonrpsee::core::DeserializeOwned` for client implementation and
 /// `Conf : Send + Sync + 'static + jsonrpsee::core::Serialize` for server implementation.
 ///
-/// Explicitly, specify client and server bounds to handle the `Serialize` and `DeserializeOwned` cases
-/// just for the `Conf::hash` part.
+/// Explicitly, specify client and server bounds to handle the `Serialize` and `DeserializeOwned`
+/// cases just for the `Conf::hash` part.
 #[rpc(server, client, namespace = "foo", client_bounds(T::Hash: jsonrpsee::core::DeserializeOwned), server_bounds(T::Hash: jsonrpsee::core::Serialize))]
 pub trait Rpc<T: Config> {
 	#[method(name = "bar")]

--- a/examples/examples/tokio_console.rs
+++ b/examples/examples/tokio_console.rs
@@ -36,9 +36,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::Error;
-use jsonrpsee::server::ServerBuilder;
-use jsonrpsee::RpcModule;
+use jsonrpsee::{core::Error, server::ServerBuilder, RpcModule};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/examples/ws.rs
+++ b/examples/examples/ws.rs
@@ -34,7 +34,10 @@ async fn main() -> anyhow::Result<()> {
 	let filter = tracing_subscriber::EnvFilter::try_from_default_env()?
 		.add_directive("jsonrpsee[method_call{name = \"say_hello\"}]=trace".parse()?);
 
-	tracing_subscriber::FmtSubscriber::builder().with_env_filter(filter).finish().try_init()?;
+	tracing_subscriber::FmtSubscriber::builder()
+		.with_env_filter(filter)
+		.finish()
+		.try_init()?;
 
 	let addr = run_server().await?;
 	let url = format!("ws://{}", addr);

--- a/examples/examples/ws.rs
+++ b/examples/examples/ws.rs
@@ -26,10 +26,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::server::ServerBuilder;
-use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::{rpc_params, RpcModule};
+use jsonrpsee::{core::client::ClientT, rpc_params, server::ServerBuilder, ws_client::WsClientBuilder, RpcModule};
 use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::main]

--- a/examples/examples/ws_pubsub_broadcast.rs
+++ b/examples/examples/ws_pubsub_broadcast.rs
@@ -28,16 +28,22 @@
 
 use std::net::SocketAddr;
 
-use futures::future::{self, Either};
-use futures::StreamExt;
-use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
-use jsonrpsee::core::server::rpc_module::SubscriptionMessage;
+use futures::{
+	future::{self, Either},
+	StreamExt,
+};
+use jsonrpsee::core::{
+	client::{Subscription, SubscriptionClientT},
+	server::rpc_module::SubscriptionMessage,
+};
 
-use jsonrpsee::core::SubscriptionResult;
-use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
-use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::PendingSubscriptionSink;
+use jsonrpsee::{
+	core::SubscriptionResult,
+	rpc_params,
+	server::{RpcModule, ServerBuilder},
+	ws_client::WsClientBuilder,
+	PendingSubscriptionSink,
+};
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 

--- a/examples/examples/ws_pubsub_broadcast.rs
+++ b/examples/examples/ws_pubsub_broadcast.rs
@@ -136,9 +136,7 @@ async fn pipe_from_stream_with_bounded_buffer(
 			},
 
 			// stream is closed or some error, just quit.
-			Either::Right((_, _)) => {
-				break
-			},
+			Either::Right((_, _)) => break,
 		}
 	}
 

--- a/examples/examples/ws_pubsub_broadcast.rs
+++ b/examples/examples/ws_pubsub_broadcast.rs
@@ -64,8 +64,12 @@ async fn main() -> anyhow::Result<()> {
 	let sub1: Subscription<i32> = client1.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await?;
 	let sub2: Subscription<i32> = client2.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await?;
 
-	let fut1 = sub1.take(NUM_SUBSCRIPTION_RESPONSES).for_each(|r| async move { tracing::info!("sub1 rx: {:?}", r) });
-	let fut2 = sub2.take(NUM_SUBSCRIPTION_RESPONSES).for_each(|r| async move { tracing::info!("sub2 rx: {:?}", r) });
+	let fut1 = sub1
+		.take(NUM_SUBSCRIPTION_RESPONSES)
+		.for_each(|r| async move { tracing::info!("sub1 rx: {:?}", r) });
+	let fut2 = sub2
+		.take(NUM_SUBSCRIPTION_RESPONSES)
+		.for_each(|r| async move { tracing::info!("sub2 rx: {:?}", r) });
 
 	future::join(fut1, fut2).await;
 
@@ -74,7 +78,10 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	// let's configure the server only hold 5 messages in memory.
-	let server = ServerBuilder::default().set_message_buffer_capacity(5).build("127.0.0.1:0").await?;
+	let server = ServerBuilder::default()
+		.set_message_buffer_capacity(5)
+		.build("127.0.0.1:0")
+		.await?;
 	let (tx, _rx) = broadcast::channel::<usize>(16);
 
 	let mut module = RpcModule::new(tx.clone());
@@ -122,16 +129,16 @@ async fn pipe_from_stream_with_bounded_buffer(
 				// and you might want to do something smarter if it's
 				// critical that "the most recent item" must be sent when it is produced.
 				if sink.send(notif).await.is_err() {
-					break;
+					break
 				}
 
 				closed = c;
-			}
+			},
 
 			// stream is closed or some error, just quit.
 			Either::Right((_, _)) => {
-				break;
-			}
+				break
+			},
 		}
 	}
 

--- a/examples/examples/ws_pubsub_with_params.rs
+++ b/examples/examples/ws_pubsub_with_params.rs
@@ -24,17 +24,21 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
 use futures::{Stream, StreamExt};
-use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
-use jsonrpsee::core::server::rpc_module::{SubscriptionMessage, TrySendError};
-use jsonrpsee::core::{Serialize, SubscriptionResult};
-use jsonrpsee::server::{RpcModule, ServerBuilder};
-use jsonrpsee::types::ErrorObjectOwned;
-use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::{rpc_params, PendingSubscriptionSink};
+use jsonrpsee::{
+	core::{
+		client::{Subscription, SubscriptionClientT},
+		server::rpc_module::{SubscriptionMessage, TrySendError},
+		Serialize, SubscriptionResult,
+	},
+	rpc_params,
+	server::{RpcModule, ServerBuilder},
+	types::ErrorObjectOwned,
+	ws_client::WsClientBuilder,
+	PendingSubscriptionSink,
+};
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 

--- a/examples/examples/ws_pubsub_with_params.rs
+++ b/examples/examples/ws_pubsub_with_params.rs
@@ -60,8 +60,9 @@ async fn main() -> anyhow::Result<()> {
 	tracing::info!("subscription with one param: {:?}", sub_params_one.next().await);
 
 	// Subscription with multiple parameters
-	let mut sub_params_two: Subscription<String> =
-		client.subscribe("sub_params_two", rpc_params![2, 5], "unsub_params_two").await?;
+	let mut sub_params_two: Subscription<String> = client
+		.subscribe("sub_params_two", rpc_params![2, 5], "unsub_params_two")
+		.await?;
 	tracing::info!("subscription with two params: {:?}", sub_params_two.next().await);
 
 	Ok(())
@@ -69,7 +70,10 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	const LETTERS: &str = "abcdefghijklmnopqrstuvxyz";
-	let server = ServerBuilder::default().set_message_buffer_capacity(10).build("127.0.0.1:0").await?;
+	let server = ServerBuilder::default()
+		.set_message_buffer_capacity(10)
+		.build("127.0.0.1:0")
+		.await?;
 	let mut module = RpcModule::new(());
 	module
 		.register_subscription("sub_one_param", "sub_one_param", "unsub_one_param", |params, pending, _| async move {
@@ -78,8 +82,8 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 				Ok(p) => p,
 				Err(e) => {
 					let _ = pending.reject(ErrorObjectOwned::from(e)).await;
-					return Ok(());
-				}
+					return Ok(())
+				},
 			};
 
 			let item = LETTERS.chars().nth(idx);

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -39,9 +39,11 @@
 //! - **`wasm-client`** - JSON-RPC client functionality over web-sys.
 //! - **`ws-client`** - JSON-RPC client functionality over WebSocket protocol.
 //! - **`macros`** - JSON-RPC API generation convenience by derive macros.
-//! - **`client-core`** - Enables minimal client features to generate the RPC API without transports.
+//! - **`client-core`** - Enables minimal client features to generate the RPC API without
+//!   transports.
 //! - **`client`** - Enables all client features including transports.
-//! - **`server-core`** - Enables minimal server features to generate the RPC API without transports.
+//! - **`server-core`** - Enables minimal server features to generate the RPC API without
+//!   transports.
 //! - **`server`** - Enables all server features including transports.
 //! - **`full`** - Enables all features.
 //! - **`async-client`** - Enables the async client without any transport.

--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -27,9 +27,12 @@
 use std::{fmt, iter};
 
 use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
-use syn::parse::{Parse, ParseStream, Parser};
-use syn::punctuated::Punctuated;
-use syn::{spanned::Spanned, Attribute, Error, LitStr, Token};
+use syn::{
+	parse::{Parse, ParseStream, Parser},
+	punctuated::Punctuated,
+	spanned::Spanned,
+	Attribute, Error, LitStr, Token,
+};
 
 pub(crate) struct AttributeMeta {
 	pub path: syn::Path,
@@ -134,7 +137,8 @@ impl AttributeMeta {
 
 	/// Attempt to get a list of `Argument`s from a list of names in order.
 	///
-	/// Errors if there is an argument with a name that's not on the list, or if there is a duplicate definition.
+	/// Errors if there is an argument with a name that's not on the list, or if there is a
+	/// duplicate definition.
 	pub fn retain<const N: usize>(self, allowed: [&str; N]) -> syn::Result<[Result<Argument, MissingArgument>; N]> {
 		assert!(
 			N != 0,

--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -72,7 +72,7 @@ impl Parse for Argument {
 		// inside angle brackets.
 		let tokens = iter::from_fn(move || {
 			if scope == 0 && input.peek(Token![,]) {
-				return None;
+				return None
 			}
 
 			if input.peek(Token![<]) {
@@ -152,7 +152,7 @@ impl AttributeMeta {
 				// If this position in the `result` array already contains an argument,
 				// it means we got a duplicate definition
 				if let Ok(old) = &result[idx] {
-					return Err(Error::new(old.label.span(), format!("Duplicate argument `{}`", old.label)));
+					return Err(Error::new(old.label.span(), format!("Duplicate argument `{}`", old.label)))
 				}
 
 				result[idx] = Ok(argument);
@@ -163,7 +163,7 @@ impl AttributeMeta {
 				err_str.extend(allowed[1..].iter().flat_map(|&label| ["`, `", label]));
 				err_str.push('`');
 
-				return Err(Error::new(argument.label.span(), err_str));
+				return Err(Error::new(argument.label.span(), err_str))
 			}
 		}
 

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -47,16 +47,16 @@ fn find_jsonrpsee_crate(http_name: &str, ws_name: &str) -> Result<proc_macro2::T
 		Ok(FoundCrate::Name(name)) => {
 			let ident = syn::Ident::new(&name, Span::call_site());
 			Ok(quote!(#ident))
-		}
+		},
 		Ok(FoundCrate::Itself) => panic!("Deriving RPC methods in any of the `jsonrpsee` crates is not supported"),
 		Err(_) => match (crate_name(http_name), crate_name(ws_name)) {
 			(Ok(FoundCrate::Name(name)), _) | (_, Ok(FoundCrate::Name(name))) => {
 				let ident = syn::Ident::new(&name, Span::call_site());
 				Ok(quote!(#ident))
-			}
+			},
 			(Ok(FoundCrate::Itself), _) | (_, Ok(FoundCrate::Itself)) => {
 				panic!("Deriving RPC methods in any of the `jsonrpsee` crates is not supported")
-			}
+			},
 			(_, Err(e)) => Err(syn::Error::new(Span::call_site(), &e)),
 		},
 	}
@@ -104,7 +104,7 @@ pub(crate) fn generate_where_clause(
 
 		bounds.extend(custom_bounds.iter().cloned());
 
-		return bounds;
+		return bounds
 	}
 
 	item_trait
@@ -170,7 +170,7 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
 		while let Some(seg) = it.next() {
 			// The leaf segment should be `Option` with or without angled brackets.
 			if seg.ident == "Option" && it.peek().is_none() {
-				return true;
+				return true
 			}
 		}
 	}
@@ -184,8 +184,8 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
 /// Thus, if the attribute starts with `doc` => it's regarded as a doc comment.
 pub(crate) fn extract_doc_comments(attrs: &[syn::Attribute]) -> TokenStream2 {
 	let docs = attrs.iter().filter(|attr| {
-		attr.path.is_ident("doc")
-			&& match attr.parse_meta() {
+		attr.path.is_ident("doc") &&
+			match attr.parse_meta() {
 				Ok(syn::Meta::NameValue(meta)) => matches!(&meta.lit, syn::Lit::Str(_)),
 				_ => false,
 			}

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -62,11 +62,11 @@ fn find_jsonrpsee_crate(http_name: &str, ws_name: &str) -> Result<proc_macro2::T
 	}
 }
 
-/// Traverses the RPC trait definition and applies the required bounds for the generic type parameters that are used.
-/// The bounds applied depend on whether the type parameter is used as a parameter, return value or subscription result
-/// and whether it's used in client or server mode.
-/// Type params get `Send + Sync + 'static` bounds and input/output parameters get `Serialize` and/or `DeserializeOwned`
-/// bounds. Inspired by <https://github.com/paritytech/jsonrpc/blob/master/derive/src/to_delegate.rs#L414>
+/// Traverses the RPC trait definition and applies the required bounds for the generic type
+/// parameters that are used. The bounds applied depend on whether the type parameter is used as a
+/// parameter, return value or subscription result and whether it's used in client or server mode.
+/// Type params get `Send + Sync + 'static` bounds and input/output parameters get `Serialize`
+/// and/or `DeserializeOwned` bounds. Inspired by <https://github.com/paritytech/jsonrpc/blob/master/derive/src/to_delegate.rs#L414>
 ///
 /// ### Example
 ///
@@ -84,8 +84,8 @@ fn find_jsonrpsee_crate(http_name: &str, ws_name: &str) -> Result<proc_macro2::T
 ///  }
 /// ```
 ///
-/// Because the `item` attribute is not parsed as ordinary rust syntax, the `syn::Type` is traversed to find
-/// each generic parameter of it.
+/// Because the `item` attribute is not parsed as ordinary rust syntax, the `syn::Type` is traversed
+/// to find each generic parameter of it.
 /// This is used as an additional input before traversing the entire trait.
 /// Otherwise, it's not possible to know whether a type parameter is used for subscription result.
 pub(crate) fn generate_where_clause(

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -49,12 +49,14 @@ pub(crate) mod visitor;
 /// type that implements `Client` or `SubscriptionClient` (depending on whether trait has
 /// subscriptions methods or not), namely `HttpClient` and `WsClient`.
 ///
-/// For servers, it will generate a trait mostly equivalent to the input, with the following differences:
+/// For servers, it will generate a trait mostly equivalent to the input, with the following
+/// differences:
 ///
-/// - The trait will have one additional (already implemented) method, `into_rpc`, which turns any object that
-///   implements the server trait into an `RpcModule`.
+/// - The trait will have one additional (already implemented) method, `into_rpc`, which turns any
+///   object that implements the server trait into an `RpcModule`.
 /// - For subscription methods:
-///   - There will be one additional argument inserted right after `&self`: `subscription_sink: SubscriptionSink`.
+///   - There will be one additional argument inserted right after `&self`: `subscription_sink:
+///     SubscriptionSink`.
 ///   It should be used to accept or reject a subscription and send data back to subscribers.
 ///   - The return type of the subscription method is `SubscriptionResult` for improved ergonomics.
 ///
@@ -62,15 +64,16 @@ pub(crate) mod visitor;
 /// a new name. For the `Foo` trait, server trait will be named `FooServer`, and client,
 /// correspondingly, `FooClient`.
 ///
-/// To use the `FooClient`, just import it in the context. To use the server, the `FooServer` trait must be implemented
-/// on your type first.
+/// To use the `FooClient`, just import it in the context. To use the server, the `FooServer` trait
+/// must be implemented on your type first.
 ///
-/// Note: you need to import the `jsonrpsee` façade crate in your code for the macro to work properly.
+/// Note: you need to import the `jsonrpsee` façade crate in your code for the macro to work
+/// properly.
 ///
 /// ## Prerequisites
 ///
-/// - Implementors of the server trait must be `Sync`, `Send`, `Sized` and `'static`. If you want to implement this
-///   trait on some type that is not thread-safe, consider using `Arc<RwLock<..>>`.
+/// - Implementors of the server trait must be `Sync`, `Send`, `Sized` and `'static`. If you want to
+///   implement this trait on some type that is not thread-safe, consider using `Arc<RwLock<..>>`.
 ///
 /// ## Examples
 ///
@@ -141,14 +144,14 @@ pub(crate) mod visitor;
 /// **Arguments:**
 ///
 /// - `server`: generate `<Trait>Server` trait for the server implementation.
-/// - `client`: generate `<Trait>Client` extension trait that builds RPC clients to invoke a concrete RPC
-///   implementation's methods conveniently.
-/// - `namespace`: add a prefix to all the methods and subscriptions in this RPC. For example, with namespace `foo` and
-///   method `spam`, the resulting method name will be `foo_spam`.
-/// - `server_bounds`: replace *all* auto-generated trait bounds with the user-defined ones for the server
-///   implementation.
-/// - `client_bounds`: replace *all* auto-generated trait bounds with the user-defined ones for the client
-///   implementation.
+/// - `client`: generate `<Trait>Client` extension trait that builds RPC clients to invoke a
+///   concrete RPC implementation's methods conveniently.
+/// - `namespace`: add a prefix to all the methods and subscriptions in this RPC. For example, with
+///   namespace `foo` and method `spam`, the resulting method name will be `foo_spam`.
+/// - `server_bounds`: replace *all* auto-generated trait bounds with the user-defined ones for the
+///   server implementation.
+/// - `client_bounds`: replace *all* auto-generated trait bounds with the user-defined ones for the
+///   client implementation.
 ///
 /// **Trait requirements:**
 ///
@@ -158,7 +161,8 @@ pub(crate) mod visitor;
 /// - have Rust methods not marked with either the `method` or `subscription` attribute;
 /// - be empty.
 ///
-/// At least one of the `server` or `client` flags must be provided, otherwise the compilation will err.
+/// At least one of the `server` or `client` flags must be provided, otherwise the compilation will
+/// err.
 ///
 /// ### `method` attribute
 ///
@@ -166,12 +170,14 @@ pub(crate) mod visitor;
 ///
 /// **Arguments:**
 ///
-/// - `name` (mandatory): name of the RPC method. Does not have to be the same as the Rust method name.
-/// - `aliases`: list of name aliases for the RPC method as a comma separated string.
-///              Aliases are processed ignoring the namespace, so add the complete name, including the
-///              namespace.
-/// - `blocking`: when set method execution will always spawn on a dedicated thread. Only usable with non-`async` methods.
-/// - `param_kind`: kind of structure to use for parameter passing. Can be "array" or "map", defaults to "array".
+/// - `name` (mandatory): name of the RPC method. Does not have to be the same as the Rust method
+///   name.
+/// - `aliases`: list of name aliases for the RPC method as a comma separated string. Aliases are
+///   processed ignoring the namespace, so add the complete name, including the namespace.
+/// - `blocking`: when set method execution will always spawn on a dedicated thread. Only usable
+///   with non-`async` methods.
+/// - `param_kind`: kind of structure to use for parameter passing. Can be "array" or "map",
+///   defaults to "array".
 ///
 /// **Method requirements:**
 ///
@@ -187,14 +193,18 @@ pub(crate) mod visitor;
 ///
 /// **Arguments:**
 ///
-/// - `name` (mandatory): name of the RPC method. Does not have to be the same as the Rust method name.
-/// - `unsubscribe` (optional): name of the RPC method to unsubscribe from the subscription. Must not be the same as `name`.
-///                             This is generated for you if the subscription name starts with `subscribe`.
-/// - `aliases` (optional): aliases for `name`. Aliases are processed ignoring the namespace,
-///                         so add the complete name, including the namespace.
+/// - `name` (mandatory): name of the RPC method. Does not have to be the same as the Rust method
+///   name.
+/// - `unsubscribe` (optional): name of the RPC method to unsubscribe from the subscription. Must
+///   not be the same as `name`. This is generated for you if the subscription name starts with
+///   `subscribe`.
+/// - `aliases` (optional): aliases for `name`. Aliases are processed ignoring the namespace, so add
+///   the complete name, including the namespace.
 /// - `unsubscribe_aliases` (optional): Similar to `aliases` but for `unsubscribe`.
-/// - `item` (mandatory): type of items yielded by the subscription. Note that it must be the type, not string.
-/// - `param_kind`: kind of structure to use for parameter passing. Can be "array" or "map", defaults to "array".
+/// - `item` (mandatory): type of items yielded by the subscription. Note that it must be the type,
+///   not string.
+/// - `param_kind`: kind of structure to use for parameter passing. Can be "array" or "map",
+///   defaults to "array".
 ///
 /// **Method requirements:**
 ///

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -23,13 +23,14 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-use crate::attributes::ParamKind;
-use crate::helpers::generate_where_clause;
-use crate::rpc_macro::{RpcDescription, RpcMethod, RpcSubscription};
+use crate::{
+	attributes::ParamKind,
+	helpers::generate_where_clause,
+	rpc_macro::{RpcDescription, RpcMethod, RpcSubscription},
+};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
-use syn::spanned::Spanned;
-use syn::{AngleBracketedGenericArguments, FnArg, Pat, PatIdent, PatType, PathArguments, TypeParam};
+use syn::{spanned::Spanned, AngleBracketedGenericArguments, FnArg, Pat, PatIdent, PatType, PathArguments, TypeParam};
 
 impl RpcDescription {
 	pub(super) fn render_client(&self) -> Result<TokenStream2, syn::Error> {
@@ -121,7 +122,8 @@ impl RpcDescription {
 		let rpc_method_name = self.rpc_identifier(&method.name);
 
 		// Called method is either `request` or `notification`.
-		// `returns` represent the return type of the *rust method* (`Result< <..>, jsonrpsee::core::Error`).
+		// `returns` represent the return type of the *rust method* (`Result< <..>,
+		// jsonrpsee::core::Error`).
 		let (called_method, returns) = if let Some(returns) = &method.returns {
 			let called_method = quote::format_ident!("request");
 			let returns = self.return_result_type(returns.clone());

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -48,9 +48,16 @@ impl RpcDescription {
 			quote! { #jsonrpsee::core::client::SubscriptionClientT }
 		};
 
-		let method_impls =
-			self.methods.iter().map(|method| self.render_method(method)).collect::<Result<Vec<_>, _>>()?;
-		let sub_impls = self.subscriptions.iter().map(|sub| self.render_sub(sub)).collect::<Result<Vec<_>, _>>()?;
+		let method_impls = self
+			.methods
+			.iter()
+			.map(|method| self.render_method(method))
+			.collect::<Result<Vec<_>, _>>()?;
+		let sub_impls = self
+			.subscriptions
+			.iter()
+			.map(|sub| self.render_sub(sub))
+			.collect::<Result<Vec<_>, _>>()?;
 
 		let async_trait = self.jrps_client_item(quote! { core::__reexports::async_trait });
 
@@ -90,7 +97,7 @@ impl RpcDescription {
 		if type_name.ident == "Result" {
 			// Result<T, E> should have 2 generic args.
 			if args.len() != 2 {
-				return quote_spanned!(args.span() => compile_error!("Result must be have two arguments"));
+				return quote_spanned!(args.span() => compile_error!("Result must be have two arguments"))
 			}
 
 			// Force the last argument to be `jsonrpsee::core::Error`:
@@ -101,7 +108,7 @@ impl RpcDescription {
 		} else if type_name.ident == "RpcResult" {
 			// RpcResult<T> (an alias we export) should have 1 generic arg.
 			if args.len() != 1 {
-				return quote_spanned!(args.span() => compile_error!("RpcResult must have one argument"));
+				return quote_spanned!(args.span() => compile_error!("RpcResult must have one argument"))
 			}
 			quote!(#ty)
 		} else {
@@ -199,7 +206,7 @@ impl RpcDescription {
 		if params.is_empty() {
 			return quote!({
 				#jsonrpsee::core::params::ArrayParams::new()
-			});
+			})
 		}
 
 		match param_kind {
@@ -222,7 +229,7 @@ impl RpcDescription {
 					)*
 					params
 				})
-			}
+			},
 			ParamKind::Array => {
 				// Throw away the type.
 				let params = params.iter().map(|(param, _param_type)| param);
@@ -235,7 +242,7 @@ impl RpcDescription {
 					)*
 					params
 				})
-			}
+			},
 		}
 	}
 }

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -24,15 +24,13 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::collections::HashSet;
-use std::str::FromStr;
+use std::{collections::HashSet, str::FromStr};
 
 use super::RpcDescription;
 use crate::helpers::{generate_where_clause, is_option};
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, quote_spanned};
-use syn::punctuated::Punctuated;
-use syn::{parse_quote, token, AttrStyle, Attribute, Path, PathSegment, ReturnType};
+use syn::{parse_quote, punctuated::Punctuated, token, AttrStyle, Attribute, Path, PathSegment, ReturnType};
 
 impl RpcDescription {
 	pub(super) fn render_server(&self) -> Result<TokenStream2, syn::Error> {

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -281,7 +281,7 @@ impl RpcDescription {
 		sub: Option<proc_macro2::Ident>,
 	) -> (TokenStream2, TokenStream2) {
 		if params.is_empty() {
-			return (TokenStream2::default(), TokenStream2::default());
+			return (TokenStream2::default(), TokenStream2::default())
 		}
 
 		let params_fields_seq = params.iter().map(|(name, _)| name);
@@ -308,7 +308,7 @@ impl RpcDescription {
 							}
 						};
 					}
-				}
+				},
 				(true, None) => {
 					quote! {
 						let #name: #ty = match seq.optional_next() {
@@ -319,7 +319,7 @@ impl RpcDescription {
 							}
 						};
 					}
-				}
+				},
 				(false, Some(pending)) => {
 					quote! {
 						let #name: #ty = match seq.next() {
@@ -334,7 +334,7 @@ impl RpcDescription {
 							}
 						};
 					}
-				}
+				},
 				(false, None) => {
 					quote! {
 						let #name: #ty = match seq.next() {
@@ -345,7 +345,7 @@ impl RpcDescription {
 							}
 						};
 					}
-				}
+				},
 			});
 
 			quote! {

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -69,7 +69,7 @@ impl RpcMethod {
 		};
 
 		if blocking && sig.asyncness.is_some() {
-			return Err(syn::Error::new(sig.span(), "Blocking method must be synchronous"));
+			return Err(syn::Error::new(sig.span(), "Blocking method must be synchronous"))
 		}
 
 		let params: Vec<_> = sig
@@ -215,31 +215,31 @@ impl RpcDescription {
 		let server_bounds = optional(server_bounds, Argument::group)?;
 
 		if !needs_server && !needs_client {
-			return Err(syn::Error::new_spanned(&item.ident, "Either 'server' or 'client' attribute must be applied"));
+			return Err(syn::Error::new_spanned(&item.ident, "Either 'server' or 'client' attribute must be applied"))
 		}
 
 		if client_bounds.is_some() && !needs_client {
 			return Err(syn::Error::new_spanned(
 				&item.ident,
 				"Attribute 'client' must be specified with 'client_bounds'",
-			));
+			))
 		}
 
 		if server_bounds.is_some() && !needs_server {
 			return Err(syn::Error::new_spanned(
 				&item.ident,
 				"Attribute 'server' must be specified with 'server_bounds'",
-			));
+			))
 		}
 
 		let jsonrpsee_client_path = crate::helpers::find_jsonrpsee_client_crate().ok();
 		let jsonrpsee_server_path = crate::helpers::find_jsonrpsee_server_crate().ok();
 
 		if needs_client && jsonrpsee_client_path.is_none() {
-			return Err(syn::Error::new_spanned(&item.ident, "Unable to locate 'jsonrpsee' client dependency"));
+			return Err(syn::Error::new_spanned(&item.ident, "Unable to locate 'jsonrpsee' client dependency"))
 		}
 		if needs_server && jsonrpsee_server_path.is_none() {
-			return Err(syn::Error::new_spanned(&item.ident, "Unable to locate 'jsonrpsee' server dependency"));
+			return Err(syn::Error::new_spanned(&item.ident, "Unable to locate 'jsonrpsee' server dependency"))
 		}
 
 		item.attrs.clear(); // Remove RPC attributes.
@@ -252,7 +252,7 @@ impl RpcDescription {
 		for entry in item.items.iter() {
 			if let syn::TraitItem::Method(method) = entry {
 				if method.sig.receiver().is_none() {
-					return Err(syn::Error::new_spanned(&method.sig, "First argument of the trait must be '&self'"));
+					return Err(syn::Error::new_spanned(&method.sig, "First argument of the trait must be '&self'"))
 				}
 
 				let mut is_method = false;
@@ -269,15 +269,15 @@ impl RpcDescription {
 						return Err(syn::Error::new_spanned(
 							method,
 							"Element cannot be both subscription and method at the same time",
-						));
+						))
 					}
 
 					if !matches!(method.sig.output, syn::ReturnType::Default) {
-						return Err(syn::Error::new_spanned(method, "Subscription methods must not return anything"));
+						return Err(syn::Error::new_spanned(method, "Subscription methods must not return anything"))
 					}
 
 					if method.sig.asyncness.is_none() {
-						return Err(syn::Error::new_spanned(method, "Subscription methods must be `async`"));
+						return Err(syn::Error::new_spanned(method, "Subscription methods must be `async`"))
 					}
 
 					let sub_data = RpcSubscription::from_item(attr.clone(), method.clone())?;
@@ -288,15 +288,15 @@ impl RpcDescription {
 					return Err(syn::Error::new_spanned(
 						method,
 						"Methods must have either 'method' or 'subscription' attribute",
-					));
+					))
 				}
 			} else {
-				return Err(syn::Error::new_spanned(entry, "Only methods allowed in RPC traits"));
+				return Err(syn::Error::new_spanned(entry, "Only methods allowed in RPC traits"))
 			}
 		}
 
 		if methods.is_empty() && subscriptions.is_empty() {
-			return Err(syn::Error::new_spanned(&item, "RPC cannot be empty"));
+			return Err(syn::Error::new_spanned(&item, "RPC cannot be empty"))
 		}
 
 		Ok(Self {
@@ -353,7 +353,9 @@ impl RpcDescription {
 fn parse_aliases(arg: Result<Argument, MissingArgument>) -> syn::Result<Vec<String>> {
 	let aliases = optional(arg, Argument::value::<Aliases>)?;
 
-	Ok(aliases.map(|a| a.list.into_iter().map(|lit| lit.value()).collect()).unwrap_or_default())
+	Ok(aliases
+		.map(|a| a.list.into_iter().map(|lit| lit.value()).collect())
+		.unwrap_or_default())
 }
 
 fn parse_subscribe(arg: Result<Argument, MissingArgument>) -> syn::Result<Option<String>> {

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -28,14 +28,15 @@
 
 use std::borrow::Cow;
 
-use crate::attributes::{
-	optional, parse_param_kind, Aliases, Argument, AttributeMeta, MissingArgument, NameMapping, ParamKind,
+use crate::{
+	attributes::{
+		optional, parse_param_kind, Aliases, Argument, AttributeMeta, MissingArgument, NameMapping, ParamKind,
+	},
+	helpers::extract_doc_comments,
 };
-use crate::helpers::extract_doc_comments;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::spanned::Spanned;
-use syn::{punctuated::Punctuated, Attribute, Token};
+use syn::{punctuated::Punctuated, spanned::Spanned, Attribute, Token};
 
 #[derive(Debug, Clone)]
 pub struct RpcMethod {

--- a/proc-macros/src/visitor.rs
+++ b/proc-macros/src/visitor.rs
@@ -26,8 +26,10 @@
 
 use std::collections::HashSet;
 
-use syn::visit::{self, Visit};
-use syn::Ident;
+use syn::{
+	visit::{self, Visit},
+	Ident,
+};
 
 /// Visitor that parses generic type parameters from `syn::Type` by traversing the AST.
 /// A `syn::Type` can any type such as `Vec<T>, T, Foo<A<B<V>>>, usize or similar`.

--- a/proc-macros/src/visitor.rs
+++ b/proc-macros/src/visitor.rs
@@ -139,13 +139,12 @@ impl FindSubscriptionParams {
 					self.visit_type(&arg.ty);
 				}
 				self.visit_return_type(&ty.output);
-			}
+			},
 			syn::Type::Group(ty) => self.visit_type(&ty.elem),
-			syn::Type::ImplTrait(ty) => {
+			syn::Type::ImplTrait(ty) =>
 				for bound in &ty.bounds {
 					self.visit_type_param_bound(bound);
-				}
-			}
+				},
 			syn::Type::Macro(ty) => self.visit_macro(&ty.mac),
 			syn::Type::Paren(ty) => self.visit_type(&ty.elem),
 			syn::Type::Path(ty) => {
@@ -153,25 +152,23 @@ impl FindSubscriptionParams {
 					self.visit_type(&qself.ty);
 				}
 				self.visit_path(&ty.path);
-			}
+			},
 			syn::Type::Ptr(ty) => self.visit_type(&ty.elem),
 			syn::Type::Reference(ty) => self.visit_type(&ty.elem),
 			syn::Type::Slice(ty) => self.visit_type(&ty.elem),
-			syn::Type::TraitObject(ty) => {
+			syn::Type::TraitObject(ty) =>
 				for bound in &ty.bounds {
 					self.visit_type_param_bound(bound);
-				}
-			}
-			syn::Type::Tuple(ty) => {
+				},
+			syn::Type::Tuple(ty) =>
 				for elem in &ty.elems {
 					self.visit_type(elem);
-				}
-			}
+				},
 
-			syn::Type::Infer(_) | syn::Type::Never(_) | syn::Type::Verbatim(_) => {}
+			syn::Type::Infer(_) | syn::Type::Never(_) | syn::Type::Verbatim(_) => {},
 
 			#[cfg_attr(all(test, exhaustive), deny(non_exhaustive_omitted_patterns))]
-			_ => {}
+			_ => {},
 		}
 	}
 
@@ -183,31 +180,30 @@ impl FindSubscriptionParams {
 	/// Traverse syntax tree.
 	fn visit_path_arguments(&mut self, arguments: &syn::PathArguments) {
 		match arguments {
-			syn::PathArguments::None => {}
-			syn::PathArguments::AngleBracketed(arguments) => {
+			syn::PathArguments::None => {},
+			syn::PathArguments::AngleBracketed(arguments) =>
 				for arg in &arguments.args {
 					match arg {
 						syn::GenericArgument::Type(arg) => self.visit_type(arg),
 						syn::GenericArgument::Binding(arg) => self.visit_type(&arg.ty),
-						syn::GenericArgument::Lifetime(_)
-						| syn::GenericArgument::Constraint(_)
-						| syn::GenericArgument::Const(_) => {}
+						syn::GenericArgument::Lifetime(_) |
+						syn::GenericArgument::Constraint(_) |
+						syn::GenericArgument::Const(_) => {},
 					}
-				}
-			}
+				},
 			syn::PathArguments::Parenthesized(arguments) => {
 				for argument in &arguments.inputs {
 					self.visit_type(argument);
 				}
 				self.visit_return_type(&arguments.output);
-			}
+			},
 		}
 	}
 
 	/// Traverse syntax tree.
 	fn visit_return_type(&mut self, return_type: &syn::ReturnType) {
 		match return_type {
-			syn::ReturnType::Default => {}
+			syn::ReturnType::Default => {},
 			syn::ReturnType::Type(_, output) => self.visit_type(output),
 		}
 	}
@@ -216,7 +212,7 @@ impl FindSubscriptionParams {
 	fn visit_type_param_bound(&mut self, bound: &syn::TypeParamBound) {
 		match bound {
 			syn::TypeParamBound::Trait(bound) => self.visit_path(&bound.path),
-			syn::TypeParamBound::Lifetime(_) => {}
+			syn::TypeParamBound::Lifetime(_) => {},
 		}
 	}
 

--- a/proc-macros/tests/ui.rs
+++ b/proc-macros/tests/ui.rs
@@ -2,8 +2,9 @@
 //! check whether expected valid examples of code compile correctly, and for incorrect ones
 //! errors are helpful and valid (e.g. have correct spans).
 //!
-//! Use with `TRYBUILD=overwrite` after updating codebase (see `trybuild` docs for more details on that)
-//! to automatically regenerate `stderr` files, but don't forget to check that new files make sense.
+//! Use with `TRYBUILD=overwrite` after updating codebase (see `trybuild` docs for more details on
+//! that) to automatically regenerate `stderr` files, but don't forget to check that new files make
+//! sense.
 
 #[test]
 fn ui_pass() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,11 @@
+# Basic
 hard_tabs = true
 max_width = 120
 use_small_heuristics = "Max"
 edition = "2021"
+# Imports
+imports_granularity = "Crate"
+reorder_imports     = true
+# Format comments
+comment_width = 100
+wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,3 +9,14 @@ reorder_imports     = true
 # Format comments
 comment_width = 100
 wrap_comments = true
+# Misc
+chain_width = 80
+spaces_around_ranges = false
+binop_separator = "Back"
+reorder_impl_items = false
+match_arm_leading_pipes = "Preserve"
+match_arm_blocks = false
+match_block_trailing_comma = true
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,6 +9,8 @@ reorder_imports     = true
 # Format comments
 comment_width = 100
 wrap_comments = true
+# Consistency
+newline_style = "Unix"
 # Misc
 chain_width = 80
 spaces_around_ranges = false

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,7 +20,6 @@ soketto = { version = "0.7.1", features = ["http"] }
 tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tokio-stream = "0.1.7"
-http = "0.2.7"
 hyper = { version = "0.14", features = ["server", "http1", "http2"] }
 tower = "0.4.13"
 

--- a/server/src/future.rs
+++ b/server/src/future.rs
@@ -26,15 +26,19 @@
 
 //! Utilities for handling async code.
 
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+	future::Future,
+	pin::Pin,
+	sync::Arc,
+	task::{Context, Poll},
+};
 
 use futures_util::future::FutureExt;
 use jsonrpsee_core::Error;
-use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore, TryAcquireError};
-use tokio::time::{self, Duration, Interval};
+use tokio::{
+	sync::{watch, OwnedSemaphorePermit, Semaphore, TryAcquireError},
+	time::{self, Duration, Interval},
+};
 
 /// Polling for server stop monitor interval in milliseconds.
 const STOP_MONITOR_POLLING_INTERVAL: Duration = Duration::from_millis(1000);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -42,12 +42,17 @@ pub mod middleware;
 mod tests;
 
 pub use future::ServerHandle;
-pub use jsonrpsee_core::server::host_filtering::AllowHosts;
-pub use jsonrpsee_core::server::rpc_module::{
-	DisconnectError, PendingSubscriptionSink, RpcModule, SendTimeoutError, SubscriptionMessage, SubscriptionSink,
-	TrySendError,
+pub use jsonrpsee_core::{
+	id_providers::*,
+	server::{
+		host_filtering::AllowHosts,
+		rpc_module::{
+			DisconnectError, PendingSubscriptionSink, RpcModule, SendTimeoutError, SubscriptionMessage,
+			SubscriptionSink, TrySendError,
+		},
+	},
+	traits::IdProvider,
 };
-pub use jsonrpsee_core::{id_providers::*, traits::IdProvider};
 pub use jsonrpsee_types as types;
 pub use server::{Builder as ServerBuilder, Server};
 pub use tracing;

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -29,8 +29,8 @@
 use std::net::SocketAddr;
 
 /// HTTP request.
-pub type HttpRequest = http::Request<Body>;
-pub use http::HeaderMap as Headers;
+pub type HttpRequest = hyper::http::Request<Body>;
+pub use hyper::http::HeaderMap as Headers;
 pub use hyper::Body;
 pub use jsonrpsee_types::Params;
 

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -30,8 +30,7 @@ use std::net::SocketAddr;
 
 /// HTTP request.
 pub type HttpRequest = hyper::http::Request<Body>;
-pub use hyper::http::HeaderMap as Headers;
-pub use hyper::Body;
+pub use hyper::{http::HeaderMap as Headers, Body};
 pub use jsonrpsee_types::Params;
 
 /// The type JSON-RPC v2 call, it can be a subscription, method call or unknown.
@@ -80,11 +79,12 @@ impl std::fmt::Display for TransportProtocol {
 	}
 }
 
-/// Defines a logger specifically for WebSocket connections with callbacks during the RPC request life-cycle.
-/// The primary use case for this is to collect timings for a larger metrics collection solution.
+/// Defines a logger specifically for WebSocket connections with callbacks during the RPC request
+/// life-cycle. The primary use case for this is to collect timings for a larger metrics collection
+/// solution.
 ///
-/// See the [`ServerBuilder::set_logger`](../../jsonrpsee_server/struct.ServerBuilder.html#method.set_logger)
-/// for examples.
+/// See the [`ServerBuilder::set_logger`](../../jsonrpsee_server/struct.ServerBuilder.html#method.
+/// set_logger) for examples.
 pub trait Logger: Send + Sync + Clone + 'static {
 	/// Intended to carry timestamp of a request, for example `std::time::Instant`. How the trait
 	/// measures time, if at all, is entirely up to the implementation.
@@ -99,7 +99,8 @@ pub trait Logger: Send + Sync + Clone + 'static {
 	/// Called on each JSON-RPC method call, batch requests will trigger `on_call` multiple times.
 	fn on_call(&self, method_name: &str, params: Params, kind: MethodKind, transport: TransportProtocol);
 
-	/// Called on each JSON-RPC method completion, batch requests will trigger `on_result` multiple times.
+	/// Called on each JSON-RPC method completion, batch requests will trigger `on_result` multiple
+	/// times.
 	fn on_result(&self, method_name: &str, success: bool, started_at: Self::Instant, transport: TransportProtocol);
 
 	/// Called once the JSON-RPC request is finished and response is sent to the output buffer.

--- a/server/src/middleware/proxy_get_request.rs
+++ b/server/src/middleware/proxy_get_request.rs
@@ -35,7 +35,7 @@ impl ProxyGetRequestLayer {
 	pub fn new(path: impl Into<String>, method: impl Into<String>) -> Result<Self, RpcError> {
 		let path = path.into();
 		if !path.starts_with('/') {
-			return Err(RpcError::Custom("ProxyGetRequestLayer path must start with `/`".to_string()));
+			return Err(RpcError::Custom("ProxyGetRequestLayer path must start with `/`".to_string()))
 		}
 
 		Ok(Self { path, method: method.into() })
@@ -76,7 +76,7 @@ impl<S> ProxyGetRequest<S> {
 	/// Fails if the path does not start with `/`.
 	pub fn new(inner: S, path: &str, method: &str) -> Result<Self, RpcError> {
 		if !path.starts_with('/') {
-			return Err(RpcError::Custom(format!("ProxyGetRequest path must start with `/`, got: {path}")));
+			return Err(RpcError::Custom(format!("ProxyGetRequest path must start with `/`, got: {path}")))
 		}
 
 		Ok(Self { inner, path: Arc::from(path), method: Arc::from(method) })
@@ -110,7 +110,8 @@ where
 			*req.uri_mut() = Uri::from_static("/");
 
 			// Requests must have the following headers:
-			req.headers_mut().insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+			req.headers_mut()
+				.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 			req.headers_mut().insert(ACCEPT, HeaderValue::from_static("application/json"));
 
 			// Adjust the body to reflect the method call.
@@ -130,7 +131,7 @@ where
 
 			// Nothing to modify: return the response as is.
 			if !modify {
-				return Ok(res);
+				return Ok(res)
 			}
 
 			let body = res.into_body();

--- a/server/src/middleware/proxy_get_request.rs
+++ b/server/src/middleware/proxy_get_request.rs
@@ -2,16 +2,20 @@
 //! RPC method calls.
 
 use crate::transport::http;
-use hyper::header::{ACCEPT, CONTENT_TYPE};
-use hyper::http::HeaderValue;
-use hyper::{Body, Method, Request, Response, Uri};
+use hyper::{
+	header::{ACCEPT, CONTENT_TYPE},
+	http::HeaderValue,
+	Body, Method, Request, Response, Uri,
+};
 use jsonrpsee_core::error::Error as RpcError;
 use jsonrpsee_types::{Id, RequestSer};
-use std::error::Error;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+	error::Error,
+	future::Future,
+	pin::Pin,
+	sync::Arc,
+	task::{Context, Poll},
+};
 use tower::{Layer, Service};
 
 /// Layer that applies [`ProxyGetRequest`] which proxies the `GET /path` requests to

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -27,7 +27,12 @@ pub(crate) async fn server() -> SocketAddr {
 ///
 /// Returns the address together with handle for the server.
 pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
-	let server = ServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let server = ServerBuilder::default()
+		.build("127.0.0.1:0")
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	let ctx = TestContext;
 	let mut module = RpcModule::new(ctx);
 	module
@@ -70,7 +75,9 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 	module
 		.register_method("invalid_params", |_params, _| Err::<(), _>(CallError::InvalidParams(anyhow!("buh!")).into()))
 		.unwrap();
-	module.register_method("call_fail", |_params, _| Err::<(), _>(Error::to_call_error(MyAppError))).unwrap();
+	module
+		.register_method("call_fail", |_params, _| Err::<(), _>(Error::to_call_error(MyAppError)))
+		.unwrap();
 	module
 		.register_method("sleep_for", |params, _| {
 			let sleep: Vec<u64> = params.parse()?;
@@ -118,7 +125,12 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 
 /// Run server with user provided context.
 pub(crate) async fn server_with_context() -> SocketAddr {
-	let server = ServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let server = ServerBuilder::default()
+		.build("127.0.0.1:0")
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 
 	let ctx = TestContext;
 	let mut rpc_module = RpcModule::new(ctx);
@@ -161,7 +173,9 @@ pub(crate) async fn server_with_context() -> SocketAddr {
 }
 
 pub(crate) fn init_logger() {
-	let _ = FmtSubscriber::builder().with_env_filter(EnvFilter::from_default_env()).try_init();
+	let _ = FmtSubscriber::builder()
+		.with_env_filter(EnvFilter::from_default_env())
+		.try_init();
 }
 
 pub(crate) fn deser_call<T: DeserializeOwned>(raw: String) -> T {

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -1,13 +1,10 @@
-use std::fmt;
-use std::net::SocketAddr;
+use std::{fmt, net::SocketAddr};
 
-use crate::types::error::CallError;
-use crate::{RpcModule, ServerBuilder, ServerHandle};
+use crate::{types::error::CallError, RpcModule, ServerBuilder, ServerHandle};
 
 use anyhow::anyhow;
 use jsonrpsee_core::{DeserializeOwned, Error};
-use jsonrpsee_test_utils::mocks::TestContext;
-use jsonrpsee_test_utils::TimeoutFutureExt;
+use jsonrpsee_test_utils::{mocks::TestContext, TimeoutFutureExt};
 use jsonrpsee_types::Response;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -26,12 +26,13 @@
 
 use std::net::SocketAddr;
 
-use crate::types::error::CallError;
-use crate::{RpcModule, ServerBuilder, ServerHandle};
+use crate::{types::error::CallError, RpcModule, ServerBuilder, ServerHandle};
 use jsonrpsee_core::Error;
-use jsonrpsee_test_utils::helpers::*;
-use jsonrpsee_test_utils::mocks::{Id, StatusCode, TestContext};
-use jsonrpsee_test_utils::TimeoutFutureExt;
+use jsonrpsee_test_utils::{
+	helpers::*,
+	mocks::{Id, StatusCode, TestContext},
+	TimeoutFutureExt,
+};
 use serde_json::Value as JsonValue;
 
 fn init_logger() {
@@ -373,8 +374,8 @@ async fn invalid_json_id_missing_value() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
-	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be
-	// Null.
+	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid
+	// Request), it MUST be Null.
 	assert_eq!(response.body, parse_error(Id::Null));
 }
 

--- a/server/src/tests/shared.rs
+++ b/server/src/tests/shared.rs
@@ -1,5 +1,5 @@
 use crate::tests::helpers::{init_logger, server_with_handles};
-use http::StatusCode;
+use hyper::http::StatusCode;
 use jsonrpsee_core::Error;
 use jsonrpsee_test_utils::{
 	helpers::{http_request, ok_response, to_http_uri},

--- a/server/src/tests/shared.rs
+++ b/server/src/tests/shared.rs
@@ -45,8 +45,13 @@ async fn run_forever() {
 async fn http_only_works() {
 	use crate::{RpcModule, ServerBuilder};
 
-	let server =
-		ServerBuilder::default().http_only().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let server = ServerBuilder::default()
+		.http_only()
+		.build("127.0.0.1:0")
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	let mut module = RpcModule::new(());
 	module
 		.register_method("say_hello", |_, _| {
@@ -59,11 +64,19 @@ async fn http_only_works() {
 	let _server_handle = server.start(module).unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id":1}"#;
-	let response = http_request(req.into(), to_http_uri(addr)).with_default_timeout().await.unwrap().unwrap();
+	let response = http_request(req.into(), to_http_uri(addr))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, ok_response("hello".to_string().into(), Id::Num(1)));
 
-	let err = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap_err();
+	let err = WebSocketTestClient::new(addr)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap_err();
 	assert!(matches!(err, WebSocketTestError::RejectedWithStatusCode(code) if code == 403));
 }
 
@@ -71,7 +84,13 @@ async fn http_only_works() {
 async fn ws_only_works() {
 	use crate::{RpcModule, ServerBuilder};
 
-	let server = ServerBuilder::default().ws_only().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let server = ServerBuilder::default()
+		.ws_only()
+		.build("127.0.0.1:0")
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	let mut module = RpcModule::new(());
 	module
 		.register_method("say_hello", |_, _| {
@@ -84,7 +103,11 @@ async fn ws_only_works() {
 	let _server_handle = server.start(module).unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id":1}"#;
-	let response = http_request(req.into(), to_http_uri(addr)).with_default_timeout().await.unwrap().unwrap();
+	let response = http_request(req.into(), to_http_uri(addr))
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(response.status, StatusCode::FORBIDDEN);
 
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -359,7 +359,12 @@ async fn single_method_send_binary() {
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":[1, 2],"id":1}"#;
-	let response = client.send_request_binary(req.as_bytes()).with_default_timeout().await.unwrap().unwrap();
+	let response = client
+		.send_request_binary(req.as_bytes())
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(response, ok_response(JsonValue::Number(3.into()), Id::Num(1)));
 }
 
@@ -440,7 +445,12 @@ async fn parse_error_request_should_not_close_connection() {
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
 	let invalid_request = r#"{"jsonrpc":"2.0","method":"bar","params":[1,"id":99}"#;
-	let response1 = client.send_request_text(invalid_request).with_default_timeout().await.unwrap().unwrap();
+	let response1 = client
+		.send_request_text(invalid_request)
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(response1, parse_error(Id::Null));
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":33}"#;
 	let response2 = client.send_request_text(request).with_default_timeout().await.unwrap().unwrap();
@@ -529,8 +539,12 @@ async fn unsubscribe_wrong_sub_id_type() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
-	let unsub: bool =
-		deser_call(client.send_request_text(call("unsubscribe_hello", vec![13.99_f64], Id::Num(0))).await.unwrap());
+	let unsub: bool = deser_call(
+		client
+			.send_request_text(call("unsubscribe_hello", vec![13.99_f64], Id::Num(0)))
+			.await
+			.unwrap(),
+	);
 	assert!(!unsub);
 }
 
@@ -571,9 +585,15 @@ async fn custom_subscription_id_works() {
 
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
-	let sub = client.send_request_text(call("subscribe_hello", Vec::<()>::new(), Id::Num(0))).await.unwrap();
+	let sub = client
+		.send_request_text(call("subscribe_hello", Vec::<()>::new(), Id::Num(0)))
+		.await
+		.unwrap();
 	assert_eq!(&sub, r#"{"jsonrpc":"2.0","result":"0xdeadbeef","id":0}"#);
-	let unsub = client.send_request_text(call("unsubscribe_hello", vec!["0xdeadbeef"], Id::Num(1))).await.unwrap();
+	let unsub = client
+		.send_request_text(call("unsubscribe_hello", vec!["0xdeadbeef"], Id::Num(1)))
+		.await
+		.unwrap();
 	assert_eq!(&unsub, r#"{"jsonrpc":"2.0","result":true,"id":1}"#);
 }
 
@@ -652,7 +672,12 @@ async fn batch_with_mixed_calls() {
 			{"jsonrpc": "2.0", "method": "foo.get", "params": {"name": "myself"}, "id": "5"}
 		]"#;
 	let res = r#"[{"jsonrpc":"2.0","result":7,"id":"1"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request"},"id":null},{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":"5"}]"#;
-	let response = client.send_request_text(req.to_string()).with_default_timeout().await.unwrap().unwrap();
+	let response = client
+		.send_request_text(req.to_string())
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(response, res);
 }
 
@@ -668,7 +693,12 @@ async fn batch_notif_without_params_works() {
 			{"jsonrpc": "2.0", "method": "add"}
 		]"#;
 	let res = r#"[{"jsonrpc":"2.0","result":7,"id":"1"}]"#;
-	let response = client.send_request_text(req.to_string()).with_default_timeout().await.unwrap().unwrap();
+	let response = client
+		.send_request_text(req.to_string())
+		.with_default_timeout()
+		.await
+		.unwrap()
+		.unwrap();
 	assert_eq!(response, res);
 }
 
@@ -755,11 +785,11 @@ async fn ws_server_backpressure_works() {
 			match sub_notif.params.result {
 				1 if seen_backpressure_item => {
 					seen_item_after_backpressure = true;
-					break;
-				}
+					break
+				},
 				2 => {
 					seen_backpressure_item = true;
-				}
+				},
 				_ => (),
 			}
 		}
@@ -776,5 +806,9 @@ async fn notif_is_ignored() {
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
 	// This call should not be answered and a timeout is regarded as "not answered"
-	assert!(client.send_request_text(r#"{"jsonrpc":"2.0","method":"bar"}"#).with_default_timeout().await.is_err());
+	assert!(client
+		.send_request_text(r#"{"jsonrpc":"2.0","method":"bar"}"#)
+		.with_default_timeout()
+		.await
+		.is_err());
 }

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -24,14 +24,21 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::tests::helpers::{deser_call, init_logger, server_with_context};
-use crate::types::SubscriptionId;
-use crate::{RpcModule, ServerBuilder};
-use jsonrpsee_core::server::rpc_module::{SendTimeoutError, SubscriptionMessage};
-use jsonrpsee_core::{traits::IdProvider, Error};
-use jsonrpsee_test_utils::helpers::*;
-use jsonrpsee_test_utils::mocks::{Id, WebSocketTestClient, WebSocketTestError};
-use jsonrpsee_test_utils::TimeoutFutureExt;
+use crate::{
+	tests::helpers::{deser_call, init_logger, server_with_context},
+	types::SubscriptionId,
+	RpcModule, ServerBuilder,
+};
+use jsonrpsee_core::{
+	server::rpc_module::{SendTimeoutError, SubscriptionMessage},
+	traits::IdProvider,
+	Error,
+};
+use jsonrpsee_test_utils::{
+	helpers::*,
+	mocks::{Id, WebSocketTestClient, WebSocketTestError},
+	TimeoutFutureExt,
+};
 use jsonrpsee_types::SubscriptionResponse;
 use serde_json::Value as JsonValue;
 
@@ -373,8 +380,8 @@ async fn invalid_json_id_missing_value() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id"}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
-	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be
-	// Null.
+	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid
+	// Request), it MUST be Null.
 	assert_eq!(response, parse_error(Id::Null));
 }
 

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -6,7 +6,7 @@ use crate::logger::{self, Logger, TransportProtocol};
 
 use futures_util::future::Either;
 use futures_util::stream::{FuturesOrdered, StreamExt};
-use http::Method;
+use hyper::Method;
 use jsonrpsee_core::error::GenericTransportError;
 use jsonrpsee_core::http_helpers::read_body;
 use jsonrpsee_core::server::helpers::{batch_response_error, prepare_error, BatchResponseBuilder, MethodResponse};
@@ -23,7 +23,7 @@ type Notif<'a> = Notification<'a, Option<&'a JsonRawValue>>;
 
 /// Checks that content type of received request is valid for JSON-RPC.
 pub(crate) fn content_type_is_json(request: &hyper::Request<hyper::Body>) -> bool {
-	is_json(request.headers().get(http::header::CONTENT_TYPE))
+	is_json(request.headers().get(hyper::http::header::CONTENT_TYPE))
 }
 
 /// Returns true if the `content_type` header indicates a valid JSON message.

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -1,21 +1,26 @@
-use std::convert::Infallible;
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 
 use crate::logger::{self, Logger, TransportProtocol};
 
-use futures_util::future::Either;
-use futures_util::stream::{FuturesOrdered, StreamExt};
+use futures_util::{
+	future::Either,
+	stream::{FuturesOrdered, StreamExt},
+};
 use hyper::Method;
-use jsonrpsee_core::error::GenericTransportError;
-use jsonrpsee_core::http_helpers::read_body;
-use jsonrpsee_core::server::helpers::{batch_response_error, prepare_error, BatchResponseBuilder, MethodResponse};
-use jsonrpsee_core::server::rpc_module::MethodCallback;
-use jsonrpsee_core::server::rpc_module::Methods;
-use jsonrpsee_core::tracing::{rx_log_from_json, tx_log_from_str};
-use jsonrpsee_core::JsonRawValue;
-use jsonrpsee_types::error::{ErrorCode, BATCHES_NOT_SUPPORTED_CODE, BATCHES_NOT_SUPPORTED_MSG};
-use jsonrpsee_types::{ErrorObject, Id, InvalidRequest, Notification, Params, Request};
+use jsonrpsee_core::{
+	error::GenericTransportError,
+	http_helpers::read_body,
+	server::{
+		helpers::{batch_response_error, prepare_error, BatchResponseBuilder, MethodResponse},
+		rpc_module::{MethodCallback, Methods},
+	},
+	tracing::{rx_log_from_json, tx_log_from_str},
+	JsonRawValue,
+};
+use jsonrpsee_types::{
+	error::{ErrorCode, BATCHES_NOT_SUPPORTED_CODE, BATCHES_NOT_SUPPORTED_MSG},
+	ErrorObject, Id, InvalidRequest, Notification, Params, Request,
+};
 use tokio::sync::OwnedSemaphorePermit;
 use tracing::instrument;
 
@@ -312,9 +317,10 @@ pub(crate) async fn handle_request<L: Logger>(
 }
 
 pub(crate) mod response {
-	use jsonrpsee_types::error::reject_too_big_request;
-	use jsonrpsee_types::error::{ErrorCode, ErrorResponse};
-	use jsonrpsee_types::Id;
+	use jsonrpsee_types::{
+		error::{reject_too_big_request, ErrorCode, ErrorResponse},
+		Id,
+	};
 
 	const JSON: &str = "application/json; charset=utf-8";
 	const TEXT: &str = "text/plain";

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -363,9 +363,7 @@ pub(crate) async fn background_task<L: Logger>(
 						tracing::debug!("WS transport error: {}; terminate connection: {}", err, conn_id);
 						break Err(err.into())
 					},
-					MonitoredError::Shutdown => {
-						break Ok(())
-					},
+					MonitoredError::Shutdown => break Ok(()),
 				};
 			};
 		};
@@ -509,9 +507,7 @@ async fn send_task(
 			},
 
 			// Nothing else to receive.
-			Either::Left((None, _)) => {
-				break
-			},
+			Either::Left((None, _)) => break,
 
 			// Handle timer intervals.
 			Either::Right((Either::Left((_, stop)), next_rx)) => {
@@ -524,9 +520,7 @@ async fn send_task(
 			},
 
 			// Server is stopped or closed
-			Either::Right((Either::Right(_), _)) => {
-				break
-			},
+			Either::Right((Either::Right(_), _)) => break,
 		}
 	}
 

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -51,7 +51,12 @@ pub fn to_ws_uri_string(addr: SocketAddr) -> String {
 /// Converts a sockaddress to a HTTP URI.
 pub fn to_http_uri(sockaddr: SocketAddr) -> Uri {
 	let s = sockaddr.to_string();
-	Uri::builder().scheme("http").authority(s.as_str()).path_and_query("/").build().unwrap()
+	Uri::builder()
+		.scheme("http")
+		.authority(s.as_str())
+		.path_and_query("/")
+		.build()
+		.unwrap()
 }
 
 pub fn ok_response(result: Value, id: Id) -> String {

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -24,12 +24,13 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::convert::Infallible;
-use std::net::SocketAddr;
+use std::{convert::Infallible, net::SocketAddr};
 
 use crate::mocks::{Body, HttpResponse, Id, Uri};
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Client, Request, Response, Server};
+use hyper::{
+	service::{make_service_fn, service_fn},
+	Client, Request, Response, Server,
+};
 use serde::Serialize;
 use serde_json::Value;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -28,8 +28,7 @@
 
 #![recursion_limit = "256"]
 
-use std::future::Future;
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
 use tokio::time::{timeout, Timeout};
 

--- a/test-utils/src/mocks.rs
+++ b/test-utils/src/mocks.rs
@@ -24,17 +24,16 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::io;
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{io, net::SocketAddr, time::Duration};
 
-use futures_channel::mpsc;
-use futures_channel::oneshot;
-use futures_util::future::FutureExt;
-use futures_util::io::{BufReader, BufWriter};
-use futures_util::sink::SinkExt;
-use futures_util::stream::{self, StreamExt};
-use futures_util::{pin_mut, select};
+use futures_channel::{mpsc, oneshot};
+use futures_util::{
+	future::FutureExt,
+	io::{BufReader, BufWriter},
+	pin_mut, select,
+	sink::SinkExt,
+	stream::{self, StreamExt},
+};
 use serde::{Deserialize, Serialize};
 use soketto::handshake::{self, http::is_upgrade_request, server::Response, Error as SokettoError, Server};
 use tokio::net::TcpStream;
@@ -163,8 +162,8 @@ pub struct WebSocketTestServer {
 }
 
 impl WebSocketTestServer {
-	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded response` for every
-	// connection.
+	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded response`
+	// for every connection.
 	pub async fn with_hardcoded_response(sockaddr: SocketAddr, response: String) -> Self {
 		let listener = tokio::net::TcpListener::bind(sockaddr).await.unwrap();
 		let local_addr = listener.local_addr().unwrap();
@@ -174,8 +173,8 @@ impl WebSocketTestServer {
 		Self { local_addr, exit: tx }
 	}
 
-	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded notification` for every
-	// connection.
+	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured `hardcoded
+	// notification` for every connection.
 	pub async fn with_hardcoded_notification(sockaddr: SocketAddr, notification: String) -> Self {
 		let (tx, rx) = mpsc::unbounded();
 		let (addr_tx, addr_rx) = oneshot::channel();
@@ -193,8 +192,8 @@ impl WebSocketTestServer {
 		Self { local_addr, exit: tx }
 	}
 
-	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured subscription ID and subscription
-	// response.
+	// Spawns a dummy `JSONRPC v2` WebSocket server that sends out a pre-configured subscription ID and
+	// subscription response.
 	//
 	// NOTE: ignores the actual subscription and unsubscription method.
 	pub async fn with_hardcoded_subscription(
@@ -328,7 +327,8 @@ async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut ex
 }
 
 // Run a WebSocket server running on localhost that redirects requests for testing.
-// Requests to any url except for `/myblock/two` will redirect one or two times (HTTP 301) and eventually end up in `/myblock/two`.
+// Requests to any url except for `/myblock/two` will redirect one or two times (HTTP 301) and
+// eventually end up in `/myblock/two`.
 pub fn ws_server_with_redirect(other_server: String) -> String {
 	let addr = ([127, 0, 0, 1], 0).into();
 

--- a/test-utils/src/mocks.rs
+++ b/test-utils/src/mocks.rs
@@ -107,11 +107,10 @@ impl WebSocketTestClient {
 			Ok(handshake::ServerResponse::Accepted { .. }) => {
 				let (tx, rx) = client.into_builder().finish();
 				Ok(Self { tx, rx })
-			}
+			},
 			Ok(handshake::ServerResponse::Redirect { .. }) => Err(WebSocketTestError::Redirect),
-			Ok(handshake::ServerResponse::Rejected { status_code }) => {
-				Err(WebSocketTestError::RejectedWithStatusCode(status_code))
-			}
+			Ok(handshake::ServerResponse::Rejected { status_code }) =>
+				Err(WebSocketTestError::RejectedWithStatusCode(status_code)),
 			Err(err) => Err(WebSocketTestError::Soketto(err)),
 		}
 	}
@@ -258,7 +257,7 @@ async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut ex
 	let accept = server.send_response(&Response::Accept { key, protocol: None }).await;
 
 	if accept.is_err() {
-		return;
+		return
 	}
 
 	let (mut sender, receiver) = server.into_builder().finish();
@@ -364,12 +363,15 @@ async fn handler(
 					.body(Body::empty())
 					.unwrap();
 				Ok(response)
-			}
+			},
 			"/myblock/one" => {
-				let response =
-					hyper::Response::builder().status(301).header("Location", "two").body(Body::empty()).unwrap();
+				let response = hyper::Response::builder()
+					.status(301)
+					.header("Location", "two")
+					.body(Body::empty())
+					.unwrap();
 				Ok(response)
-			}
+			},
 			_ => {
 				let response = hyper::Response::builder()
 					.status(301)
@@ -377,7 +379,7 @@ async fn handler(
 					.body(Body::empty())
 					.unwrap();
 				Ok(response)
-			}
+			},
 		}
 	} else {
 		panic!("expect upgrade to WS");

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -26,18 +26,21 @@
 
 #![cfg(test)]
 
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
 use futures::{SinkExt, Stream, StreamExt};
-use jsonrpsee::core::server::host_filtering::AllowHosts;
-use jsonrpsee::core::server::rpc_module::{SubscriptionMessage, TrySendError};
-use jsonrpsee::core::{Error, SubscriptionResult};
-use jsonrpsee::server::middleware::proxy_get_request::ProxyGetRequestLayer;
-use jsonrpsee::server::{ServerBuilder, ServerHandle};
-use jsonrpsee::types::error::ErrorObject;
-use jsonrpsee::types::ErrorObjectOwned;
-use jsonrpsee::{PendingSubscriptionSink, RpcModule};
+use jsonrpsee::{
+	core::{
+		server::{
+			host_filtering::AllowHosts,
+			rpc_module::{SubscriptionMessage, TrySendError},
+		},
+		Error, SubscriptionResult,
+	},
+	server::{middleware::proxy_get_request::ProxyGetRequestLayer, ServerBuilder, ServerHandle},
+	types::{error::ErrorObject, ErrorObjectOwned},
+	PendingSubscriptionSink, RpcModule,
+};
 use serde::Serialize;
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -83,8 +83,8 @@ pub async fn server_with_subscription_and_handle() -> (SocketAddr, ServerHandle)
 					Ok(count) => count,
 					Err(e) => {
 						let _ = pending.reject(ErrorObjectOwned::from(e)).await;
-						return Ok(());
-					}
+						return Ok(())
+					},
 				};
 
 				let wrapping_counter = futures::stream::iter((count..).cycle());
@@ -147,7 +147,9 @@ pub async fn server() -> SocketAddr {
 		})
 		.unwrap();
 
-	module.register_async_method("err", |_, _| async { Err::<(), _>(Error::Custom("err".to_string())) }).unwrap();
+	module
+		.register_async_method("err", |_, _| async { Err::<(), _>(Error::Custom("err".to_string())) })
+		.unwrap();
 
 	let addr = server.local_addr().unwrap();
 
@@ -209,7 +211,9 @@ pub async fn server_with_access_control(allowed_hosts: AllowHosts, cors: CorsLay
 	module.register_method("say_hello", |_, _| Ok("hello")).unwrap();
 	module.register_method("notif", |_, _| Ok("")).unwrap();
 
-	module.register_method("system_health", |_, _| Ok(serde_json::json!({ "health": true }))).unwrap();
+	module
+		.register_method("system_health", |_, _| Ok(serde_json::json!({ "health": true })))
+		.unwrap();
 
 	let handle = server.start(module).unwrap();
 	(addr, handle)

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -29,8 +29,7 @@
 
 mod helpers;
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use futures::{channel::mpsc, StreamExt, TryStreamExt};
 use helpers::{
@@ -38,14 +37,18 @@ use helpers::{
 	server_with_subscription, server_with_subscription_and_handle,
 };
 use hyper::http::HeaderValue;
-use jsonrpsee::core::client::{ClientT, IdKind, Subscription, SubscriptionClientT};
-use jsonrpsee::core::params::{ArrayParams, BatchRequestBuilder};
-use jsonrpsee::core::server::rpc_module::SubscriptionMessage;
-use jsonrpsee::core::{Error, JsonValue};
-use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::rpc_params;
-use jsonrpsee::types::error::{ErrorObject, UNKNOWN_ERROR_CODE};
-use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::{
+	core::{
+		client::{ClientT, IdKind, Subscription, SubscriptionClientT},
+		params::{ArrayParams, BatchRequestBuilder},
+		server::rpc_module::SubscriptionMessage,
+		Error, JsonValue,
+	},
+	http_client::HttpClientBuilder,
+	rpc_params,
+	types::error::{ErrorObject, UNKNOWN_ERROR_CODE},
+	ws_client::WsClientBuilder,
+};
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 use tower_http::cors::CorsLayer;
@@ -81,8 +84,8 @@ async fn ws_unsubscription_works() {
 	let mut sub: Subscription<usize> =
 		client.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo").await.unwrap();
 
-	// It's technically possible to have race-conditions between the notifications and the unsubscribe message.
-	// So let's wait for the first notification and then unsubscribe.
+	// It's technically possible to have race-conditions between the notifications and the unsubscribe
+	// message. So let's wait for the first notification and then unsubscribe.
 	let _item = sub.next().await.unwrap().unwrap();
 
 	sub.unsubscribe().await.unwrap();
@@ -236,9 +239,9 @@ async fn ws_subscription_several_clients_with_drop() {
 		drop(client);
 	}
 
-	// make sure nothing weird happened after dropping half of the clients (should be `unsubscribed` in the server)
-	// would be good to know that subscriptions actually were removed but not possible to verify at
-	// this layer.
+	// make sure nothing weird happened after dropping half of the clients (should be `unsubscribed` in
+	// the server) would be good to know that subscriptions actually were removed but not possible to
+	// verify at this layer.
 	for _ in 0..10 {
 		for (client, hello_sub, foo_sub) in &mut clients {
 			assert!(client.is_connected());
@@ -732,8 +735,11 @@ async fn http_batch_works() {
 #[tokio::test]
 async fn ws_server_limit_subs_per_conn_works() {
 	use futures::StreamExt;
-	use jsonrpsee::types::error::{CallError, TOO_MANY_SUBSCRIPTIONS_CODE, TOO_MANY_SUBSCRIPTIONS_MSG};
-	use jsonrpsee::{server::ServerBuilder, RpcModule};
+	use jsonrpsee::{
+		server::ServerBuilder,
+		types::error::{CallError, TOO_MANY_SUBSCRIPTIONS_CODE, TOO_MANY_SUBSCRIPTIONS_MSG},
+		RpcModule,
+	};
 
 	init_logger();
 
@@ -787,8 +793,7 @@ async fn ws_server_limit_subs_per_conn_works() {
 #[tokio::test]
 async fn ws_server_unsub_methods_should_ignore_sub_limit() {
 	use futures::StreamExt;
-	use jsonrpsee::core::client::SubscriptionKind;
-	use jsonrpsee::{server::ServerBuilder, RpcModule};
+	use jsonrpsee::{core::client::SubscriptionKind, server::ServerBuilder, RpcModule};
 
 	init_logger();
 
@@ -945,16 +950,17 @@ async fn http_cors_preflight_works() {
 	let allow_methods = comma_separated_header_values(preflight_headers, "access-control-allow-methods");
 	let allow_headers = comma_separated_header_values(preflight_headers, "access-control-allow-headers");
 
-	// We expect the preflight response to tell us that our origin, methods and headers are all OK to use.
-	// If they aren't, the browser will not make the actual request. Note that if these `access-control-*`
-	// headers aren't return, the default is that the origin/method/headers are not allowed, I think.
+	// We expect the preflight response to tell us that our origin, methods and headers are all OK to
+	// use. If they aren't, the browser will not make the actual request. Note that if these
+	// `access-control-*` headers aren't return, the default is that the origin/method/headers are not
+	// allowed, I think.
 	assert!(preflight_res.status().is_success());
 	assert!(has(&allow_origins, "https://foo.com") || has(&allow_origins, "*"));
 	assert!(has(&allow_methods, "post") || has(&allow_methods, "*"));
 	assert!(has(&allow_headers, "content-type") || has(&allow_headers, "*"));
 
-	// Assuming that that was successful, we now make the actual request. No CORS headers are needed here
-	// as the browser checked their validity in the preflight request.
+	// Assuming that that was successful, we now make the actual request. No CORS headers are needed
+	// here as the browser checked their validity in the preflight request.
 	let req = Request::builder()
 		.method(Method::POST)
 		.uri(&uri)

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -60,10 +60,14 @@ async fn ws_subscription_works() {
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let mut hello_sub: Subscription<String> =
-		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
-	let mut foo_sub: Subscription<u64> =
-		client.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo").await.unwrap();
+	let mut hello_sub: Subscription<String> = client
+		.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+		.await
+		.unwrap();
+	let mut foo_sub: Subscription<u64> = client
+		.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo")
+		.await
+		.unwrap();
 
 	for _ in 0..10 {
 		let hello = hello_sub.next().await.unwrap().unwrap();
@@ -79,10 +83,16 @@ async fn ws_unsubscription_works() {
 
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
-	let client = WsClientBuilder::default().max_concurrent_requests(1).build(&server_url).await.unwrap();
+	let client = WsClientBuilder::default()
+		.max_concurrent_requests(1)
+		.build(&server_url)
+		.await
+		.unwrap();
 
-	let mut sub: Subscription<usize> =
-		client.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo").await.unwrap();
+	let mut sub: Subscription<usize> = client
+		.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo")
+		.await
+		.unwrap();
 
 	// It's technically possible to have race-conditions between the notifications and the unsubscribe
 	// message. So let's wait for the first notification and then unsubscribe.
@@ -98,7 +108,7 @@ async fn ws_unsubscription_works() {
 		let res: Result<String, _> = client.request("say_hello", rpc_params![]).await;
 		if res.is_ok() {
 			success = true;
-			break;
+			break
 		}
 		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 	}
@@ -113,8 +123,10 @@ async fn ws_subscription_with_input_works() {
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let mut add_one: Subscription<u64> =
-		client.subscribe("subscribe_add_one", rpc_params![1], "unsubscribe_add_one").await.unwrap();
+	let mut add_one: Subscription<u64> = client
+		.subscribe("subscribe_add_one", rpc_params![1], "unsubscribe_add_one")
+		.await
+		.unwrap();
 
 	for i in 2..4 {
 		let next = add_one.next().await.unwrap().unwrap();
@@ -139,7 +151,11 @@ async fn ws_method_call_str_id_works() {
 
 	let server_addr = server().await;
 	let server_url = format!("ws://{}", server_addr);
-	let client = WsClientBuilder::default().id_format(IdKind::String).build(&server_url).await.unwrap();
+	let client = WsClientBuilder::default()
+		.id_format(IdKind::String)
+		.build(&server_url)
+		.await
+		.unwrap();
 	let response: String = client.request("say_hello", rpc_params![]).await.unwrap();
 	assert_eq!(&response, "hello");
 }
@@ -193,10 +209,14 @@ async fn ws_subscription_several_clients() {
 	let mut clients = Vec::with_capacity(10);
 	for _ in 0..10 {
 		let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-		let hello_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
-		let foo_sub: Subscription<JsonValue> =
-			client.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo").await.unwrap();
+		let hello_sub: Subscription<JsonValue> = client
+			.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+			.await
+			.unwrap();
+		let foo_sub: Subscription<JsonValue> = client
+			.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo")
+			.await
+			.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 }
@@ -215,10 +235,14 @@ async fn ws_subscription_several_clients_with_drop() {
 			.build(&server_url)
 			.await
 			.unwrap();
-		let hello_sub: Subscription<String> =
-			client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
-		let foo_sub: Subscription<u64> =
-			client.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo").await.unwrap();
+		let hello_sub: Subscription<String> = client
+			.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+			.await
+			.unwrap();
+		let foo_sub: Subscription<u64> = client
+			.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo")
+			.await
+			.unwrap();
 		clients.push((client, hello_sub, foo_sub))
 	}
 
@@ -260,9 +284,15 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
 
-	let client = WsClientBuilder::default().max_buffer_capacity_per_subscription(4).build(&server_url).await.unwrap();
-	let mut hello_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+	let client = WsClientBuilder::default()
+		.max_buffer_capacity_per_subscription(4)
+		.build(&server_url)
+		.await
+		.unwrap();
+	let mut hello_sub: Subscription<JsonValue> = client
+		.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+		.await
+		.unwrap();
 
 	// don't poll the subscription stream for 2 seconds, should be full now.
 	tokio::time::sleep(Duration::from_secs(2)).await;
@@ -278,8 +308,10 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 	let _hello_req: JsonValue = client.request("say_hello", rpc_params![]).await.unwrap();
 
 	// The same subscription should be possible to register again.
-	let mut other_sub: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+	let mut other_sub: Subscription<JsonValue> = client
+		.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+		.await
+		.unwrap();
 
 	other_sub.next().await.unwrap().unwrap();
 }
@@ -290,7 +322,13 @@ async fn ws_making_more_requests_than_allowed_should_not_deadlock() {
 
 	let server_addr = server().await;
 	let server_url = format!("ws://{}", server_addr);
-	let client = Arc::new(WsClientBuilder::default().max_concurrent_requests(2).build(&server_url).await.unwrap());
+	let client = Arc::new(
+		WsClientBuilder::default()
+			.max_concurrent_requests(2)
+			.build(&server_url)
+			.await
+			.unwrap(),
+	);
 
 	let mut requests = Vec::new();
 
@@ -310,7 +348,10 @@ async fn http_making_more_requests_than_allowed_should_not_deadlock() {
 
 	let server_addr = server().await;
 	let server_url = format!("http://{}", server_addr);
-	let client = HttpClientBuilder::default().max_concurrent_requests(2).build(&server_url).unwrap();
+	let client = HttpClientBuilder::default()
+		.max_concurrent_requests(2)
+		.build(&server_url)
+		.unwrap();
 	let client = Arc::new(client);
 
 	let mut requests = Vec::new();
@@ -329,7 +370,9 @@ async fn http_making_more_requests_than_allowed_should_not_deadlock() {
 async fn https_works() {
 	init_logger();
 
-	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io:443").unwrap();
+	let client = HttpClientBuilder::default()
+		.build("https://kusama-rpc.polkadot.io:443")
+		.unwrap();
 	let response: String = client.request("system_chain", rpc_params![]).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
@@ -338,7 +381,10 @@ async fn https_works() {
 async fn wss_works() {
 	init_logger();
 
-	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io:443").await.unwrap();
+	let client = WsClientBuilder::default()
+		.build("wss://kusama-rpc.polkadot.io:443")
+		.await
+		.unwrap();
 	let response: String = client.request("system_chain", rpc_params![]).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
@@ -366,13 +412,21 @@ async fn ws_unsubscribe_releases_request_slots() {
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
 
-	let client = WsClientBuilder::default().max_concurrent_requests(1).build(&server_url).await.unwrap();
+	let client = WsClientBuilder::default()
+		.max_concurrent_requests(1)
+		.build(&server_url)
+		.await
+		.unwrap();
 
-	let sub1: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+	let sub1: Subscription<JsonValue> = client
+		.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+		.await
+		.unwrap();
 	drop(sub1);
-	let _: Subscription<JsonValue> =
-		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+	let _: Subscription<JsonValue> = client
+		.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+		.await
+		.unwrap();
 }
 
 #[tokio::test]
@@ -384,8 +438,10 @@ async fn server_should_be_able_to_close_subscriptions() {
 
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
-	let mut sub: Subscription<String> =
-		client.subscribe("subscribe_noop", rpc_params![], "unsubscribe_noop").await.unwrap();
+	let mut sub: Subscription<String> = client
+		.subscribe("subscribe_noop", rpc_params![], "unsubscribe_noop")
+		.await
+		.unwrap();
 
 	assert!(sub.next().await.is_none());
 }
@@ -399,8 +455,10 @@ async fn ws_close_pending_subscription_when_server_terminated() {
 
 	let c1 = WsClientBuilder::default().build(&server_url).await.unwrap();
 
-	let mut sub: Subscription<String> =
-		c1.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+	let mut sub: Subscription<String> = c1
+		.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+		.await
+		.unwrap();
 
 	assert!(matches!(sub.next().await, Some(Ok(_))));
 
@@ -461,8 +519,10 @@ async fn ws_server_should_stop_subscription_after_client_drop() {
 
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
-	let mut sub: Subscription<usize> =
-		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+	let mut sub: Subscription<usize> = client
+		.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello")
+		.await
+		.unwrap();
 
 	let res = sub.next().await.unwrap().unwrap();
 
@@ -492,7 +552,10 @@ async fn ws_server_stop_subscription_when_dropped() {
 	let _handle = server.start(module).unwrap();
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
-	assert!(client.subscribe::<String, ArrayParams>("subscribe_nop", rpc_params![], "unsubscribe_nop").await.is_err());
+	assert!(client
+		.subscribe::<String, ArrayParams>("subscribe_nop", rpc_params![], "unsubscribe_nop")
+		.await
+		.is_err());
 }
 
 #[tokio::test]
@@ -604,10 +667,14 @@ async fn ws_server_subscribe_with_stream() {
 	let server_url = format!("ws://{}", addr);
 
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let mut sub1: Subscription<usize> =
-		client.subscribe("subscribe_5_ints", rpc_params![], "unsubscribe_5_ints").await.unwrap();
-	let mut sub2: Subscription<usize> =
-		client.subscribe("subscribe_5_ints", rpc_params![], "unsubscribe_5_ints").await.unwrap();
+	let mut sub1: Subscription<usize> = client
+		.subscribe("subscribe_5_ints", rpc_params![], "unsubscribe_5_ints")
+		.await
+		.unwrap();
+	let mut sub2: Subscription<usize> = client
+		.subscribe("subscribe_5_ints", rpc_params![], "unsubscribe_5_ints")
+		.await
+		.unwrap();
 
 	let (r1, r2) = futures::future::try_join(
 		sub1.by_ref().take(2).try_collect::<Vec<_>>(),
@@ -640,7 +707,10 @@ async fn ws_server_pipe_from_stream_should_cancel_tasks_immediately() {
 
 	for _ in 0..10 {
 		subs.push(
-			client.subscribe::<i32, ArrayParams>("subscribe_sleep", rpc_params![], "unsubscribe_sleep").await.unwrap(),
+			client
+				.subscribe::<i32, ArrayParams>("subscribe_sleep", rpc_params![], "unsubscribe_sleep")
+				.await
+				.unwrap(),
 		)
 	}
 
@@ -743,7 +813,11 @@ async fn ws_server_limit_subs_per_conn_works() {
 
 	init_logger();
 
-	let server = ServerBuilder::default().max_subscriptions_per_connection(10).build("127.0.0.1:0").await.unwrap();
+	let server = ServerBuilder::default()
+		.max_subscriptions_per_connection(10)
+		.build("127.0.0.1:0")
+		.await
+		.unwrap();
 	let server_url = format!("ws://{}", server.local_addr().unwrap());
 
 	let mut module = RpcModule::new(());
@@ -777,8 +851,12 @@ async fn ws_server_limit_subs_per_conn_works() {
 		);
 	}
 
-	let err1 = c1.subscribe::<usize, ArrayParams>("subscribe_forever", rpc_params![], "unsubscribe_forever").await;
-	let err2 = c1.subscribe::<usize, ArrayParams>("subscribe_forever", rpc_params![], "unsubscribe_forever").await;
+	let err1 = c1
+		.subscribe::<usize, ArrayParams>("subscribe_forever", rpc_params![], "unsubscribe_forever")
+		.await;
+	let err2 = c1
+		.subscribe::<usize, ArrayParams>("subscribe_forever", rpc_params![], "unsubscribe_forever")
+		.await;
 
 	let data = "\"Exceeded max limit of 10\"";
 
@@ -797,7 +875,11 @@ async fn ws_server_unsub_methods_should_ignore_sub_limit() {
 
 	init_logger();
 
-	let server = ServerBuilder::default().max_subscriptions_per_connection(10).build("127.0.0.1:0").await.unwrap();
+	let server = ServerBuilder::default()
+		.max_subscriptions_per_connection(10)
+		.build("127.0.0.1:0")
+		.await
+		.unwrap();
 	let server_url = format!("ws://{}", server.local_addr().unwrap());
 
 	let mut module = RpcModule::new(());
@@ -1010,7 +1092,11 @@ async fn http_health_api_works() {
 	let http_client = Client::new();
 	let uri = format!("http://{}/health", server_addr);
 
-	let req = Request::builder().method("GET").uri(&uri).body(Body::empty()).expect("request builder");
+	let req = Request::builder()
+		.method("GET")
+		.uri(&uri)
+		.body(Body::empty())
+		.expect("request builder");
 	let res = http_client.request(req).await.unwrap();
 
 	assert!(res.status().is_success());
@@ -1028,7 +1114,11 @@ async fn ws_host_filtering_wildcard_works() {
 
 	let acl = AllowHosts::Only(vec!["http://localhost:*".into(), "http://127.0.0.1:*".into()]);
 
-	let server = ServerBuilder::default().set_host_filtering(acl).build("127.0.0.1:0").await.unwrap();
+	let server = ServerBuilder::default()
+		.set_host_filtering(acl)
+		.build("127.0.0.1:0")
+		.await
+		.unwrap();
 	let mut module = RpcModule::new(());
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| Ok("hello")).unwrap();
@@ -1049,7 +1139,11 @@ async fn http_host_filtering_wildcard_works() {
 
 	let allowed_hosts = AllowHosts::Only(vec!["http://localhost:*".into(), "http://127.0.0.1:*".into()]);
 
-	let server = ServerBuilder::default().set_host_filtering(allowed_hosts).build("127.0.0.1:0").await.unwrap();
+	let server = ServerBuilder::default()
+		.set_host_filtering(allowed_hosts)
+		.build("127.0.0.1:0")
+		.await
+		.unwrap();
 	let mut module = RpcModule::new(());
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| Ok("hello")).unwrap();
@@ -1070,7 +1164,11 @@ async fn deny_invalid_host() {
 
 	let allowed_hosts = AllowHosts::Only(vec!["http://example.com".into()]);
 
-	let server = ServerBuilder::default().set_host_filtering(allowed_hosts).build("127.0.0.1:0").await.unwrap();
+	let server = ServerBuilder::default()
+		.set_host_filtering(allowed_hosts)
+		.build("127.0.0.1:0")
+		.await
+		.unwrap();
 	let mut module = RpcModule::new(());
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| Ok("hello")).unwrap();

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -26,21 +26,27 @@
 
 mod helpers;
 
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+	collections::HashMap,
+	net::SocketAddr,
+	sync::{Arc, Mutex},
+	time::Duration,
+};
 
 use helpers::init_logger;
-use jsonrpsee::core::{client::ClientT, Error};
-use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::rpc_params;
-use jsonrpsee::server::logger::{HttpRequest, Logger, MethodKind, TransportProtocol};
-use jsonrpsee::server::{ServerBuilder, ServerHandle};
-use jsonrpsee::types::Params;
-use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::RpcModule;
+use jsonrpsee::{
+	core::{client::ClientT, Error},
+	http_client::HttpClientBuilder,
+	proc_macros::rpc,
+	rpc_params,
+	server::{
+		logger::{HttpRequest, Logger, MethodKind, TransportProtocol},
+		ServerBuilder, ServerHandle,
+	},
+	types::Params,
+	ws_client::WsClientBuilder,
+	RpcModule,
+};
 use tokio::time::sleep;
 
 #[derive(Clone, Default)]

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -31,21 +31,26 @@ mod helpers;
 use std::net::SocketAddr;
 
 use helpers::init_logger;
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::core::{client::SubscriptionClientT, Error};
-use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::rpc_params;
-use jsonrpsee::server::ServerBuilder;
-use jsonrpsee::types::error::{CallError, ErrorCode};
+use jsonrpsee::{
+	core::{
+		client::{ClientT, SubscriptionClientT},
+		Error,
+	},
+	http_client::HttpClientBuilder,
+	rpc_params,
+	server::ServerBuilder,
+	types::error::{CallError, ErrorCode},
+};
 
 use jsonrpsee::ws_client::*;
 use serde_json::json;
 
 mod rpc_impl {
-	use jsonrpsee::core::server::rpc_module::SubscriptionMessage;
-	use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
-	use jsonrpsee::proc_macros::rpc;
-	use jsonrpsee::PendingSubscriptionSink;
+	use jsonrpsee::{
+		core::{async_trait, server::rpc_module::SubscriptionMessage, RpcResult, SubscriptionResult},
+		proc_macros::rpc,
+		PendingSubscriptionSink,
+	};
 
 	#[rpc(client, server, namespace = "foo")]
 	pub trait Rpc {

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -270,7 +270,10 @@ async fn macro_optional_param_parsing() {
 	assert_eq!(&res, "Called with: 42, Some(70), None");
 
 	// Optional param using `null`
-	let res: String = module.call("foo_optional_params", [json!(42_u64), json!(null), json!(70_u64)]).await.unwrap();
+	let res: String = module
+		.call("foo_optional_params", [json!(42_u64), json!(null), json!(70_u64)])
+		.await
+		.unwrap();
 
 	assert_eq!(&res, "Called with: 42, None, Some(70)");
 
@@ -367,7 +370,10 @@ async fn calls_with_bad_params() {
 	);
 
 	// Call with faulty params as array.
-	let err: Error = client.request::<String, ArrayParams>("foo_foo", rpc_params!["faulty", "ok"]).await.unwrap_err();
+	let err: Error = client
+		.request::<String, ArrayParams>("foo_foo", rpc_params!["faulty", "ok"])
+		.await
+		.unwrap_err();
 	assert!(
 		matches!(err, Error::Call(CallError::Custom (err)) if err.message().contains("invalid type: string \"faulty\", expected u8") && err.code() == ErrorCode::InvalidParams.code())
 	);
@@ -376,8 +382,10 @@ async fn calls_with_bad_params() {
 	let mut params = ObjectParams::new();
 	params.insert("val", "0x0").unwrap();
 
-	let err: Error =
-		client.subscribe::<String, ObjectParams>("foo_echo", params, "foo_unsubscribe_echo").await.unwrap_err();
+	let err: Error = client
+		.subscribe::<String, ObjectParams>("foo_echo", params, "foo_unsubscribe_echo")
+		.await
+		.unwrap_err();
 	assert!(
 		matches!(err, Error::Call(CallError::Custom (err)) if err.message().contains("invalid type: string \"0x0\", expected u32") && err.code() == ErrorCode::InvalidParams.code())
 	);

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -26,19 +26,26 @@
 
 mod helpers;
 
-use std::collections::{HashMap, VecDeque};
-use std::time::Duration;
+use std::{
+	collections::{HashMap, VecDeque},
+	time::Duration,
+};
 
 use futures::StreamExt;
 use helpers::{init_logger, pipe_from_stream_and_drop};
-use jsonrpsee::core::error::{Error, SubscriptionCallbackError};
-use jsonrpsee::core::server::rpc_module::*;
-use jsonrpsee::core::EmptyServerParams;
-use jsonrpsee::types::error::{CallError, ErrorCode, ErrorObject, PARSE_ERROR_CODE};
-use jsonrpsee::types::{ErrorObjectOwned, Params};
+use jsonrpsee::{
+	core::{
+		error::{Error, SubscriptionCallbackError},
+		server::rpc_module::*,
+		EmptyServerParams,
+	},
+	types::{
+		error::{CallError, ErrorCode, ErrorObject, PARSE_ERROR_CODE},
+		ErrorObjectOwned, Params,
+	},
+};
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
-use tokio::time::interval;
+use tokio::{sync::mpsc, time::interval};
 use tokio_stream::wrappers::IntervalStream;
 
 // Helper macro to assert that a binding is of a specific type.

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -81,7 +81,9 @@ fn flatten_rpc_modules() {
 #[test]
 fn rpc_context_modules_can_register_subscriptions() {
 	let mut cxmodule = RpcModule::new(());
-	cxmodule.register_subscription("hi", "hi", "goodbye", |_, _, _| async { Ok(()) }).unwrap();
+	cxmodule
+		.register_subscription("hi", "hi", "goodbye", |_, _, _| async { Ok(()) })
+		.unwrap();
 
 	assert!(cxmodule.method("hi").is_some());
 	assert!(cxmodule.method("goodbye").is_some());
@@ -208,17 +210,26 @@ async fn calling_method_without_server_using_proc_macro() {
 	assert!(!res);
 
 	// Call sync method with params
-	let res: String = module.call("rebel", (Gun { shoots: true }, HashMap::<u8, u8>::default())).await.unwrap();
+	let res: String = module
+		.call("rebel", (Gun { shoots: true }, HashMap::<u8, u8>::default()))
+		.await
+		.unwrap();
 	assert_eq!(&res, "0 Gun { shoots: true }");
 
 	// Call sync method with bad params
-	let err = module.call::<_, EmptyServerParams>("rebel", (Gun { shoots: true }, false)).await.unwrap_err();
+	let err = module
+		.call::<_, EmptyServerParams>("rebel", (Gun { shoots: true }, false))
+		.await
+		.unwrap_err();
 	assert!(matches!(err,
 		Error::Call(CallError::Custom(err)) if err.code() == -32602 && err.message() == "invalid type: boolean `false`, expected a map at line 1 column 5"
 	));
 
 	// Call async method with params and context
-	let result: String = module.call("revolution", (Beverage { ice: true }, vec![1, 2, 3])).await.unwrap();
+	let result: String = module
+		.call("revolution", (Beverage { ice: true }, vec![1, 2, 3]))
+		.await
+		.unwrap();
 	assert_eq!(&result, "drink: Beverage { ice: true }, phases: [1, 2, 3]");
 
 	// Call async method with option which is `Some`
@@ -287,7 +298,7 @@ async fn close_test_subscribing_without_server() {
 
 			match sink.send(msg).await {
 				Ok(_) => panic!("The sink should be closed"),
-				Err(DisconnectError(_)) => {}
+				Err(DisconnectError(_)) => {},
 			}
 			Ok(())
 		})
@@ -328,8 +339,8 @@ async fn subscribing_without_server_bad_params() {
 				Err(e) => {
 					let err: ErrorObjectOwned = e.into();
 					let _ = pending.reject(err).await;
-					return Err(SubscriptionCallbackError::None);
-				}
+					return Err(SubscriptionCallbackError::None)
+				},
 			};
 
 			let sink = pending.accept().await.unwrap();
@@ -340,7 +351,10 @@ async fn subscribing_without_server_bad_params() {
 		})
 		.unwrap();
 
-	let sub = module.subscribe_unbounded("my_sub", EmptyServerParams::new()).await.unwrap_err();
+	let sub = module
+		.subscribe_unbounded("my_sub", EmptyServerParams::new())
+		.await
+		.unwrap_err();
 
 	assert!(
 		matches!(sub, Error::Call(CallError::Custom(e)) if e.message().contains("invalid length 0, expected an array of length 1 at line 1 column 2") && e.code() == ErrorCode::InvalidParams.code())
@@ -419,7 +433,10 @@ async fn rejected_subscription_without_server() {
 		})
 		.unwrap();
 
-	let sub_err = module.subscribe_unbounded("my_sub", EmptyServerParams::new()).await.unwrap_err();
+	let sub_err = module
+		.subscribe_unbounded("my_sub", EmptyServerParams::new())
+		.await
+		.unwrap_err();
 	assert!(
 		matches!(sub_err, Error::Call(CallError::Custom(e)) if e.message().contains("rejected") && e.code() == PARSE_ERROR_CODE)
 	);
@@ -438,7 +455,10 @@ async fn reject_works() {
 		})
 		.unwrap();
 
-	let sub_err = module.subscribe_unbounded("my_sub", EmptyServerParams::new()).await.unwrap_err();
+	let sub_err = module
+		.subscribe_unbounded("my_sub", EmptyServerParams::new())
+		.await
+		.unwrap_err();
 	assert!(
 		matches!(sub_err, Error::Call(CallError::Custom(e)) if e.message().contains("rejected") && e.code() == PARSE_ERROR_CODE)
 	);
@@ -470,7 +490,7 @@ async fn bounded_subscription_works() {
 					Err(TrySendError::Closed(_)) => panic!("This is a bug"),
 					Err(TrySendError::Full(m)) => {
 						buf.push_back(m);
-					}
+					},
 					Ok(_) => (),
 				}
 			}
@@ -484,7 +504,7 @@ async fn bounded_subscription_works() {
 					Err(TrySendError::Closed(_)) => panic!("This is a bug"),
 					Err(TrySendError::Full(m)) => {
 						buf.push_front(m);
-					}
+					},
 					Ok(_) => (),
 				}
 

--- a/tests/wasm-tests/tests/wasm.rs
+++ b/tests/wasm-tests/tests/wasm.rs
@@ -47,8 +47,10 @@ async fn rpc_method_call_works() {
 async fn rpc_subcription_works() {
 	let client = WasmClientBuilder::default().build("ws://localhost:9944").await.unwrap();
 
-	let mut sub: Subscription<serde_json::Value> =
-		client.subscribe("state_subscribeStorage", rpc_params![], "state_unsubscribeStorage").await.unwrap();
+	let mut sub: Subscription<serde_json::Value> = client
+		.subscribe("state_subscribeStorage", rpc_params![], "state_unsubscribeStorage")
+		.await
+		.unwrap();
 
 	for _ in 0..3 {
 		let val = sub.next().await.unwrap();

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -27,12 +27,9 @@
 use std::fmt;
 
 use crate::params::{Id, TwoPointZero};
-use serde::de::Deserializer;
-use serde::ser::Serializer;
-use serde::{Deserialize, Serialize};
+use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
 use serde_json::value::RawValue;
-use std::borrow::Borrow;
-use std::borrow::Cow as StdCow;
+use std::borrow::{Borrow, Cow as StdCow};
 use thiserror::Error;
 
 /// [Failed JSON-RPC response object](https://www.jsonrpc.org/specification#response_object).
@@ -332,7 +329,8 @@ impl CallError {
 	}
 }
 
-/// Helper to get a `JSON-RPC` error object when the maximum number of subscriptions have been exceeded.
+/// Helper to get a `JSON-RPC` error object when the maximum number of subscriptions have been
+/// exceeded.
 pub fn reject_too_many_subscriptions(limit: u32) -> ErrorObject<'static> {
 	ErrorObjectOwned::owned(
 		TOO_MANY_SUBSCRIPTIONS_CODE,

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -178,14 +178,14 @@ impl<'a> ParamsSequence<'a> {
 				self.0 = "";
 
 				tracing::trace!("[next_inner] Reached end of sequence.");
-				return None;
-			}
+				return None
+			},
 			b'[' | b',' => json = &json[1..],
 			_ => {
 				let errmsg = format!("Invalid params. Expected one of '[', ']' or ',' but found {json:?}");
 				tracing::error!("[next_inner] {}", errmsg);
-				return Some(Err(CallError::InvalidParams(anyhow!(errmsg))));
-			}
+				return Some(Err(CallError::InvalidParams(anyhow!(errmsg))))
+			},
 		}
 
 		let mut iter = serde_json::Deserializer::from_str(json).into_iter::<T>();
@@ -195,7 +195,7 @@ impl<'a> ParamsSequence<'a> {
 				self.0 = json[iter.byte_offset()..].trim_start();
 
 				Some(Ok(value))
-			}
+			},
 			Err(e) => {
 				tracing::error!(
 					"[next_inner] Deserialization to {:?} failed. Error: {:?}, input JSON: {:?}",
@@ -206,7 +206,7 @@ impl<'a> ParamsSequence<'a> {
 				self.0 = "";
 
 				Some(Err(CallError::InvalidParams(e.into())))
-			}
+			},
 		}
 	}
 
@@ -304,13 +304,12 @@ impl<'a> TryFrom<JsonValue> for SubscriptionId<'a> {
 	fn try_from(json: JsonValue) -> Result<SubscriptionId<'a>, ()> {
 		match json {
 			JsonValue::String(s) => Ok(SubscriptionId::Str(s.into())),
-			JsonValue::Number(n) => {
+			JsonValue::Number(n) =>
 				if let Some(n) = n.as_u64() {
 					Ok(SubscriptionId::Num(n))
 				} else {
 					Err(())
-				}
-			}
+				},
 			_ => Err(()),
 		}
 	}
@@ -402,7 +401,7 @@ mod test {
 			Id::Str(ref cow) => {
 				assert!(cow.is_borrowed());
 				assert_eq!(cow, "2");
-			}
+			},
 			_ => panic!("Expected Id::Str"),
 		}
 

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -25,16 +25,19 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Types to handle JSON-RPC request parameters according to the [spec](https://www.jsonrpc.org/specification#parameter_structures).
-//! Some types come with a "*Ser" variant that implements [`serde::Serialize`]; these are used in the client.
+//! Some types come with a "*Ser" variant that implements [`serde::Serialize`]; these are used in
+//! the client.
 
 use std::fmt;
 
 use crate::error::CallError;
 use anyhow::anyhow;
 use beef::Cow;
-use serde::de::{self, Deserializer, Unexpected, Visitor};
-use serde::ser::Serializer;
-use serde::{Deserialize, Serialize};
+use serde::{
+	de::{self, Deserializer, Unexpected, Visitor},
+	ser::Serializer,
+	Deserialize, Serialize,
+};
 use serde_json::Value as JsonValue;
 
 /// JSON-RPC v2 marker type.
@@ -81,9 +84,9 @@ impl Serialize for TwoPointZero {
 
 /// Parameters sent with an incoming JSON-RPC request.
 ///
-/// The data containing the params is a `Cow<&str>` and can either be a borrowed `&str` of JSON from an incoming
-/// [`super::request::Request`] (which in turn borrows it from the input buffer that is shared between requests);
-/// or, it can be an owned [`String`].
+/// The data containing the params is a `Cow<&str>` and can either be a borrowed `&str` of JSON from
+/// an incoming [`super::request::Request`] (which in turn borrows it from the input buffer that is
+/// shared between requests); or, it can be an owned [`String`].
 #[derive(Clone, Debug)]
 pub struct Params<'a>(Option<Cow<'a, str>>);
 
@@ -104,8 +107,9 @@ impl<'a> Params<'a> {
 
 	/// Obtain a sequence parser, [`ParamsSequence`].
 	///
-	/// This allows sequential parsing of the incoming params, using an `Iterator`-style API and is useful when the RPC
-	/// request has optional parameters at the tail that may or may not be present.
+	/// This allows sequential parsing of the incoming params, using an `Iterator`-style API and is
+	/// useful when the RPC request has optional parameters at the tail that may or may not be
+	/// present.
 	pub fn sequence(&self) -> ParamsSequence {
 		let json = match self.0.as_ref() {
 			// It's assumed that params is `[a,b,c]`, if empty regard as no params.
@@ -126,7 +130,8 @@ impl<'a> Params<'a> {
 		serde_json::from_str(params).map_err(|e| CallError::InvalidParams(e.into()))
 	}
 
-	/// Attempt to parse parameters as an array of a single value of type `T`, and returns that value.
+	/// Attempt to parse parameters as an array of a single value of type `T`, and returns that
+	/// value.
 	pub fn one<T>(&'a self) -> Result<T, CallError>
 	where
 		T: Deserialize<'a>,
@@ -152,9 +157,10 @@ impl<'a> Params<'a> {
 
 /// An `Iterator`-like parser for a sequence of [`Params`].
 ///
-/// This will parse the params one at a time, and allows for graceful handling of optional parameters at the tail; other
-/// use cases are likely better served by [`Params::parse`]. The reason this is not an actual [`Iterator`] is that
-/// params parsing (often) yields values of different types.
+/// This will parse the params one at a time, and allows for graceful handling of optional
+/// parameters at the tail; other use cases are likely better served by [`Params::parse`]. The
+/// reason this is not an actual [`Iterator`] is that params parsing (often) yields values of
+/// different types.
 ///
 /// Regards empty array `[]` as no parameters provided.
 #[derive(Debug, Copy, Clone)]
@@ -311,7 +317,8 @@ impl<'a> TryFrom<JsonValue> for SubscriptionId<'a> {
 }
 
 impl<'a> SubscriptionId<'a> {
-	/// Convert `SubscriptionId<'a>` to `SubscriptionId<'static>` so that it can be moved across threads.
+	/// Convert `SubscriptionId<'a>` to `SubscriptionId<'static>` so that it can be moved across
+	/// threads.
 	///
 	/// This can cause an allocation if the id is a string.
 	pub fn into_owned(self) -> SubscriptionId<'static> {

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -25,7 +25,8 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Types to handle JSON-RPC requests according to the [spec](https://www.jsonrpc.org/specification#request-object).
-//! Some types come with a "*Ser" variant that implements [`serde::Serialize`]; these are used in the client.
+//! Some types come with a "*Ser" variant that implements [`serde::Serialize`]; these are used in
+//! the client.
 
 use std::borrow::Cow as StdCow;
 

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -28,8 +28,10 @@
 
 use std::fmt;
 
-use crate::params::{Id, SubscriptionId, TwoPointZero};
-use crate::request::Notification;
+use crate::{
+	params::{Id, SubscriptionId, TwoPointZero},
+	request::Notification,
+};
 use serde::{Deserialize, Serialize};
 
 /// JSON-RPC successful response object as defined in the [spec](https://www.jsonrpc.org/specification#response_object).
@@ -72,9 +74,11 @@ pub struct SubscriptionPayload<'a, T> {
 	pub result: T,
 }
 
-/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member along with `result` field.
+/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member along
+/// with `result` field.
 pub type SubscriptionResponse<'a, T> = Notification<'a, SubscriptionPayload<'a, T>>;
-/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member along with `error` field.
+/// Subscription response object, embedding a [`SubscriptionPayload`] in the `params` member along
+/// with `error` field.
 pub type SubscriptionError<'a, T> = Notification<'a, SubscriptionPayloadError<'a, T>>;
 
 /// Error value for subscriptions.


### PR DESCRIPTION
The current import items are a bit of a mess.  Updating the format rule as the substrate repo.

- https://github.com/paritytech/substrate/blob/master/rustfmt.toml

No logic update, just format.