### PR TITLE
downgrade parsing JSON-RPC params logs to `debug/trace`

### DIFF
--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -298,7 +298,7 @@ impl RpcDescription {
 						let #name: #ty = match seq.optional_next() {
 							Ok(v) => v,
 							Err(e) => {
-								#tracing::warn!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
+								#tracing::debug!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								#pending.reject(e).await;
 								return #sub_err::None;
 							}
@@ -310,7 +310,7 @@ impl RpcDescription {
 						let #name: #ty = match seq.optional_next() {
 							Ok(v) => v,
 							Err(e) => {
-								#tracing::warn!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
+								#tracing::debug!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								return #response_payload::Error(e);
 							}
 						};
@@ -321,7 +321,7 @@ impl RpcDescription {
 						let #name: #ty = match seq.next() {
 							Ok(v) => v,
 							Err(e) => {
-								#tracing::warn!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
+								#tracing::debug!(concat!("Error parsing optional \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								#pending.reject(e).await;
 								return #sub_err::None;
 							}
@@ -333,7 +333,7 @@ impl RpcDescription {
 						let #name: #ty = match seq.next() {
 							Ok(v) => v,
 							Err(e) => {
-								#tracing::warn!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
+								#tracing::debug!(concat!("Error parsing \"", stringify!(#name), "\" as \"", stringify!(#ty), "\": {:?}"), e);
 								return #response_payload::Error(e);
 							}
 						};
@@ -399,7 +399,7 @@ impl RpcDescription {
 					let parsed: ParamsObject<#(#types,)*> = match params.parse() {
 						Ok(p) => p,
 						Err(e) => {
-							#tracing::warn!("Failed to parse JSON-RPC params as object: {}", e);
+							#tracing::debug!("Failed to parse JSON-RPC params as object: {}", e);
 							#pending.reject(e).await;
 							return #sub_err::None;
 						}
@@ -418,7 +418,7 @@ impl RpcDescription {
 					let parsed: ParamsObject<#(#types,)*> = match params.parse() {
 						Ok(p) => p,
 						Err(e) => {
-							#tracing::warn!("Failed to parse JSON-RPC params as object: {}", e);
+							#tracing::debug!("Failed to parse JSON-RPC params as object: {}", e);
 							return #response_payload::Error(e);
 						}
 					};

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -161,7 +161,7 @@ where
 					stopped = stop;
 				}
 				AcceptConnection::Err((e, stop)) => {
-					tracing::error!("Error while awaiting a new connection: {:?}", e);
+					tracing::debug!("Error while awaiting a new connection: {:?}", e);
 					stopped = stop;
 				}
 				AcceptConnection::Shutdown => break,
@@ -663,7 +663,7 @@ impl<L: Logger> hyper::service::Service<hyper::Request<hyper::Body>> for TowerSe
 					response.map(|()| hyper::Body::empty())
 				}
 				Err(e) => {
-					tracing::error!("Could not upgrade connection: {}", e);
+					tracing::debug!("Could not upgrade connection: {}", e);
 					hyper::Response::new(hyper::Body::from(format!("Could not upgrade connection: {e}")))
 				}
 			};

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -82,7 +82,7 @@ pub(crate) async fn process_validated_request<L: Logger>(
 		Err(GenericTransportError::TooLarge) => return response::too_large(max_request_body_size),
 		Err(GenericTransportError::Malformed) => return response::malformed(),
 		Err(GenericTransportError::Inner(e)) => {
-			tracing::error!("Internal error reading request body: {}", e);
+			tracing::warn!("Internal error reading request body: {}", e);
 			return response::internal_error();
 		}
 	};
@@ -250,7 +250,7 @@ pub(crate) async fn execute_call<L: Logger>(req: Request<'_>, call: CallData<'_,
 			}
 			MethodCallback::Subscription(_) | MethodCallback::Unsubscription(_) => {
 				logger.on_call(name, params.clone(), logger::MethodKind::Unknown, TransportProtocol::Http);
-				tracing::error!("Subscriptions not supported on HTTP");
+				tracing::warn!("Subscriptions not supported on HTTP");
 				MethodResponse::error(id, ErrorObject::from(ErrorCode::InternalError))
 			}
 		},

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -179,7 +179,7 @@ impl<'a> ParamsSequence<'a> {
 			b'[' | b',' => json = &json[1..],
 			_ => {
 				let errmsg = format!("Invalid params. Expected one of '[', ']' or ',' but found {json:?}");
-				tracing::error!("[next_inner] {}", errmsg);
+				tracing::trace!("[next_inner] {}", errmsg);
 				return Some(Err(invalid_params(errmsg)));
 			}
 		}
