### PR TITLE
fix(server): remove `MethodSinkPermit` to fix backpressure issue on concurrent subscriptions

### DIFF
--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -34,7 +34,7 @@ use jsonrpsee_types::error::{
 use jsonrpsee_types::{Id, InvalidRequest, Response, ResponsePayload};
 use serde::Serialize;
 use serde_json::value::to_raw_value;
-use tokio::sync::mpsc::{self, OwnedPermit};
+use tokio::sync::mpsc::{self, Permit};
 
 use super::{DisconnectError, SendTimeoutError, SubscriptionMessage, TrySendError};
 
@@ -139,6 +139,14 @@ impl MethodSink {
 		self.tx.send(msg).await.map_err(Into::into)
 	}
 
+	/// Send a JSON-RPC error to the client
+	pub async fn send_error<'a>(self, id: Id<'a>, err: ErrorObject<'a>) -> Result<(), DisconnectError> {
+		let json =
+			serde_json::to_string(&Response::new(ResponsePayload::<()>::Error(err), id)).expect("valid JSON; qed");
+
+		self.send(json).await
+	}
+
 	/// Similar to to `MethodSink::send` but only waits for a limited time.
 	pub async fn send_timeout(&self, msg: String, timeout: Duration) -> Result<(), SendTimeoutError> {
 		tx_log_from_str(&msg, self.max_log_length);
@@ -147,8 +155,8 @@ impl MethodSink {
 
 	/// Waits for channel capacity. Once capacity to send one message is available, it is reserved for the caller.
 	pub async fn reserve(&self) -> Result<MethodSinkPermit, DisconnectError> {
-		match self.tx.clone().reserve_owned().await {
-			Ok(permit) => Ok(MethodSinkPermit { tx: permit, max_log_length: self.max_log_length }),
+		match self.tx.reserve().await {
+			Ok(permit) => Ok(MethodSinkPermit { tx: permit }),
 			Err(_) => Err(DisconnectError(SubscriptionMessage::empty())),
 		}
 	}
@@ -156,25 +164,17 @@ impl MethodSink {
 
 /// A method sink with reserved spot in the bounded queue.
 #[derive(Debug)]
-pub struct MethodSinkPermit {
-	tx: OwnedPermit<String>,
-	max_log_length: u32,
+pub struct MethodSinkPermit<'a> {
+	tx: Permit<'a, String>,
 }
 
-impl MethodSinkPermit {
+impl<'a> MethodSinkPermit<'a> {
 	/// Send a JSON-RPC error to the client
 	pub fn send_error(self, id: Id, err: ErrorObject) {
-		let json = serde_json::to_string(&Response::new(ResponsePayload::<()>::Error(err.into_owned()), id))
-			.expect("valid JSON; qed");
+		let json =
+			serde_json::to_string(&Response::new(ResponsePayload::<()>::Error(err), id)).expect("valid JSON; qed");
 
-		self.send_raw(json)
-	}
-
-	/// Send a raw JSON-RPC message to the client, `MethodSink` does not check the validity
-	/// of the JSON being sent.
-	pub fn send_raw(self, json: String) {
-		self.tx.send(json.clone());
-		tx_log_from_str(&json, self.max_log_length);
+		self.tx.send(json);
 	}
 }
 

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -153,11 +153,11 @@ impl MethodSink {
 		self.tx.send_timeout(msg, timeout).await.map_err(Into::into)
 	}
 
-	/// Waits for channel capacity. Once capacity to send one message is available.
+	/// Waits for there to be space on the return channel.
 	pub async fn has_capacity(&self) -> Result<(), DisconnectError> {
 		match self.tx.reserve().await {
 			// The permit is thrown away here because it's just
-			// a way to ensure that underlying buffer is not empty.
+			// a way to ensure that the return buffer has space.
 			Ok(_) => Ok(()),
 			Err(_) => Err(DisconnectError(SubscriptionMessage::empty())),
 		}

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -38,7 +38,7 @@ mod rpc_module;
 mod subscription;
 
 pub use error::*;
-pub use helpers::{BatchResponseBuilder, BoundedWriter, MethodResponse, MethodSink, MethodSinkPermit};
+pub use helpers::{BatchResponseBuilder, BoundedWriter, MethodResponse, MethodSink};
 pub use host_filtering::*;
 pub use rpc_module::*;
 pub use subscription::*;

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -261,7 +261,7 @@ pub(crate) async fn background_task<L: Logger>(sender: Sender, mut receiver: Rec
 	let result = loop {
 		data.clear();
 
-		// This is a guard to ensure that the underlying socket is only read if there is space in 
+		// This is a guard to ensure that the underlying socket is only read if there is space in
 		// the buffer for messages to be sent back to them.
 		//
 		// Thus, this check enforces that if the client can't keep up with receiving messages,

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -261,11 +261,11 @@ pub(crate) async fn background_task<L: Logger>(sender: Sender, mut receiver: Rec
 	let result = loop {
 		data.clear();
 
-		// This is a guard to ensure that underlying socket is only "read" if connection buffer has capacity
-		// to send further messages.
+		// This is a guard to ensure that the underlying socket is only read if there is space in 
+		// the buffer for messages to be sent back to them.
 		//
-		// This, this check enforces that if the client can't keep up with connection
-		// no new messages are handled before the existing ones are read.
+		// Thus, this check enforces that if the client can't keep up with receiving messages,
+		// then no new messages will be read from them.
 		//
 		// TCP retransmission mechanism will take of the rest and adjust the window size accordingly.
 		let Some(stop) = wait_until_connection_buffer_has_capacity(&sink, stopped).await else {


### PR DESCRIPTION
After a method call has been received, this PR removes the `MethodSinkPermit` because it wasn't dropped properly and might "deadlock" if all slots in the mpsc channel were acquired by subscriptions which hadn't been "accepted". As `async fn accept` tries to acquire a slot in the mpsc buffer was well.

Refactored to code a little bit as well to make things more understable 