### PR TITLE
patch release v0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,13 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 
-## [v0.18.2] - 2023-04-26
+## [v0.18.2] - 2023-05-10
 
-This release fixes a couple bugs around batch requests and connection shutdowns.
-
-### Added
-- server: export BatchRequestConfig  ([#1112](https://github.com/paritytech/jsonrpsee/pull/1112))
+This release improves error message for `too big batch response` and exposes the `BatchRequestConfig type` in order to make it possible to use `ServerBuilder::set_batch_request_config`
 
 ### Fixed
+- server: export BatchRequestConfig  ([#1112](https://github.com/paritytech/jsonrpsee/pull/1112))
 - fix(server): improve too big batch response msg  ([#1107](https://github.com/paritytech/jsonrpsee/pull/1107))
-- fix: `publish script` to work for workspace members  ([#1101](https://github.com/paritytech/jsonrpsee/pull/1101))
-- fix(ws server): fix shutdown on connection closed  ([#1103](https://github.com/paritytech/jsonrpsee/pull/1103))
 
 ## [v0.18.1] - 2023-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+
+## [v0.18.2] - 2023-04-26
+
+This release fixes a couple bugs around batch requests and connection shutdowns.
+
+### Added
+- server: export BatchRequestConfig  ([#1112](https://github.com/paritytech/jsonrpsee/pull/1112))
+
+### Fixed
+- fix(server): improve too big batch response msg  ([#1107](https://github.com/paritytech/jsonrpsee/pull/1107))
+- fix: `publish script` to work for workspace members  ([#1101](https://github.com/paritytech/jsonrpsee/pull/1101))
+- fix(ws server): fix shutdown on connection closed  ([#1103](https://github.com/paritytech/jsonrpsee/pull/1103))
+
 ## [v0.18.1] - 2023-04-26
 
 This release fixes a couple bugs and improves the ergonomics for the HTTP client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 rust-version = "1.64.0"
 license = "MIT"
@@ -30,11 +30,11 @@ keywords = ["jsonrpc", "json", "http", "websocket", "WASM"]
 readme = "README.md"
 
 [workspace.dependencies]
-jsonrpsee-types = { path = "types", version = "0.18.1" }
-jsonrpsee-core = { path = "core", version = "0.18.1" }
-jsonrpsee-server = { path = "server", version = "0.18.1" }
-jsonrpsee-ws-client = { path = "client/ws-client", version = "0.18.1" }
-jsonrpsee-http-client = { path = "client/http-client", version = "0.18.1" }
-jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.18.1" }
-jsonrpsee-client-transport = { path = "client/transport", version = "0.18.1" }
-jsonrpsee-proc-macros = { path = "proc-macros", version = "0.18.1" }
+jsonrpsee-types = { path = "types", version = "0.18.2" }
+jsonrpsee-core = { path = "core", version = "0.18.2" }
+jsonrpsee-server = { path = "server", version = "0.18.2" }
+jsonrpsee-ws-client = { path = "client/ws-client", version = "0.18.2" }
+jsonrpsee-http-client = { path = "client/http-client", version = "0.18.2" }
+jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.18.2" }
+jsonrpsee-client-transport = { path = "client/transport", version = "0.18.2" }
+jsonrpsee-proc-macros = { path = "proc-macros", version = "0.18.2" }


### PR DESCRIPTION
## [v0.18.2] - 2023-04-26

This release fixes a couple bugs around batch requests and connection shutdowns.

### Added
- server: export BatchRequestConfig  ([#1112](https://github.com/paritytech/jsonrpsee/pull/1112))

### Fixed
- fix(server): improve too big batch response msg  ([#1107](https://github.com/paritytech/jsonrpsee/pull/1107))
- fix: `publish script` to work for workspace members  ([#1101](https://github.com/paritytech/jsonrpsee/pull/1101))
- fix(ws server): fix shutdown on connection closed  ([#1103](https://github.com/paritytech/jsonrpsee/pull/1103))