@@ -193,7 +193,7 @@ impl<'a> ParamsSequence<'a> {
 				Some(Ok(value))
 			}
 			Err(e) => {
-				tracing::error!(
+				tracing::trace!(
 					"[next_inner] Deserialization to {:?} failed. Error: {:?}, input JSON: {:?}",
 					std::any::type_name::<T>(),
 					e,


### PR DESCRIPTION
The reason behind this is that it's quite likely that parsing params in the server fails when the user passes in
the wrong params and doesn't really have to regarded as an `error/warn`.

So let's downgrade that along some others. 

After this PR:

```bash
➜  jsonrpsee git:(na-downgrade-more-logs) ✗ gg "tracing::error\!"
client/transport/src/ws/mod.rs:                                                                         tracing::error!("Redirection failed: {:?}", e);
core/src/client/async_client/helpers.rs:                                tracing::error!("Dropping subscription {:?} error: {:?}", sub_id, err);
core/src/client/async_client/helpers.rs:                        tracing::error!("The server tried to close an invalid subscription: {:?}", sub_id);
core/src/client/async_client/helpers.rs:                                tracing::error!("Error sending notification, dropping handler for {:?} error: {:?}", notif.method, err);
core/src/client/async_client/helpers.rs:                        tracing::error!("Notification: {:?} not a registered method", notif.method);
core/src/client/async_client/helpers.rs:                tracing::error!("Send unsubscribe request failed: {:?}", e);
core/src/client/async_client/mod.rs:                                    tracing::error!("[backend]: {}", err);
core/src/client/async_client/mod.rs:                                    tracing::error!("[backend]: Could not send ping frame: {}", err);
core/src/server/helpers.rs:                             tracing::error!("Error serializing response: {:?}", err);
core/src/server/rpc_module.rs:                                          tracing::error!("Join error for blocking RPC method: {:?}", err);
```

```bash
➜  jsonrpsee git:(na-downgrade-more-logs) ✗ gg "tracing::warn\!"
client/transport/src/ws/mod.rs:                         tracing::warn!("set nodelay failed: {:?}", err);
client/transport/src/ws/mod.rs:                         tracing::warn!("set nodelay failed: {:?}", err);
core/src/client/async_client/helpers.rs:                        tracing::warn!("Received unknown batch response");
core/src/client/async_client/helpers.rs:                        tracing::warn!("Subscription {:?} is not active", sub_id);
core/src/client/async_client/helpers.rs:                        tracing::warn!("Subscription {:?} is not active", sub_id);
core/src/client/async_client/mod.rs:                            tracing::warn!("[backend]: Batch request already pending: {:?}", batch.ids);
core/src/client/async_client/mod.rs:                            tracing::warn!("[backend]: Batch request failed: {:?}", e);
core/src/client/async_client/mod.rs:                            tracing::warn!("[backend]: Notification failed: {:?}", e);
core/src/client/async_client/mod.rs:                            tracing::warn!("[backend]: Request failed: {:?}", e);
core/src/client/async_client/mod.rs:                            tracing::warn!("[backend]: Subscription failed: {:?}", e);
core/src/server/rpc_module.rs:                                                  tracing::warn!(
server/src/server.rs:           tracing::warn!("Could not set NODELAY on socket: {:?}", e);
server/src/transport/http.rs:                   tracing::warn!("Internal error reading request body: {}", e);
server/src/transport/http.rs:                           tracing::warn!("Subscriptions not supported on HTTP");
test-utils/src/mocks.rs:                                                        tracing::warn!("send response to subscription: {:?}", e);
test-utils/src/mocks.rs:                                                        tracing::warn!("send notification: {:?}", e);
test-utils/src/mocks.rs:                                                                tracing::warn!("send response to request error: {:?}", e);
test-utils/src/mocks.rs:                                                                tracing::warn!("send subscription id error: {:?}", e);
```


```bash
➜  jsonrpsee git:(na-downgrade-more-logs) ✗ gg "tracing::info\!"
examples/examples/core_client.rs:       tracing::info!("response: {:?}", response);
examples/examples/http.rs:                              |request: &hyper::Request<hyper::Body>, _span: &tracing::Span| tracing::info!(request = ?request, "on_request"),
examples/examples/http.rs:                              tracing::info!(size_bytes = chunk.len(), latency = ?latency, "sending body chunk")
examples/examples/http.rs:      tracing::info!("r: {:?}", response);
examples/examples/middleware.rs:                                        |request: &hyper::Request<hyper::Body>, _span: &tracing::Span| tracing::info!(request = ?request, "on_request"),
examples/examples/middleware.rs:                                        tracing::info!(size_bytes = chunk.len(), latency = ?latency, "sending body chunk")
examples/examples/ws.rs:        tracing::info!("response: {:?}", response);
examples/examples/ws_pubsub_broadcast.rs:       let fut1 = sub1.take(NUM_SUBSCRIPTION_RESPONSES).for_each(|r| async move { tracing::info!("sub1 rx: {:?}", r) });
examples/examples/ws_pubsub_broadcast.rs:       let fut2 = sub2.take(NUM_SUBSCRIPTION_RESPONSES).for_each(|r| async move { tracing::info!("sub2 rx: {:?}", r) });
examples/examples/ws_pubsub_with_params.rs:     tracing::info!("subscription with one param: {:?}", sub_params_one.next().await);
examples/examples/ws_pubsub_with_params.rs:     tracing::info!("subscription with two params: {:?}", sub_params_two.next().await);
```
