### PR TITLE
remove `CallError`

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -186,7 +186,7 @@ fn gen_rpc_module() -> jsonrpsee::RpcModule<()> {
 	module
 		.register_async_method(ASYNC_SLOW_CALL, |_, _| async move {
 			tokio::time::sleep(SLOW_CALL).await;
-			Result::<_, jsonrpsee::core::Error>::Ok("slow call async")
+			"slow call async"
 		})
 		.unwrap();
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -43,7 +43,6 @@ use jsonrpsee_core::client::{
 use jsonrpsee_core::params::BatchRequestBuilder;
 use jsonrpsee_core::traits::ToRpcParams;
 use jsonrpsee_core::{Error, JsonRawValue, TEN_MB_SIZE_BYTES};
-use jsonrpsee_types::error::CallError;
 use jsonrpsee_types::{ErrorObject, ResponseSuccess, TwoPointZero};
 use serde::de::DeserializeOwned;
 use tower::layer::util::Identity;
@@ -301,7 +300,7 @@ where
 		// NOTE: it's decoded first to `JsonRawValue` and then to `R` below to get
 		// a better error message if `R` couldn't be decoded.
 		let response = ResponseSuccess::try_from(serde_json::from_slice::<Response<&JsonRawValue>>(&body)?)
-			.map_err(|e| Error::Call(CallError::Custom(e)))?;
+			.map_err(|e| Error::Call(e))?;
 
 		let result = serde_json::from_str(response.result.get()).map_err(Error::ParseError)?;
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -299,8 +299,7 @@ where
 
 		// NOTE: it's decoded first to `JsonRawValue` and then to `R` below to get
 		// a better error message if `R` couldn't be decoded.
-		let response = ResponseSuccess::try_from(serde_json::from_slice::<Response<&JsonRawValue>>(&body)?)
-			.map_err(|e| Error::Call(e))?;
+		let response = ResponseSuccess::try_from(serde_json::from_slice::<Response<&JsonRawValue>>(&body)?)?;
 
 		let result = serde_json::from_str(response.result.get()).map_err(Error::ParseError)?;
 

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -34,7 +34,7 @@ use jsonrpsee_core::{rpc_params, DeserializeOwned};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::Id;
 use jsonrpsee_test_utils::TimeoutFutureExt;
-use jsonrpsee_types::error::{CallError, ErrorObjectOwned};
+use jsonrpsee_types::error::ErrorObjectOwned;
 
 fn init_logger() {
 	let _ = tracing_subscriber::FmtSubscriber::builder()
@@ -276,10 +276,9 @@ async fn run_request_with_response(response: String) -> Result<String, Error> {
 }
 
 fn assert_jsonrpc_error_response(err: Error, exp: ErrorObjectOwned) {
-	let exp = CallError::Custom(exp);
 	match &err {
 		Error::Call(err) => {
-			assert_eq!(err.to_string(), exp.to_string());
+			assert_eq!(err, &exp);
 		}
 		e => panic!("Expected error: \"{err}\", got: {e:?}"),
 	};

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -35,7 +35,7 @@ use jsonrpsee_core::{rpc_params, DeserializeOwned, Error};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::{Id, WebSocketTestServer};
 use jsonrpsee_test_utils::TimeoutFutureExt;
-use jsonrpsee_types::error::{CallError, ErrorObjectOwned};
+use jsonrpsee_types::error::ErrorObjectOwned;
 use serde_json::Value as JsonValue;
 
 fn init_logger() {
@@ -393,10 +393,9 @@ async fn run_request_with_response(response: String) -> Result<String, Error> {
 }
 
 fn assert_error_response(err: Error, exp: ErrorObjectOwned) {
-	let exp = CallError::Custom(exp);
 	match &err {
 		Error::Call(e) => {
-			assert_eq!(e.to_string(), exp.to_string());
+			assert_eq!(e, &exp);
 		}
 		e => panic!("Expected error: \"{err}\", got: {e:?}"),
 	};

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -175,7 +175,7 @@ pub(crate) fn process_single_response(
 	max_capacity_per_subscription: usize,
 ) -> Result<Option<RequestMessage>, Error> {
 	let response_id = response.id.clone().into_owned();
-	let result = ResponseSuccess::try_from(response).map(|s| s.result).map_err(|e| Error::Call(e));
+	let result = ResponseSuccess::try_from(response).map(|s| s.result).map_err(Error::Call);
 
 	match manager.request_status(&response_id) {
 		RequestStatus::PendingMethodCall => {

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -34,7 +34,6 @@ use futures_timer::Delay;
 use futures_util::future::{self, Either};
 use tokio::sync::{mpsc, oneshot};
 
-use jsonrpsee_types::error::CallError;
 use jsonrpsee_types::response::SubscriptionError;
 use jsonrpsee_types::{
 	ErrorObject, Id, Notification, RequestSer, Response, ResponseSuccess, SubscriptionId, SubscriptionResponse,
@@ -176,7 +175,7 @@ pub(crate) fn process_single_response(
 	max_capacity_per_subscription: usize,
 ) -> Result<Option<RequestMessage>, Error> {
 	let response_id = response.id.clone().into_owned();
-	let result = ResponseSuccess::try_from(response).map(|s| s.result).map_err(|e| Error::Call(CallError::Custom(e)));
+	let result = ResponseSuccess::try_from(response).map(|s| s.result).map_err(|e| Error::Call(e));
 
 	match manager.request_status(&response_id) {
 		RequestStatus::PendingMethodCall => {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -46,7 +46,7 @@ impl<T: fmt::Display> fmt::Display for Mismatch<T> {
 /// Error type.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	/// Error that occurs when a call failed.
+	/// JSON-RPC error which can occur when a JSON-RPC call fails.
 	#[error("{0}")]
 	Call(#[from] ErrorObjectOwned),
 	/// Networking error or error on the low-level protocol layer.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,7 +62,7 @@ pub use async_trait::async_trait;
 pub use error::{Error, GenericTransportError, StringError};
 
 /// JSON-RPC result.
-pub type RpcResult<T> = std::result::Result<T, ErrorObjectOwned>;
+pub type RpcResult<T> = std::result::Result<T, jsonrpee_types::ErrorObjectOwned>;
 
 /// Empty server `RpcParams` type to use while registering modules.
 pub type EmptyServerParams = Vec<()>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,7 +62,7 @@ pub use async_trait::async_trait;
 pub use error::{Error, GenericTransportError, StringError};
 
 /// JSON-RPC result.
-pub type RpcResult<T> = std::result::Result<T, jsonrpee_types::ErrorObjectOwned>;
+pub type RpcResult<T> = std::result::Result<T, jsonrpsee_types::ErrorObjectOwned>;
 
 /// Empty server `RpcParams` type to use while registering modules.
 pub type EmptyServerParams = Vec<()>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,7 +62,7 @@ pub use async_trait::async_trait;
 pub use error::{Error, GenericTransportError, StringError};
 
 /// JSON-RPC result.
-pub type RpcResult<T> = std::result::Result<T, Error>;
+pub type RpcResult<T> = std::result::Result<T, ErrorObjectOwned>;
 
 /// Empty server `RpcParams` type to use while registering modules.
 pub type EmptyServerParams = Vec<()>;
@@ -77,6 +77,7 @@ pub mod __reexports {
 }
 
 pub use beef::Cow;
+use jsonrpsee_types::ErrorObjectOwned;
 pub use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json::{
 	to_value as to_json_value, value::to_raw_value as to_json_raw_value, value::RawValue as JsonRawValue,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -77,7 +77,6 @@ pub mod __reexports {
 }
 
 pub use beef::Cow;
-use jsonrpsee_types::ErrorObjectOwned;
 pub use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json::{
 	to_value as to_json_value, value::to_raw_value as to_json_raw_value, value::RawValue as JsonRawValue,

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -168,12 +168,6 @@ impl MethodSinkPermit {
 		self.send_raw(json)
 	}
 
-	/*
-	/// Helper for sending the general purpose `Error` as a JSON-RPC errors to the client.
-	pub fn send_call_error(self, id: Id, err: Error) {
-		self.send_error(id, err.into())
-	}*/
-
 	/// Send a raw JSON-RPC message to the client, `MethodSink` does not check the validity
 	/// of the JSON being sent.
 	pub fn send_raw(self, json: String) {

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -28,12 +28,11 @@ use std::io;
 use std::time::Duration;
 
 use crate::tracing::tx_log_from_str;
-use crate::Error;
 use jsonrpsee_types::error::{ErrorCode, ErrorObject, OVERSIZED_RESPONSE_CODE, OVERSIZED_RESPONSE_MSG};
 use jsonrpsee_types::{Id, InvalidRequest, Response, ResponsePayload};
 use serde::Serialize;
-use tokio::sync::mpsc::{self, OwnedPermit};
 use serde_json::value::to_raw_value;
+use tokio::sync::mpsc::{self, OwnedPermit};
 
 use super::{DisconnectError, SendTimeoutError, SubscriptionMessage, TrySendError};
 
@@ -169,10 +168,11 @@ impl MethodSinkPermit {
 		self.send_raw(json)
 	}
 
+	/*
 	/// Helper for sending the general purpose `Error` as a JSON-RPC errors to the client.
 	pub fn send_call_error(self, id: Id, err: Error) {
 		self.send_error(id, err.into())
-	}
+	}*/
 
 	/// Send a raw JSON-RPC message to the client, `MethodSink` does not check the validity
 	/// of the JSON being sent.

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -253,7 +253,7 @@ impl Methods {
 		tracing::trace!("[Methods::call] Method: {:?}, params: {:?}", method, params);
 		let (resp, _) = self.inner_call(req, 1, mock_subscription_permit()).await;
 		let rp = serde_json::from_str::<Response<T>>(&resp.result)?;
-		ResponseSuccess::try_from(rp).map(|s| s.result).map_err(|e| Error::Call(e))
+		ResponseSuccess::try_from(rp).map(|s| s.result).map_err(Error::Call)
 	}
 
 	/// Make a request (JSON-RPC method call or subscription) by using raw JSON.
@@ -386,7 +386,7 @@ impl Methods {
 
 		// TODO: hack around the lifetime on the `SubscriptionId` by deserialize first to serde_json::Value.
 		let as_success: ResponseSuccess<serde_json::Value> =
-			serde_json::from_str::<Response<_>>(&resp.result)?.try_into().map_err(|e| Error::Call(e))?;
+			serde_json::from_str::<Response<_>>(&resp.result)?.try_into()?;
 
 		let sub_id = as_success.result.try_into().map_err(|_| Error::InvalidSubscriptionId)?;
 

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -41,7 +41,7 @@ use crate::server::subscription::{
 };
 use crate::traits::ToRpcParams;
 use futures_util::{future::BoxFuture, FutureExt};
-use jsonrpsee_types::error::{CallError, ErrorCode, ErrorObject};
+use jsonrpsee_types::error::{ErrorCode, ErrorObject};
 use jsonrpsee_types::{
 	Id, Params, Request, Response, ResponsePayload, ResponseSuccess, SubscriptionId as RpcSubscriptionId,
 };
@@ -253,7 +253,7 @@ impl Methods {
 		tracing::trace!("[Methods::call] Method: {:?}, params: {:?}", method, params);
 		let (resp, _) = self.inner_call(req, 1, mock_subscription_permit()).await;
 		let rp = serde_json::from_str::<Response<T>>(&resp.result)?;
-		ResponseSuccess::try_from(rp).map(|s| s.result).map_err(|e| Error::Call(CallError::Custom(e)))
+		ResponseSuccess::try_from(rp).map(|s| s.result).map_err(|e| Error::Call(e))
 	}
 
 	/// Make a request (JSON-RPC method call or subscription) by using raw JSON.
@@ -385,9 +385,8 @@ impl Methods {
 		let (resp, rx) = self.inner_call(req, buf_size, mock_subscription_permit()).await;
 
 		// TODO: hack around the lifetime on the `SubscriptionId` by deserialize first to serde_json::Value.
-		let as_success: ResponseSuccess<serde_json::Value> = serde_json::from_str::<Response<_>>(&resp.result)?
-			.try_into()
-			.map_err(|e| Error::Call(CallError::Custom(e)))?;
+		let as_success: ResponseSuccess<serde_json::Value> =
+			serde_json::from_str::<Response<_>>(&resp.result)?.try_into().map_err(|e| Error::Call(e))?;
 
 		let sub_id = as_success.result.try_into().map_err(|_| Error::InvalidSubscriptionId)?;
 

--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -38,7 +38,6 @@
 //! like to query a certain `URI` path for statistics.
 
 use hyper::{Body, Client, Request};
-use jsonrpsee::core::RpcResult;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -95,7 +94,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo").unwrap();
-	module.register_method("system_health", |_, _| RpcResult::Ok(serde_json::json!({ "health": true }))).unwrap();
+	module.register_method("system_health", |_, _| serde_json::json!({ "health": true })).unwrap();
 
 	let handle = server.start(module)?;
 

--- a/examples/examples/proc_macro.rs
+++ b/examples/examples/proc_macro.rs
@@ -26,9 +26,10 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, client::Subscription, Error, SubscriptionResult};
+use jsonrpsee::core::{async_trait, client::Subscription, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{PendingSubscriptionSink, ServerBuilder, SubscriptionMessage};
+use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
 
 type ExampleHash = [u8; 32];
@@ -41,7 +42,11 @@ where
 {
 	/// Async method call example.
 	#[method(name = "getKeys")]
-	async fn storage_keys(&self, storage_key: StorageKey, hash: Option<Hash>) -> Result<Vec<StorageKey>, Error>;
+	async fn storage_keys(
+		&self,
+		storage_key: StorageKey,
+		hash: Option<Hash>,
+	) -> Result<Vec<StorageKey>, ErrorObjectOwned>;
 
 	/// Subscription that takes a `StorageKey` as input and produces a `Vec<Hash>`.
 	#[subscription(name = "subscribeStorage" => "override", item = Vec<Hash>)]
@@ -56,7 +61,7 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 		&self,
 		storage_key: ExampleStorageKey,
 		_hash: Option<ExampleHash>,
-	) -> Result<Vec<ExampleStorageKey>, Error> {
+	) -> Result<Vec<ExampleStorageKey>, ErrorObjectOwned> {
 		Ok(vec![storage_key])
 	}
 

--- a/examples/examples/proc_macro_bounds.rs
+++ b/examples/examples/proc_macro_bounds.rs
@@ -26,9 +26,10 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, Error};
+use jsonrpsee::core::async_trait;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
 
 type ExampleHash = [u8; 32];
@@ -53,14 +54,14 @@ impl Config for ExampleHash {
 #[rpc(server, client, namespace = "foo", client_bounds(T::Hash: jsonrpsee::core::DeserializeOwned), server_bounds(T::Hash: jsonrpsee::core::Serialize + Clone))]
 pub trait Rpc<T: Config> {
 	#[method(name = "bar")]
-	fn method(&self) -> Result<T::Hash, Error>;
+	fn method(&self) -> Result<T::Hash, ErrorObjectOwned>;
 }
 
 pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer<ExampleHash> for RpcServerImpl {
-	fn method(&self) -> Result<<ExampleHash as Config>::Hash, Error> {
+	fn method(&self) -> Result<<ExampleHash as Config>::Hash, ErrorObjectOwned> {
 		Ok([0u8; 32])
 	}
 }

--- a/examples/examples/ws_pubsub_with_params.rs
+++ b/examples/examples/ws_pubsub_with_params.rs
@@ -31,7 +31,6 @@ use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use jsonrpsee::core::Serialize;
 use jsonrpsee::server::{RpcModule, ServerBuilder, SubscriptionMessage, TrySendError};
-use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, PendingSubscriptionSink};
 use tokio::time::interval;
@@ -72,7 +71,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 			let idx = match params.one::<usize>() {
 				Ok(p) => p,
 				Err(e) => {
-					let _ = pending.reject(ErrorObjectOwned::from(e)).await;
+					let _ = pending.reject(e).await;
 					return Ok(());
 				}
 			};

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -102,6 +102,11 @@ impl RpcDescription {
 			if args.len() != 1 {
 				return quote_spanned!(args.span() => compile_error!("RpcResult must have one argument"));
 			}
+
+			// Force the last argument to be `jsonrpsee::core::Error`:
+			let error_arg = args.last_mut().unwrap();
+			*error_arg = syn::GenericArgument::Type(syn::Type::Verbatim(self.jrps_client_item(quote! { core::Error })));
+
 			quote!(#ty)
 		} else {
 			// Any other type name isn't allowed.

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -103,11 +103,11 @@ impl RpcDescription {
 				return quote_spanned!(args.span() => compile_error!("RpcResult must have one argument"));
 			}
 
-			// Force the last argument to be `jsonrpsee::core::Error`:
-			let error_arg = args.last_mut().unwrap();
-			*error_arg = syn::GenericArgument::Type(syn::Type::Verbatim(self.jrps_client_item(quote! { core::Error })));
+			// The type alias `RpcResult<T>` is modified to `Result<T, Error>`.
+			let ret_ty = args.last_mut().unwrap();
+			let err_ty = self.jrps_client_item(quote! { core::Error });
 
-			quote!(#ty)
+			quote! { core::result::Result<#ret_ty, #err_ty> }
 		} else {
 			// Any other type name isn't allowed.
 			quote_spanned!(type_name.span() => compile_error!("The return type must be Result or RpcResult"))

--- a/proc-macros/tests/ui/correct/custom_ret_types.rs
+++ b/proc-macros/tests/ui/correct/custom_ret_types.rs
@@ -2,7 +2,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, RpcResult, Serialize};
+use jsonrpsee::core::{async_trait, Serialize};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{IntoResponse, ServerBuilder};
 use jsonrpsee::types::ResponsePayload;
@@ -86,7 +86,7 @@ async fn main() {
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	let get_error_object = |err| match err {
-		jsonrpsee::core::Error::Call(jsonrpsee::types::error::CallError::Custom(object)) => object,
+		jsonrpsee::core::Error::Call(object) => object,
 		_ => panic!("wrong error kind: {:?}", err),
 	};
 

--- a/proc-macros/tests/ui/correct/only_client.rs
+++ b/proc-macros/tests/ui/correct/only_client.rs
@@ -1,14 +1,14 @@
 //! Example of using proc macro to generate working client.
 
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use jsonrpsee::{core::Error, proc_macros::rpc};
 
 #[rpc(client)]
 pub trait Rpc {
 	#[method(name = "foo")]
-	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
+	async fn async_method(&self, param_a: u8, param_b: String) -> Result<u16, Error>;
 
 	#[method(name = "bar")]
-	fn sync_method(&self) -> RpcResult<u16>;
+	fn sync_method(&self) -> Result<u16, Error>;
 
 	#[subscription(name = "subscribe", item = String)]
 	async fn sub(&self) -> Result<(), Error>;

--- a/proc-macros/tests/ui/correct/only_client.rs
+++ b/proc-macros/tests/ui/correct/only_client.rs
@@ -1,6 +1,6 @@
 //! Example of using proc macro to generate working client.
 
-use jsonrpsee::{core::Error, proc_macros::rpc};
+use jsonrpsee::proc_macros::rpc;
 
 #[rpc(client)]
 pub trait Rpc {

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated associated function `DeprecatedClient::async_method`: please use `new_method` instead
+error: use of deprecated method `DeprecatedClient::async_method`: please use `new_method` instead
   --> $DIR/rpc_deprecated_method.rs:63:20
    |
 63 |     assert_eq!(client.async_method().await.unwrap(), 16);

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.rs
@@ -1,5 +1,4 @@
-use jsonrpsee::core::Error;
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 pub trait Config {
 	type Hash: Send + Sync + 'static;
@@ -10,7 +9,7 @@ pub trait Config {
 #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
 pub trait EmptyBounds<Conf: Config> {
 	#[method(name = "bar")]
-	fn method(&self) -> Result<Conf::Hash, Error>;
+	fn method(&self) -> RpcResult<Conf::Hash>;
 }
 
 fn main() {}

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
@@ -1,41 +1,41 @@
 error[E0277]: the trait bound `<Conf as Config>::Hash: Serialize` is not satisfied
-  --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:10:1
-   |
-10 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `<Conf as Config>::Hash`
-   |
-   = note: required for `std::result::Result<<Conf as Config>::Hash, jsonrpsee::jsonrpsee_core::Error>` to implement `IntoResponse`
+ --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
+  |
+9 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `<Conf as Config>::Hash`
+  |
+  = note: required for `std::result::Result<<Conf as Config>::Hash, ErrorObject<'_>>` to implement `IntoResponse`
 note: required by a bound in `RpcModule::<Context>::register_method`
-  --> $WORKSPACE/core/src/server/rpc_module.rs
-   |
-   |         R: IntoResponse + 'static,
-   |            ^^^^^^^^^^^^ required by this bound in `RpcModule::<Context>::register_method`
-   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $WORKSPACE/core/src/server/rpc_module.rs
+  |
+  |         R: IntoResponse + 'static,
+  |            ^^^^^^^^^^^^ required by this bound in `RpcModule::<Context>::register_method`
+  = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Conf as Config>::Hash: Clone` is not satisfied
-  --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:10:1
-   |
-10 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Conf as Config>::Hash`
-   |
-   = note: required for `std::result::Result<<Conf as Config>::Hash, jsonrpsee::jsonrpsee_core::Error>` to implement `IntoResponse`
+ --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
+  |
+9 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Conf as Config>::Hash`
+  |
+  = note: required for `std::result::Result<<Conf as Config>::Hash, ErrorObject<'_>>` to implement `IntoResponse`
 note: required by a bound in `RpcModule::<Context>::register_method`
-  --> $WORKSPACE/core/src/server/rpc_module.rs
-   |
-   |         R: IntoResponse + 'static,
-   |            ^^^^^^^^^^^^ required by this bound in `RpcModule::<Context>::register_method`
-   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $WORKSPACE/core/src/server/rpc_module.rs
+  |
+  |         R: IntoResponse + 'static,
+  |            ^^^^^^^^^^^^ required by this bound in `RpcModule::<Context>::register_method`
+  = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `for<'de> <Conf as Config>::Hash: Deserialize<'de>` is not satisfied
-  --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:10:1
-   |
-10 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `<Conf as Config>::Hash`
-   |
-   = note: required for `<Conf as Config>::Hash` to implement `DeserializeOwned`
+ --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
+  |
+9 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `<Conf as Config>::Hash`
+  |
+  = note: required for `<Conf as Config>::Hash` to implement `DeserializeOwned`
 note: required by a bound in `request`
-  --> $WORKSPACE/core/src/client/mod.rs
-   |
-   |         R: DeserializeOwned,
-   |            ^^^^^^^^^^^^^^^^ required by this bound in `ClientT::request`
-   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $WORKSPACE/core/src/client/mod.rs
+  |
+  |         R: DeserializeOwned,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ClientT::request`
+  = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -70,9 +70,7 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 			Ok(sum)
 		})
 		.unwrap();
-	module
-		.register_method::<Result<(), ErrorObjectOwned>, _>("invalid_params", |_params, _| Err(invalid_params()))
-		.unwrap();
+	module.register_method("invalid_params", |_params, _| Err::<(), _>(invalid_params())).unwrap();
 	module.register_method("call_fail", |_params, _| Err::<(), _>(MyAppError)).unwrap();
 	module
 		.register_method::<Result<&str, ErrorObjectOwned>, _>("sleep_for", |params, _| {
@@ -112,9 +110,9 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 		})
 		.unwrap();
 	module
-		.register_async_method::<Result<&str, MyAppError>, _, _>("should_ok_async", |_p, ctx| async move {
+		.register_async_method("should_ok_async", |_p, ctx| async move {
 			ctx.ok()?;
-			Ok("ok")
+			Ok::<_, MyAppError>("ok")
 		})
 		.unwrap();
 

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -71,7 +71,7 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 		})
 		.unwrap();
 	module
-		.register_method::<Result<(), ErrorObjectOwned>, _>("invalid_params", |_params, _| Err(invalid_params().into()))
+		.register_method::<Result<(), ErrorObjectOwned>, _>("invalid_params", |_params, _| Err(invalid_params()))
 		.unwrap();
 	module.register_method("call_fail", |_params, _| Err::<(), _>(MyAppError)).unwrap();
 	module
@@ -189,7 +189,7 @@ impl std::error::Error for MyAppError {}
 
 impl From<MyAppError> for ErrorObjectOwned {
 	fn from(_: MyAppError) -> Self {
-		ErrorObject::owned(1, "MyAppError", None::<()>)
+		ErrorObject::owned(-32000, "MyAppError", None::<()>)
 	}
 }
 

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -28,14 +28,6 @@ pub(crate) async fn server() -> SocketAddr {
 
 /// Spawns a dummy JSON-RPC server.
 ///
-/// It has the following methods:
-///     sync methods: `say_hello` and `add`
-///     async: `say_hello_async` and `add_sync`
-///     other: `invalid_params` (always returns `CallError::InvalidParams`),
-///            `call_fail` (always returns `CallError::Failed`),
-///            `sleep_for`
-///            `subscribe_hello` (starts a subscription that doesn't send anything)
-///
 /// Returns the address together with handle for the server.
 pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 	let server = ServerBuilder::default().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -173,7 +173,7 @@ async fn single_method_call_with_faulty_context() {
 	let req = r#"{"jsonrpc":"2.0","method":"should_err","params":[],"id":1}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
-	assert_eq!(response.body, call_execution_failed("RPC context failed", Id::Num(1)));
+	assert_eq!(response.body, call_execution_failed("MyAppError", Id::Num(1)));
 }
 
 #[tokio::test]

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -157,7 +157,7 @@ async fn single_method_call_with_multiple_params_of_different_types() {
 async fn single_method_call_with_faulty_params_returns_err() {
 	let (addr, _handle) = server().with_default_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
-	let expected = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"invalid type: string \"this should be a number\", expected u64 at line 1 column 26"},"id":1}"#;
+	let expected = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"invalid type: string \"this should be a number\", expected u64 at line 1 column 26"},"id":1}"#;
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":["this should be a number"],"id":1}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -302,7 +302,7 @@ async fn single_method_call_with_params_works() {
 async fn single_method_call_with_faulty_params_returns_err() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
-	let expected = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"invalid type: string \"should be a number\", expected u64 at line 1 column 21"},"id":1}"#;
+	let expected = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"invalid type: string \"should be a number\", expected u64 at line 1 column 21"},"id":1}"#;
 
 	let req = r#"{"jsonrpc":"2.0","method":"add", "params":["should be a number"],"id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -29,7 +29,6 @@ use crate::tests::helpers::{deser_call, init_logger, server_with_context};
 use crate::types::SubscriptionId;
 use crate::{RpcModule, ServerBuilder};
 use jsonrpsee_core::server::{SendTimeoutError, SubscriptionMessage};
-use jsonrpsee_core::RpcResult;
 use jsonrpsee_core::{traits::IdProvider, Error};
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::{Id, WebSocketTestClient, WebSocketTestError};
@@ -121,7 +120,7 @@ async fn can_set_max_connections() {
 	// Server that accepts max 2 connections
 	let server = ServerBuilder::default().max_connections(2).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| RpcResult::Ok(())).unwrap();
+	module.register_method("anything", |_p, _cx| ()).unwrap();
 	let addr = server.local_addr().unwrap();
 
 	let server_handle = server.start(module).unwrap();

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -316,7 +316,7 @@ async fn single_method_call_with_faulty_context() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"should_err", "params":[],"id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
-	assert_eq!(response, call_execution_failed("RPC context failed", Id::Num(1)));
+	assert_eq!(response, call_execution_failed("MyAppError", Id::Num(1)));
 }
 
 #[tokio::test]
@@ -356,7 +356,7 @@ async fn async_method_call_that_fails() {
 
 	let req = r#"{"jsonrpc":"2.0","method":"err_async", "params":[],"id":1}"#;
 	let response = client.send_request_text(req).await.unwrap();
-	assert_eq!(response, call_execution_failed("nah", Id::Num(1)));
+	assert_eq!(response, call_execution_failed("MyAppError", Id::Num(1)));
 }
 
 #[tokio::test]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 publish = false
 
 [dependencies]
-anyhow = "1"
 futures-channel = "0.3.14"
 futures-util = "0.3.14"
 hyper = { version = "0.14.10", features = ["full"] }

--- a/test-utils/src/mocks.rs
+++ b/test-utils/src/mocks.rs
@@ -44,17 +44,6 @@ pub use hyper::{Body, HeaderMap, StatusCode, Uri};
 
 type Error = Box<dyn std::error::Error>;
 
-pub struct TestContext;
-
-impl TestContext {
-	pub fn ok(&self) -> Result<(), anyhow::Error> {
-		Ok(())
-	}
-	pub fn err(&self) -> Result<(), anyhow::Error> {
-		Err(anyhow::anyhow!("RPC context failed"))
-	}
-}
-
 /// Request Id
 #[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/test-utils/src/mocks.rs
+++ b/test-utils/src/mocks.rs
@@ -333,7 +333,7 @@ pub fn ws_server_with_redirect(other_server: String) -> String {
 	let server = hyper::Server::bind(&addr).serve(service);
 	let addr = server.local_addr();
 
-	tokio::spawn(async move { server.await });
+	tokio::spawn(server);
 	format!("ws://{addr}")
 }
 

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -74,7 +74,7 @@ pub async fn server_with_subscription_and_handle() -> (SocketAddr, ServerHandle)
 				let count = match params.one::<usize>().map(|c| c.wrapping_add(1)) {
 					Ok(count) => count,
 					Err(e) => {
-						let _ = pending.reject(ErrorObjectOwned::from(e)).await;
+						let _ = pending.reject(e).await;
 						return Ok(());
 					}
 				};

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -30,12 +30,12 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures::{SinkExt, Stream, StreamExt};
-use jsonrpsee::core::{Error, RpcResult};
+use jsonrpsee::core::Error;
 use jsonrpsee::server::middleware::proxy_get_request::ProxyGetRequestLayer;
 use jsonrpsee::server::{
 	AllowHosts, PendingSubscriptionSink, RpcModule, ServerBuilder, ServerHandle, SubscriptionMessage, TrySendError,
 };
-use jsonrpsee::types::ErrorObjectOwned;
+use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 use jsonrpsee::{IntoSubscriptionCloseResponse, SubscriptionCloseResponse};
 use serde::Serialize;
 use tokio::time::interval;
@@ -159,13 +159,19 @@ pub async fn server() -> SocketAddr {
 	module
 		.register_async_method("slow_hello", |_, _| async {
 			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-			Result::<_, Error>::Ok("hello")
+			"hello"
 		})
 		.unwrap();
 
-	module
-		.register_async_method::<RpcResult<()>, _, _>("err", |_, _| async { Err(Error::Custom("err".to_string())) })
-		.unwrap();
+	struct CustomError;
+
+	impl From<CustomError> for ErrorObjectOwned {
+		fn from(_: CustomError) -> Self {
+			ErrorObject::owned(-32001, "err", None::<()>)
+		}
+	}
+
+	module.register_async_method::<Result<(), CustomError>, _, _>("err", |_, _| async { Err(CustomError) }).unwrap();
 
 	let addr = server.local_addr().unwrap();
 
@@ -227,7 +233,7 @@ pub async fn server_with_access_control(allowed_hosts: AllowHosts, cors: CorsLay
 	module.register_method("say_hello", |_, _| "hello").unwrap();
 	module.register_method("notif", |_, _| "").unwrap();
 
-	module.register_method("system_health", |_, _| RpcResult::Ok(serde_json::json!({ "health": true }))).unwrap();
+	module.register_method("system_health", |_, _| serde_json::json!({ "health": true })).unwrap();
 
 	let handle = server.start(module).unwrap();
 	(addr, handle)

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -690,7 +690,7 @@ async fn ws_batch_works() {
 		})
 		.collect();
 	assert_eq!(ok_responses, vec!["hello"]);
-	assert_eq!(err_responses, vec![&ErrorObject::borrowed(UNKNOWN_ERROR_CODE, &"Custom error: err", None)]);
+	assert_eq!(err_responses, vec![&ErrorObject::borrowed(UNKNOWN_ERROR_CODE, &"err", None)]);
 }
 
 #[tokio::test]
@@ -730,13 +730,13 @@ async fn http_batch_works() {
 		})
 		.collect();
 	assert_eq!(ok_responses, vec!["hello"]);
-	assert_eq!(err_responses, vec![&ErrorObject::borrowed(UNKNOWN_ERROR_CODE, &"Custom error: err", None)]);
+	assert_eq!(err_responses, vec![&ErrorObject::borrowed(UNKNOWN_ERROR_CODE, &"err", None)]);
 }
 
 #[tokio::test]
 async fn ws_server_limit_subs_per_conn_works() {
 	use futures::StreamExt;
-	use jsonrpsee::types::error::{CallError, TOO_MANY_SUBSCRIPTIONS_CODE, TOO_MANY_SUBSCRIPTIONS_MSG};
+	use jsonrpsee::types::error::{TOO_MANY_SUBSCRIPTIONS_CODE, TOO_MANY_SUBSCRIPTIONS_MSG};
 	use jsonrpsee::{server::ServerBuilder, RpcModule};
 
 	init_logger();
@@ -781,10 +781,10 @@ async fn ws_server_limit_subs_per_conn_works() {
 	let data = "\"Exceeded max limit of 10\"";
 
 	assert!(
-		matches!(err1, Err(Error::Call(CallError::Custom(err))) if err.code() == TOO_MANY_SUBSCRIPTIONS_CODE && err.message() == TOO_MANY_SUBSCRIPTIONS_MSG && err.data().unwrap().get() == data)
+		matches!(err1, Err(Error::Call(err)) if err.code() == TOO_MANY_SUBSCRIPTIONS_CODE && err.message() == TOO_MANY_SUBSCRIPTIONS_MSG && err.data().unwrap().get() == data)
 	);
 	assert!(
-		matches!(err2, Err(Error::Call(CallError::Custom(err))) if err.code() == TOO_MANY_SUBSCRIPTIONS_CODE && err.message() == TOO_MANY_SUBSCRIPTIONS_MSG && err.data().unwrap().get() == data)
+		matches!(err2, Err(Error::Call(err)) if err.code() == TOO_MANY_SUBSCRIPTIONS_CODE && err.message() == TOO_MANY_SUBSCRIPTIONS_MSG && err.data().unwrap().get() == data)
 	);
 }
 

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -101,9 +101,9 @@ fn test_module() -> RpcModule<()> {
 	#[rpc(server)]
 	pub trait Rpc {
 		#[method(name = "say_hello")]
-		async fn hello(&self) -> Result<&'static str, Error> {
+		async fn hello(&self) -> String {
 			sleep(Duration::from_millis(50)).await;
-			Ok("hello")
+			"hello".to_string()
 		}
 	}
 

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -226,7 +226,7 @@ async fn calling_method_without_server_using_proc_macro() {
 	// Call async method with option which should `Err`.
 	let err = module.call::<_, Option<String>>("can_have_options", vec![2]).await.unwrap_err();
 	assert!(matches!(err,
-		Error::Call(err) if err.message() == "Custom error: too big number"
+		Error::Call(err) if err.message() == "too big number"
 	));
 }
 

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -244,7 +244,7 @@ async fn subscribing_without_server() {
 			while let Some(letter) = stream_data.pop() {
 				tracing::debug!("This is your friendly subscription sending data.");
 				let msg = SubscriptionMessage::from_json(&letter).unwrap();
-				let _ = sink.send(msg).await.unwrap();
+				sink.send(msg).await.unwrap();
 				tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 			}
 
@@ -277,10 +277,8 @@ async fn close_test_subscribing_without_server() {
 			sink.send(msg.clone()).await?;
 			sink.closed().await;
 
-			match sink.send(msg).await {
-				Ok(_) => panic!("The sink should be closed"),
-				Err(DisconnectError(_)) => {}
-			}
+			sink.send(msg).await.expect("The sink should be closed");
+
 			Ok(())
 		})
 		.unwrap();
@@ -318,8 +316,7 @@ async fn subscribing_without_server_bad_params() {
 			let p = match params.one::<String>() {
 				Ok(p) => p,
 				Err(e) => {
-					let err: ErrorObjectOwned = e.into();
-					let _ = pending.reject(err).await;
+					let _ = pending.reject(e).await;
 					return Ok(());
 				}
 			};

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -37,8 +37,9 @@ use thiserror::Error;
 pub type ErrorObjectOwned = ErrorObject<'static>;
 
 /// [Failed JSON-RPC response object](https://www.jsonrpc.org/specification#response_object).
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, thiserror::Error)]
 #[serde(deny_unknown_fields)]
+#[error("kkk")]
 pub struct ErrorObject<'a> {
 	/// Code
 	code: ErrorCode,
@@ -106,16 +107,6 @@ impl<'a> PartialEq for ErrorObject<'a> {
 impl<'a> From<ErrorCode> for ErrorObject<'a> {
 	fn from(code: ErrorCode) -> Self {
 		Self { code, message: code.message().into(), data: None }
-	}
-}
-
-impl<'a> From<CallError> for ErrorObject<'a> {
-	fn from(error: CallError) -> Self {
-		match error {
-			CallError::InvalidParams(e) => ErrorObject::owned(INVALID_PARAMS_CODE, e.to_string(), None::<()>),
-			CallError::Failed(e) => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, e.to_string(), None::<()>),
-			CallError::Custom(err) => err,
-		}
 	}
 }
 
@@ -267,25 +258,12 @@ impl serde::Serialize for ErrorCode {
 
 /// Error that occurs when a call failed.
 #[derive(Debug, thiserror::Error)]
-pub enum CallError {
-	/// Invalid params in the call.
-	#[error("Invalid params in the call: {0}")]
-	InvalidParams(#[source] anyhow::Error),
-	/// The call failed (let jsonrpsee assign default error code and error message).
-	#[error("RPC call failed: {0}")]
-	Failed(#[from] anyhow::Error),
-	/// Custom error with specific JSON-RPC error code, message and data.
-	#[error("RPC call failed: {0:?}")]
-	Custom(ErrorObjectOwned),
-}
+#[error("Invalid params in the call: {0}")]
+pub struct InvalidParams(#[source] pub anyhow::Error);
 
-impl CallError {
-	/// Create `CallError` from a generic error.
-	pub fn from_std_error<E>(err: E) -> Self
-	where
-		E: std::error::Error + Send + Sync + 'static,
-	{
-		CallError::Failed(err.into())
+impl<'a> From<InvalidParams> for ErrorObject<'a> {
+	fn from(_e: InvalidParams) -> Self {
+		ErrorCode::InvalidParams.into()
 	}
 }
 

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -39,7 +39,7 @@ pub type ErrorObjectOwned = ErrorObject<'static>;
 /// [Failed JSON-RPC response object](https://www.jsonrpc.org/specification#response_object).
 #[derive(Debug, Deserialize, Serialize, Clone, thiserror::Error)]
 #[serde(deny_unknown_fields)]
-#[error("kkk")]
+#[error("{self:?}")]
 pub struct ErrorObject<'a> {
 	/// Code
 	code: ErrorCode,

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -256,17 +256,6 @@ impl serde::Serialize for ErrorCode {
 	}
 }
 
-/// Error that occurs when a call failed.
-#[derive(Debug, thiserror::Error)]
-#[error("Invalid params in the call: {0}")]
-pub struct InvalidParams(#[source] pub anyhow::Error);
-
-impl<'a> From<InvalidParams> for ErrorObject<'a> {
-	fn from(_e: InvalidParams) -> Self {
-		ErrorCode::InvalidParams.into()
-	}
-}
-
 /// Helper to get a `JSON-RPC` error object when the maximum number of subscriptions have been exceeded.
 pub fn reject_too_many_subscriptions(limit: u32) -> ErrorObjectOwned {
 	ErrorObjectOwned::owned(

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -29,13 +29,14 @@
 
 use std::fmt;
 
-use crate::error::CallError;
-use anyhow::anyhow;
 use beef::Cow;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+
+use crate::error::ErrorCode;
+use crate::ErrorObjectOwned;
 
 /// JSON-RPC v2 marker type.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -117,17 +118,17 @@ impl<'a> Params<'a> {
 	}
 
 	/// Attempt to parse all parameters as an array or map into type `T`.
-	pub fn parse<T>(&'a self) -> Result<T, CallError>
+	pub fn parse<T>(&'a self) -> Result<T, ErrorObjectOwned>
 	where
 		T: Deserialize<'a>,
 	{
 		// NOTE(niklasad1): Option::None is serialized as `null` so we provide that here.
 		let params = self.0.as_ref().map(AsRef::as_ref).unwrap_or("null");
-		serde_json::from_str(params).map_err(|e| CallError::InvalidParams(e.into()))
+		serde_json::from_str(params).map_err(|_e| ErrorCode::InvalidParams.into())
 	}
 
 	/// Attempt to parse parameters as an array of a single value of type `T`, and returns that value.
-	pub fn one<T>(&'a self) -> Result<T, CallError>
+	pub fn one<T>(&'a self) -> Result<T, ErrorObjectOwned>
 	where
 		T: Deserialize<'a>,
 	{
@@ -161,7 +162,7 @@ impl<'a> Params<'a> {
 pub struct ParamsSequence<'a>(&'a str);
 
 impl<'a> ParamsSequence<'a> {
-	fn next_inner<T>(&mut self) -> Option<Result<T, CallError>>
+	fn next_inner<T>(&mut self) -> Option<Result<T, ErrorObjectOwned>>
 	where
 		T: Deserialize<'a>,
 	{
@@ -178,7 +179,7 @@ impl<'a> ParamsSequence<'a> {
 			_ => {
 				let errmsg = format!("Invalid params. Expected one of '[', ']' or ',' but found {json:?}");
 				tracing::error!("[next_inner] {}", errmsg);
-				return Some(Err(CallError::InvalidParams(anyhow!(errmsg))));
+				return Some(Err(ErrorCode::InvalidParams.into()));
 			}
 		}
 
@@ -199,7 +200,7 @@ impl<'a> ParamsSequence<'a> {
 				);
 				self.0 = "";
 
-				Some(Err(CallError::InvalidParams(e.into())))
+				Some(Err(ErrorCode::InvalidParams.into()))
 			}
 		}
 	}
@@ -220,13 +221,13 @@ impl<'a> ParamsSequence<'a> {
 	/// assert_eq!(c, "foo");
 	/// ```
 	#[allow(clippy::should_implement_trait)]
-	pub fn next<T>(&mut self) -> Result<T, CallError>
+	pub fn next<T>(&mut self) -> Result<T, ErrorObjectOwned>
 	where
 		T: Deserialize<'a>,
 	{
 		match self.next_inner() {
 			Some(result) => result,
-			None => Err(CallError::InvalidParams(anyhow!("No more params"))),
+			None => Err(ErrorCode::InvalidParams.into()),
 		}
 	}
 
@@ -248,7 +249,7 @@ impl<'a> ParamsSequence<'a> {
 	///
 	/// assert_eq!(params, [Some(1), Some(2), None, None]);
 	/// ```
-	pub fn optional_next<T>(&mut self) -> Result<Option<T>, CallError>
+	pub fn optional_next<T>(&mut self) -> Result<Option<T>, ErrorObjectOwned>
 	where
 		T: Deserialize<'a>,
 	{

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -36,7 +36,7 @@ use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::error::ErrorCode;
+use crate::error::{ErrorCode, INVALID_PARAMS_MSG};
 use crate::{ErrorObject, ErrorObjectOwned};
 
 /// JSON-RPC v2 marker type.
@@ -385,7 +385,7 @@ impl<'a> Id<'a> {
 }
 
 fn invalid_params(e: impl ToString) -> ErrorObjectOwned {
-	ErrorObject::owned(ErrorCode::InvalidParams.code(), e.to_string(), None::<()>)
+	ErrorObject::owned(ErrorCode::InvalidParams.code(), INVALID_PARAMS_MSG, Some(e.to_string()))
 }
 
 #[cfg(test)]

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -29,6 +29,7 @@
 
 use std::fmt;
 
+use anyhow::anyhow;
 use beef::Cow;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
@@ -227,7 +228,7 @@ impl<'a> ParamsSequence<'a> {
 	{
 		match self.next_inner() {
 			Some(result) => result,
-			None => Err(ErrorCode::InvalidParams.into()),
+			None => Err(invalid_params(anyhow!("No more params"))),
 		}
 	}
 

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -124,7 +124,7 @@ impl<'a> Params<'a> {
 	{
 		// NOTE(niklasad1): Option::None is serialized as `null` so we provide that here.
 		let params = self.0.as_ref().map(AsRef::as_ref).unwrap_or("null");
-		serde_json::from_str(params).map_err(|e| invalid_params(e))
+		serde_json::from_str(params).map_err(invalid_params)
 	}
 
 	/// Attempt to parse parameters as an array of a single value of type `T`, and returns that value.


### PR DESCRIPTION
Close https://github.com/paritytech/jsonrpsee/issues/1085

One downside of this is that `jsonrpsee::core::Error` can't be used in the proc macro API and I worked around that by changing `type RpcResult<T> = Result<T, ErrorObjectOwned>`

The reason why :point_up: is because the `IntoResponse` requires the error to implement `Into<ErrorObjectOwned>` which ends up being really weird to implement from `Error variants` that isn't really a JSON-RPC v2 spec error but something else like I/O etc.

Thus, it's more explicit for users to implement `Into<ErrorObjectOwned>` themselves which is explicit and more understandable.
