### PR TITLE
rpc module: fix race in subscription close callback

### DIFF
--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -713,7 +713,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 
 					tokio::spawn(async move {
 						// This will wait for the subscription future to be resolved
-						let response = match futures_util::try_join!(sub_fut.map(|f| Ok(f)), accepted_rx) {
+						let response = match futures_util::future::try_join(sub_fut.map(|f| Ok(f)), accepted_rx).await {
 							Ok((r, _)) => r.into_response(),
 							// The accept call failed i.e, the subscription was not accepted.
 							Err(_) => return,

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -36,7 +36,7 @@ use jsonrpsee::server::{
 	AllowHosts, PendingSubscriptionSink, RpcModule, ServerBuilder, ServerHandle, SubscriptionMessage, TrySendError,
 };
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
-use jsonrpsee::{IntoSubscriptionCloseResponse, SubscriptionCloseResponse};
+use jsonrpsee::SubscriptionCloseResponse;
 use serde::Serialize;
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
@@ -105,25 +105,8 @@ pub async fn server_with_subscription_and_handle() -> (SocketAddr, ServerHandle)
 
 	module
 		.register_subscription("subscribe_option", "n", "unsubscribe_option", |_, pending, _| async move {
-			enum Response {
-				Nothing,
-				Closed,
-			}
-
-			impl IntoSubscriptionCloseResponse for Response {
-				fn into_response(self) -> jsonrpsee::SubscriptionCloseResponse {
-					match self {
-						Response::Nothing => SubscriptionCloseResponse::None,
-						Response::Closed => SubscriptionCloseResponse::Notif("close".into()),
-					}
-				}
-			}
-
-			let Ok(_sink) = pending.accept().await else {
-				return Response::Nothing;
-			};
-
-			Response::Closed
+			let _ = pending.accept().await;
+			SubscriptionCloseResponse::None
 		})
 		.unwrap();
 


### PR DESCRIPTION
It's technically possible that `subscription future` finishes after the subscription callback is executed (most likely just in tests) anyway this PR ensures that the `subscription future` completes before the subscription callback is terminated.