### PR TITLE
fix: tokio v1.27

### DIFF
--- a/server/src/future.rs
+++ b/server/src/future.rs
@@ -132,9 +132,6 @@ where
 
 /// Represent a stop handle which is a wrapper over a `multi-consumer receiver`
 /// and cloning [`StopHandle`] will get a separate instance of the underlying receiver.
-///
-/// This means that `shutdown_requested` and `shutdown` can't be called
-/// on the same [`StopHandle`]
 #[derive(Debug, Clone)]
 pub(crate) struct StopHandle(watch::Receiver<()>);
 
@@ -144,8 +141,7 @@ impl StopHandle {
 	}
 
 	/// A future that resolves when server has been stopped
-	/// it consumes the stop handle such that [`StopHandle::shutdown_requested`]
-	/// can't be called on the same [`StopHandle`].
+	/// it consumes the stop handle.
 	pub(crate) async fn shutdown(mut self) {
 		let _ = self.0.changed().await;
 	}

--- a/server/src/future.rs
+++ b/server/src/future.rs
@@ -34,10 +34,6 @@ use std::task::{Context, Poll};
 use futures_util::future::FutureExt;
 use jsonrpsee_core::Error;
 use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore, TryAcquireError};
-use tokio::time::{self, Duration, Interval};
-
-/// Polling for server stop monitor interval in milliseconds.
-const STOP_MONITOR_POLLING_INTERVAL: Duration = Duration::from_millis(1000);
 
 /// This is a flexible collection of futures that need to be driven to completion
 /// alongside some other future, such as connection handlers that need to be
@@ -47,16 +43,11 @@ const STOP_MONITOR_POLLING_INTERVAL: Duration = Duration::from_millis(1000);
 /// `select_with` providing some other future, the result of which you need.
 pub(crate) struct FutureDriver<F> {
 	futures: Vec<F>,
-	stop_monitor_heartbeat: Interval,
 }
 
 impl<F> Default for FutureDriver<F> {
 	fn default() -> Self {
-		let mut heartbeat = time::interval(STOP_MONITOR_POLLING_INTERVAL);
-
-		heartbeat.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
-
-		FutureDriver { futures: Vec::new(), stop_monitor_heartbeat: heartbeat }
+		FutureDriver { futures: Vec::new() }
 	}
 }
 
@@ -93,12 +84,6 @@ where
 				i += 1;
 			}
 		}
-	}
-
-	fn poll_stop_monitor_heartbeat(&mut self, cx: &mut Context) {
-		// We don't care about the ticks of the heartbeat, it's here only
-		// to periodically wake the `Waker` on `cx`.
-		let _ = self.stop_monitor_heartbeat.poll_tick(cx);
 	}
 }
 
@@ -140,12 +125,16 @@ where
 		let this = Pin::into_inner(self);
 
 		this.driver.drive(cx);
-		this.driver.poll_stop_monitor_heartbeat(cx);
 
 		this.selector.poll_unpin(cx)
 	}
 }
 
+/// Represent a stop handle which is a wrapper over a `multi-consumer receiver`
+/// and cloning [`StopHandle`] will get a separate instance of the underlying receiver.
+///
+/// This means that `shutdown_requested` and `shutdown` can't be called
+/// on the same [`StopHandle`]
 #[derive(Debug, Clone)]
 pub(crate) struct StopHandle(watch::Receiver<()>);
 
@@ -154,14 +143,10 @@ impl StopHandle {
 		Self(rx)
 	}
 
-	pub(crate) fn shutdown_requested(&self) -> bool {
-		// if a message has been seen, it means that `stop` has been called.
-		self.0.has_changed().unwrap_or(true)
-	}
-
-	pub(crate) async fn shutdown(&mut self) {
-		// Err(_) implies that the `sender` has been dropped.
-		// Ok(_) implies that `stop` has been called.
+	/// A future that resolves when server has been stopped
+	/// it consumes the stop handle such that [`StopHandle::shutdown_requested`]
+	/// can't be called on the same [`StopHandle`].
+	pub(crate) async fn shutdown(mut self) {
 		let _ = self.0.changed().await;
 	}
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -168,6 +168,10 @@ where
 			}
 		}
 
