### PR TITLE
Make `jsonrpc` protocol version field in `Response` as `Option`

### DIFF
--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Response<'a, T> {
 	/// JSON-RPC version.
-	pub jsonrpc: TwoPointZero,
+	pub jsonrpc: Option<TwoPointZero>,
 	/// Result.
 	pub result: T,
 	/// Request ID
@@ -47,7 +47,7 @@ pub struct Response<'a, T> {
 impl<'a, T> Response<'a, T> {
 	/// Create a new [`Response`].
 	pub fn new(result: T, id: Id<'a>) -> Response<'a, T> {
-		Response { jsonrpc: TwoPointZero, result, id }
+		Response { jsonrpc: Some(TwoPointZero), result, id }
 	}
 
 	/// Create an owned [`Response`].
@@ -93,14 +93,14 @@ mod tests {
 
 	#[test]
 	fn serialize_call_response() {
-		let ser = serde_json::to_string(&Response { jsonrpc: TwoPointZero, result: "ok", id: Id::Number(1) }).unwrap();
+		let ser = serde_json::to_string(&Response { jsonrpc: Some(TwoPointZero), result: "ok", id: Id::Number(1) }).unwrap();
 		let exp = r#"{"jsonrpc":"2.0","result":"ok","id":1}"#;
 		assert_eq!(ser, exp);
 	}
 
 	#[test]
 	fn deserialize_call() {
-		let exp = Response { jsonrpc: TwoPointZero, result: 99_u64, id: Id::Number(11) };
+		let exp = Response { jsonrpc: Some(TwoPointZero), result: 99_u64, id: Id::Number(11) };
 		let dsr: Response<u64> = serde_json::from_str(r#"{"jsonrpc":"2.0", "result":99, "id":11}"#).unwrap();
 		assert_eq!(dsr.jsonrpc, exp.jsonrpc);
 		assert_eq!(dsr.result, exp.result);

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Response<'a, T> {
 	/// JSON-RPC version.
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub jsonrpc: Option<TwoPointZero>,
 	/// Result.
 	pub result: T,
@@ -102,7 +103,7 @@ mod tests {
 	#[test]
 	fn serialize_call_response_missing_version_field() {
 		let ser = serde_json::to_string(&Response { jsonrpc: None, result: "ok", id: Id::Number(1) }).unwrap();
-		let exp = r#"{"jsonrpc":null,"result":"ok","id":1}"#;
+		let exp = r#"{"result":"ok","id":1}"#;
 		assert_eq!(ser, exp);
 	}
 

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -99,9 +99,25 @@ mod tests {
 	}
 
 	#[test]
+	fn serialize_call_response_missing_version_field() {
+		let ser = serde_json::to_string(&Response { jsonrpc: None, result: "ok", id: Id::Number(1) }).unwrap();
+		let exp = r#"{"jsonrpc":null,"result":"ok","id":1}"#;
+		assert_eq!(ser, exp);
+	}
+
+	#[test]
 	fn deserialize_call() {
 		let exp = Response { jsonrpc: Some(TwoPointZero), result: 99_u64, id: Id::Number(11) };
 		let dsr: Response<u64> = serde_json::from_str(r#"{"jsonrpc":"2.0", "result":99, "id":11}"#).unwrap();
+		assert_eq!(dsr.jsonrpc, exp.jsonrpc);
+		assert_eq!(dsr.result, exp.result);
+		assert_eq!(dsr.id, exp.id);
+	}
+
+	#[test]
+	fn deserialize_call_missing_version_field() {
+		let exp = Response { jsonrpc: None, result: 99_u64, id: Id::Number(11) };
+		let dsr: Response<u64> = serde_json::from_str(r#"{"jsonrpc":null, "result":99, "id":11}"#).unwrap();
 		assert_eq!(dsr.jsonrpc, exp.jsonrpc);
 		assert_eq!(dsr.result, exp.result);
 		assert_eq!(dsr.id, exp.id);

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -93,7 +93,8 @@ mod tests {
 
 	#[test]
 	fn serialize_call_response() {
-		let ser = serde_json::to_string(&Response { jsonrpc: Some(TwoPointZero), result: "ok", id: Id::Number(1) }).unwrap();
+		let ser =
+			serde_json::to_string(&Response { jsonrpc: Some(TwoPointZero), result: "ok", id: Id::Number(1) }).unwrap();
 		let exp = r#"{"jsonrpc":"2.0","result":"ok","id":1}"#;
 		assert_eq!(ser, exp);
 	}


### PR DESCRIPTION
# Problem
JSON-RPC 2.0 specification does not require `jsonrpc` version in responses as a mandatory field: [JSON-RPC 2.0 Spec](https://www.jsonrpc.org/specification#response_object)
For RPC servers that put this value to `null`, the lib can't deserialize this responses, 'cause it actually requires this field to be present

# Solution
Make `jsonrpc` field in `Response` as `Option`.

Fixes #1045