### PR TITLE
WIP: refactor FutureDriver

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -321,6 +321,9 @@ fn ws_concurrent_conn_calls(
 	request: RequestType,
 	concurrent_conns: &[usize],
 ) {
+	#[cfg(feature = "tokio_unstable")]
+	console_subscriber::init();
+
 	let fast_call = request.methods()[0];
 	assert!(fast_call.starts_with("fast_call"));
 

--- a/server/src/future.rs
+++ b/server/src/future.rs
@@ -40,27 +40,27 @@ use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 /// This is a flexible collection of futures that need to be driven to completion
 /// alongside some other future, such as connection handlers that need to be
 /// handled along with a listener for new connections.
-pub(crate) struct DriveFutures<'a, S, F> {
-	future: S,
-	futures: &'a mut FuturesUnordered<F>,
+pub(crate) struct DriveFutures<'a, Fut1, Fut2> {
+	future: Fut1,
+	futures: &'a mut FuturesUnordered<Fut2>,
 }
 
-impl<'a, S, F> DriveFutures<'a, S, F>
+impl<'a, Fut1, Fut2> DriveFutures<'a, Fut1, Fut2>
 where
-	S: Future + Unpin,
-	F: Future + Unpin,
+	Fut1: Future + Unpin,
+	Fut2: Future + Unpin,
 {
-	pub(crate) fn new(future: S, futures: &'a mut FuturesUnordered<F>) -> Self {
+	pub(crate) fn new(future: Fut1, futures: &'a mut FuturesUnordered<Fut2>) -> Self {
 		Self { future, futures }
 	}
 }
 
-impl<'a, S, F> Future for DriveFutures<'a, S, F>
+impl<'a, Fut1, Fut2> Future for DriveFutures<'a, Fut1, Fut2>
 where
-	S: Future + Unpin,
-	F: Future + Unpin,
+	Fut1: Future + Unpin,
+	Fut2: Future + Unpin,
 {
-	type Output = S::Output;
+	type Output = Fut1::Output;
 
 	fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
 		let this = Pin::into_inner(self);

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -32,11 +32,11 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use crate::future::{ConnectionGuard, ServerHandle, StopHandle};
+use crate::future::{ConnectionGuard, Incoming, Monitored, MonitoredError, ServerHandle, StopHandle};
 use crate::logger::{Logger, TransportProtocol};
 use crate::transport::{http, ws};
 
-use futures_util::future::{Either, FutureExt};
+use futures_util::future::FutureExt;
 use futures_util::io::{BufReader, BufWriter};
 
 use futures_util::stream::{FuturesUnordered, StreamExt};
@@ -128,15 +128,13 @@ where
 
 		let mut id: u32 = 0;
 		let connection_guard = ConnectionGuard::new(self.cfg.max_connections as usize);
-		let listener = self.listener;
+		let mut monitored = Monitored::new(Incoming(self.listener), &stop_handle);
 
 		let mut connections = FuturesUnordered::new();
-		let stopped = stop_handle.clone().shutdown();
-		tokio::pin!(stopped);
 
 		loop {
-			match try_accept_conn(&listener, stopped).await {
-				AcceptConnection::Established { socket, remote_addr, stop } => {
+			match (&mut monitored).await {
+				Ok((socket, remote_addr)) => {
 					let data = ProcessConnection {
 						remote_addr,
 						methods: methods.clone(),
@@ -158,13 +156,13 @@ where
 					};
 					process_connection(&self.service_builder, &connection_guard, data, socket, &mut connections);
 					id = id.wrapping_add(1);
-					stopped = stop;
 				}
-				AcceptConnection::Err((e, stop)) => {
-					tracing::error!("Error while awaiting a new connection: {:?}", e);
-					stopped = stop;
+				Err(MonitoredError::Shutdown) => {
+					break;
 				}
-				AcceptConnection::Shutdown => break,
+				Err(MonitoredError::Selector(err)) => {
+					tracing::error!("Error while awaiting a new connection: {:?}", err);
+				}
 			}
 		}
 
@@ -805,27 +803,5 @@ where
 		_ = stop_handle.shutdown() => {
 			conn.graceful_shutdown();
 		}
-	}
-}
-
-enum AcceptConnection<S> {
-	Shutdown,
-	Established { socket: TcpStream, remote_addr: SocketAddr, stop: S },
-	Err((std::io::Error, S)),
-}
-
-async fn try_accept_conn<S>(listener: &TcpListener, stopped: S) -> AcceptConnection<S>
-where
-	S: Future + Unpin,
-{
-	let accept = listener.accept();
-	tokio::pin!(accept);
-
-	match futures_util::future::select(accept, stopped).await {
-		Either::Left((res, stop)) => match res {
-			Ok((socket, remote_addr)) => AcceptConnection::Established { socket, remote_addr, stop },
-			Err(e) => AcceptConnection::Err((e, stop)),
-		},
-		Either::Right(_) => AcceptConnection::Shutdown,
 	}
 }


### PR DESCRIPTION
refactor-future-driver: this PR
remove-future-driver: https://github.com/paritytech/jsonrpsee/pull/1070
master == master
remove-future-driver-tokio-spawn: https://github.com/paritytech/jsonrpsee/pull/1080


Benchmarks:

### One client with concurrent round trips

```
group                                            master                                 na-refactor-future-driver              na-remove-future-driver                na-remove-future-driver-tokio-spawn
-----                                            ------                                 -------------------------              -----------------------                -----------------------------------
async/ws_concurrent_conn_calls/fast_call/2       1.40   193.9±22.74µs        ? ?/sec    1.31   182.5±29.05µs        ? ?/sec    1.13   157.2±23.14µs        ? ?/sec    1.00   139.0±24.39µs        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/4       1.28   222.4±22.05µs        ? ?/sec    1.10   192.0±29.74µs        ? ?/sec    1.08   188.3±14.82µs        ? ?/sec    1.00   173.9±10.57µs        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/8       1.12   243.7±38.90µs        ? ?/sec    1.02    223.3±9.31µs        ? ?/sec    1.06   231.9±20.89µs        ? ?/sec    1.00    218.5±6.24µs        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/16      1.01    298.9±8.75µs        ? ?/sec    1.00    294.8±8.65µs        ? ?/sec    1.02   300.0±11.53µs        ? ?/sec    1.08    317.1±7.23µs        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/32      1.00   501.0±14.89µs        ? ?/sec    1.00   501.7±11.06µs        ? ?/sec    1.03   515.1±12.77µs        ? ?/sec    1.20   602.5±11.27µs        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/64      1.00   901.3±17.19µs        ? ?/sec    1.03   925.2±29.25µs        ? ?/sec    1.04   934.5±25.11µs        ? ?/sec    1.22  1102.3±24.21µs        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/128     1.00  1689.9±33.30µs        ? ?/sec    1.00  1695.4±26.92µs        ? ?/sec    1.00  1691.0±24.70µs        ? ?/sec    1.15  1942.7±33.94µs        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/256     1.01      3.3±0.09ms        ? ?/sec    1.01      3.4±0.07ms        ? ?/sec    1.00      3.3±0.05ms        ? ?/sec    1.13      3.8±0.07ms        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/512     1.03      6.8±0.14ms        ? ?/sec    1.02      6.8±0.13ms        ? ?/sec    1.00      6.6±0.12ms        ? ?/sec    1.13      7.5±0.13ms        ? ?/sec
async/ws_concurrent_conn_calls/fast_call/1024    1.02     14.1±0.28ms        ? ?/sec    1.03     14.2±0.44ms        ? ?/sec    1.00     13.8±0.26ms        ? ?/sec    1.10     15.2±0.26ms        ? ?/sec
```


### Concurrent connections(2-1024) with 10 calls per connection (..)
```
group                                            master                                 na-refactor-future-driver              na-remove-future-driver                na-remove-future-driver-tokio-spawn
-----                                            ------                                 -------------------------              -----------------------                -----------------------------------
async/ws_round_trip/3                            1.53      2.6±0.09ms        ? ?/sec    1.93      3.3±0.18ms        ? ?/sec    1.63      2.8±0.22ms        ? ?/sec    1.00  1724.7±266.91µs        ? ?/sec
async/ws_round_trip/9                            2.03      8.6±1.03ms        ? ?/sec    1.90      8.1±0.97ms        ? ?/sec    1.97      8.4±0.37ms        ? ?/sec    1.00      4.3±0.58ms        ? ?/sec
async/ws_round_trip/27                           2.52     36.4±1.44ms        ? ?/sec    2.16     31.2±4.07ms        ? ?/sec    2.08     30.1±1.66ms        ? ?/sec    1.00     14.4±1.83ms        ? ?/sec
async/ws_round_trip/81                           2.14     85.8±4.17ms        ? ?/sec    2.11     84.6±2.44ms        ? ?/sec    2.20     88.4±6.40ms        ? ?/sec    1.00     40.1±4.92ms        ? ?/sec
async/ws_round_trip/243                          2.24   211.8±18.61ms        ? ?/sec    1.87   177.4±17.57ms        ? ?/sec    1.63    154.0±9.42ms        ? ?/sec    1.00     94.7±8.92ms        ? ?/sec
async/ws_round_trip/729                          2.12   544.1±30.87ms        ? ?/sec    1.86   475.9±21.03ms        ? ?/sec    1.72   439.6±25.83ms        ? ?/sec    1.00   256.3±19.02ms        ? ?/sec

```



