### PR TITLE
shutdown server while there is connection does not work

### DIFF
--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -837,9 +837,6 @@ async fn close_client_with_pending_calls_works() {
 		assert!(rx.recv().await.is_some());
 	}
 
-	client.close().await.unwrap();
-	assert!(client.receive().await.is_err());
-
 	// Stop the server and ensure that the server doesn't wait for futures to complete
 	// when the connection has already been closed.
 	handle.stop().unwrap();


### PR DESCRIPTION
I am upgrading jsonrpsee and identified a regression from our tests that shutdown server while there is existing connection doesn't work.

Shouldn't the server automatically terminate the connections when it is being told to shutdown?

This is a failed test to demo this regression.

This is our test that got broken after upgrade https://github.com/AcalaNetwork/subway/blob/8021a32ec385607976597b4c49f09360903a91c4/src/client/tests.rs#L158