+		// FuturesUnordered won't poll anything until this line but because the
+		// tasks are spawned (so that they can progress independently)
+		// then this just makes sure that all tasks are completed before
+		// returning from this function.
 		while connections.next().await.is_some() {}
 	}
 }

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -1,5 +1,3 @@
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::future::{FutureDriver, StopHandle};
@@ -14,7 +12,9 @@ use hyper::upgrade::Upgraded;
 use jsonrpsee_core::server::helpers::{
 	batch_response_error, prepare_error, BatchResponseBuilder, MethodResponse, MethodSink,
 };
-use jsonrpsee_core::server::{BoundedSubscriptions, CallOrSubscription, MethodCallback, Methods, SubscriptionState};
+use jsonrpsee_core::server::{
+	BoundedSubscriptions, CallOrSubscription, MethodCallback, MethodSinkPermit, Methods, SubscriptionState,
+};
 use jsonrpsee_core::tracing::{rx_log_from_json, tx_log_from_str};
 use jsonrpsee_core::traits::IdProvider;
 use jsonrpsee_core::{Error, JsonRawValue};
@@ -67,40 +67,6 @@ pub(crate) struct CallData<'a, L: Logger> {
 	pub(crate) sink: &'a MethodSink,
 	pub(crate) logger: &'a L,
 	pub(crate) request_start: L::Instant,
-}
-
-/// This is a glorified select listening for new messages, while also checking the `stop_receiver` signal.
-struct Monitored<'a, F> {
-	future: F,
-	stop_monitor: &'a StopHandle,
-}
-
-impl<'a, F> Monitored<'a, F> {
-	fn new(future: F, stop_monitor: &'a StopHandle) -> Self {
-		Monitored { future, stop_monitor }
-	}
-}
-
-enum MonitoredError<E> {
-	Shutdown,
-	Selector(E),
-}
-
-impl<'a, 'f, F, T, E> Future for Monitored<'a, Pin<&'f mut F>>
-where
-	F: Future<Output = Result<T, E>>,
-{
-	type Output = Result<T, MonitoredError<E>>;
-
-	fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-		let this = Pin::into_inner(self);
-
-		if this.stop_monitor.shutdown_requested() {
-			return Poll::Ready(Err(MonitoredError::Shutdown));
-		}
-
-		this.future.poll_unpin(cx).map_err(MonitoredError::Selector)
-	}
 }
 
 // Batch responses must be sent back as a single message so we read the results from each
