### PR TITLE
refactor(server): downgrade connection log to debug

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -753,7 +753,7 @@ fn process_connection<'a, L: Logger, B, U>(
 
 	let max_conns = cfg.max_connections as usize;
 	let curr_conns = max_conns - connection_guard.available_connections();
-	tracing::info!("Accepting new connection {}/{}", curr_conns, max_conns);
+	tracing::debug!("Accepting new connection {}/{}", curr_conns, max_conns);
 
 	let tower_service = TowerService {
 		inner: ServiceData {


### PR DESCRIPTION
This may become annoying when getting HTTP requests, so let's make it debug instead.