@@ -285,54 +251,41 @@ pub(crate) async fn background_task<L: Logger>(
 	// Spawn another task that sends out the responses on the Websocket.
 	tokio::spawn(send_task(rx, sender, stop_handle.clone(), ping_interval, conn_rx));
 
+	tracing::info!("background task");
+
 	// Buffer for incoming data.
 	let mut data = Vec::with_capacity(100);
-	let mut method_executors = FutureDriver::default();
+	let mut method_executor = FutureDriver::default();
 	let logger = &logger;
+	let stopped = stop_handle.shutdown();
+
+	tokio::pin!(stopped);
 
 	let result = loop {
 		data.clear();
 
-		let sink_permit_fut = sink.reserve();
-
-		tokio::pin!(sink_permit_fut);
-
-		// Wait until there is a slot in the bounded channel which means that
-		// the underlying TCP socket won't be read.
-		//
-		// This will force the client to read socket on the other side
-		// otherwise the socket will not be read again.
-		let sink_permit = match method_executors.select_with(Monitored::new(sink_permit_fut, &stop_handle)).await {
-			Ok(permit) => permit,
-			Err(_) => break Ok(()),
+		let sink_permit = match wait_for_permit(&sink, &mut method_executor, stopped).await {
+			Some((p, s)) => {
+				stopped = s;
+				p
+			}
+			None => break Ok(()),
 		};
 
-		{
-			// Need the extra scope to drop this pinned future and reclaim access to `data`
-			let receive = async {
-				// Identical loop to `soketto::receive_data` with debug logs for `Pong` frames.
-				loop {
-					match receiver.receive(&mut data).await? {
-						soketto::Incoming::Data(d) => break Ok(d),
-						soketto::Incoming::Pong(_) => tracing::debug!("Received pong"),
-						soketto::Incoming::Closed(_) => {
-							// The closing reason is already logged by `soketto` trace log level.
-							// Return the `Closed` error to avoid logging unnecessary warnings on clean shutdown.
-							break Err(SokettoError::Closed);
-						}
-					}
-				}
-			};
+		match try_recv(&mut receiver, &mut data, &mut method_executor, stopped).await {
+			Receive::Shutdown => break Ok(()),
+			Receive::Ok(stop) => {
+				stopped = stop;
+			}
+			Receive::Err(err, stop) => {
+				stopped = stop;
 
-			tokio::pin!(receive);
-
-			if let Err(err) = method_executors.select_with(Monitored::new(receive, &stop_handle)).await {
 				match err {
-					MonitoredError::Selector(SokettoError::Closed) => {
+					SokettoError::Closed => {
 						tracing::debug!("WS transport: remote peer terminated the connection: {}", conn_id);
 						break Ok(());
 					}
-					MonitoredError::Selector(SokettoError::MessageTooLarge { current, maximum }) => {
+					SokettoError::MessageTooLarge { current, maximum } => {
 						tracing::debug!(
 							"WS transport error: request length: {} exceeded max limit: {} bytes",
 							current,
@@ -342,22 +295,17 @@ pub(crate) async fn background_task<L: Logger>(
 
 						continue;
 					}
-
-					// These errors can not be gracefully handled, so just log them and terminate the connection.
-					MonitoredError::Selector(err) => {
+					err => {
 						tracing::debug!("WS transport error: {}; terminate connection: {}", err, conn_id);
 						break Err(err.into());
 					}
-					MonitoredError::Shutdown => {
-						break Ok(());
-					}
 				};
-			};
-		};
+			}
+		}
 
 		let request_start = logger.on_request(TransportProtocol::WebSocket);
-
 		let first_non_whitespace = data.iter().find(|byte| !byte.is_ascii_whitespace());
+
 		match first_non_whitespace {
 			Some(b'{') => {
 				let data = std::mem::take(&mut data);
@@ -394,7 +342,7 @@ pub(crate) async fn background_task<L: Logger>(
 				}
 				.boxed();
 
-				method_executors.add(fut);
+				method_executor.add(fut);
 			}
 			Some(b'[') if !batch_requests_supported => {
 				let response = MethodResponse::error(
@@ -436,7 +384,7 @@ pub(crate) async fn background_task<L: Logger>(
 					}
 				};
 
-				method_executors.add(Box::pin(fut));
+				method_executor.add(Box::pin(fut));
 			}
 			_ => {
 				sink_permit.send_error(Id::Null, ErrorCode::ParseError.into());
@@ -449,7 +397,7 @@ pub(crate) async fn background_task<L: Logger>(
 	// Drive all running methods to completion.
 	// **NOTE** Do not return early in this function. This `await` needs to run to guarantee
 	// proper drop behaviour.
-	method_executors.await;
+	method_executor.await;
 
 	let _ = conn_tx.send(());
 	drop(conn);
@@ -461,7 +409,7 @@ pub(crate) async fn background_task<L: Logger>(
 async fn send_task(
 	rx: mpsc::Receiver<String>,
 	mut ws_sender: Sender,
-	mut stop_handle: StopHandle,
+	stop_handle: StopHandle,
 	ping_interval: Duration,
 	conn_closed: oneshot::Receiver<()>,
 ) {
@@ -518,4 +466,72 @@ async fn send_task(
 	// Terminate connection and send close message.
 	let _ = ws_sender.close().await;
 	rx.close();
+}
+
+enum Receive<S> {
+	Shutdown,
+	Err(SokettoError, S),
+	Ok(S),
+}
+
+async fn try_recv<F, S>(
+	receiver: &mut Receiver,
+	mut data: &mut Vec<u8>,
+	method_executor: &mut FutureDriver<F>,
+	stopped: S,
+) -> Receive<S>
+where
+	F: Future + Unpin,
+	S: Future<Output = ()> + Unpin,
+{
+	// Need the extra scope to drop this pinned future and reclaim access to `data`
+	let receive = async {
+		// Identical loop to `soketto::receive_data` with debug logs for `Pong` frames.
+		loop {
+			match receiver.receive(&mut data).await? {
+				soketto::Incoming::Data(d) => break Ok(d),
+				soketto::Incoming::Pong(_) => tracing::debug!("Received pong"),
+				soketto::Incoming::Closed(_) => {
+					// The closing reason is already logged by `soketto` trace log level.
+					// Return the `Closed` error to avoid logging unnecessary warnings on clean shutdown.
+					break Err(SokettoError::Closed);
+				}
+			}
+		}
+	};
+
+	let receive = method_executor.select_with(receive);
+	tokio::pin!(receive);
+
+	match futures_util::future::select(receive, stopped).await {
+		Either::Left((Ok(_), s)) => Receive::Ok(s),
+		Either::Left((Err(e), s)) => Receive::Err(e, s),
+		Either::Right(_) => Receive::Shutdown,
+	}
+}
+
+// Wait until there is a slot in the bounded channel which means that
+// the underlying TCP socket won't be read.
+//
+// This will force the client to read socket on the other side
+// otherwise the socket will not be read again.
+//
+// Fails if the connection was closed or if the server was stopped,
+async fn wait_for_permit<'a, F, S>(
+	sink: &'a MethodSink,
+	method_executor: &mut FutureDriver<F>,
+	stopped: S,
+) -> Option<(MethodSinkPermit<'a>, S)>
+where
+	F: Future + Unpin,
+	S: Future<Output = ()> + Unpin,
+{
+	let sink_permit_fut = method_executor.select_with(sink.reserve());
+	tokio::pin!(sink_permit_fut);
+
+	match futures_util::future::select(sink_permit_fut, stopped).await {
+		Either::Left((Ok(permit), s)) => Some((permit, s)),
+		// The sink or stopped were triggered, just terminate.
+		_ => None,
+	}
 }

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -251,8 +251,6 @@ pub(crate) async fn background_task<L: Logger>(
 	// Spawn another task that sends out the responses on the Websocket.
 	tokio::spawn(send_task(rx, sender, stop_handle.clone(), ping_interval, conn_rx));
 
-	tracing::info!("background task");
-
 	// Buffer for incoming data.
 	let mut data = Vec::with_capacity(100);
 	let mut method_executor = FutureDriver::default();
@@ -476,7 +474,7 @@ enum Receive<S> {
 
 async fn try_recv<F, S>(
 	receiver: &mut Receiver,
-	mut data: &mut Vec<u8>,
+	data: &mut Vec<u8>,
 	method_executor: &mut FutureDriver<F>,
 	stopped: S,
 ) -> Receive<S>
@@ -487,7 +485,7 @@ where
 	let receive = async {
 		// Identical loop to `soketto::receive_data` with debug logs for `Pong` frames.
 		loop {
-			match receiver.receive(&mut data).await? {
+			match receiver.receive(data).await? {
 				soketto::Incoming::Data(d) => break Ok(d),
 				soketto::Incoming::Pong(_) => tracing::debug!("Received pong"),
 				soketto::Incoming::Closed(_) => {


### PR DESCRIPTION
Tokio v1.27 changed how interval/timers are woken up.

Because we already have `async fn StopHandle::shutdown` we could just select on that along with the other future.
Thus, these periodically wake-ups are not needed anymore which should fix this properly.

Close #1059 