### PR TITLE
fix: include error code in RpcLogger

### DIFF
--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -252,19 +252,22 @@ impl MethodResponse {
 
 				if err.is_io() {
 					let data = to_raw_value(&format!("Exceeded max limit of {max_response_size}")).ok();
+					let err_code = OVERSIZED_RESPONSE_CODE;
+
 					let err = ResponsePayload::error_borrowed(ErrorObject::borrowed(
-						OVERSIZED_RESPONSE_CODE,
+						err_code,
 						&OVERSIZED_RESPONSE_MSG,
 						data.as_deref(),
 					));
 					let result =
 						serde_json::to_string(&Response::new(err, id)).expect("JSON serialization infallible; qed");
 
-					Self { result, success_or_error: MethodResponseResult::Failed(OVERSIZED_RESPONSE_CODE) }
+					Self { result, success_or_error: MethodResponseResult::Failed(err_code) }
 				} else {
-					let result = serde_json::to_string(&Response::new(ErrorCode::InternalError.into(), id))
+					let err_code = ErrorCode::InternalError;
+					let result = serde_json::to_string(&Response::new(err_code.into(), id))
 						.expect("JSON serialization infallible; qed");
-					Self { result, success_or_error: MethodResponseResult::Failed(ErrorCode::InternalError.code()) }
+					Self { result, success_or_error: MethodResponseResult::Failed(err_code.code()) }
 				}
 			}
 		}

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -173,7 +173,7 @@ pub fn prepare_error(data: &[u8]) -> (Id<'_>, ErrorCode) {
 	}
 }
 
-/// Represent the response to method call.
+/// Represent the response to a method call.
 #[derive(Debug, Clone)]
 pub struct MethodResponse {
 	/// Serialized JSON-RPC response,
@@ -194,15 +194,12 @@ impl MethodResponse {
 	}
 }
 
-/// Represent the outcome of method call i.e, success or failed.
-///
-/// If the call failed then the JSON-RPC error code is embedded
-/// to be used for logging and metrics.
+/// Represent the outcome of a method call success or failed.
 #[derive(Debug, Copy, Clone)]
 pub enum MethodResponseResult {
 	/// The method call was successful.
 	Success,
-	/// The method call failed and the error code can used in the RpcLogger.
+	/// The method call with error code.
 	Failed(i32),
 }
 
@@ -217,7 +214,9 @@ impl MethodResponseResult {
 		matches!(self, MethodResponseResult::Failed(_))
 	}
 
-	/// Get the error code.
+	/// Get the error code
+	///
+	/// Returns `Some(error code)` if the call failed.
 	pub fn as_error_code(&self) -> Option<i32> {
 		match self {
 			Self::Failed(e) => Some(*e),

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -272,9 +272,11 @@ impl MethodResponse {
 
 	/// Create a `MethodResponse` from an error.
 	pub fn error<'a>(id: Id, err: impl Into<ErrorObject<'a>>) -> Self {
+		let err: ErrorObject = err.into();
+		let err_code = err.code();
 		let err = ResponsePayload::error_borrowed(err);
 		let result = serde_json::to_string(&Response::new(err, id)).expect("JSON serialization infallible; qed");
-		Self { result, success_or_error: MethodResponseResult::Failed(ErrorCode::InternalError.code()) }
+		Self { result, success_or_error: MethodResponseResult::Failed(err_code) }
 	}
 }
 

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -199,7 +199,7 @@ impl MethodResponse {
 pub enum MethodResponseResult {
 	/// The method call was successful.
 	Success,
-	/// The method call with error code.
+	/// The method call failed with error code.
 	Failed(i32),
 }
 

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -739,7 +739,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 							Ok(msg) => {
 								// If the subscription was accepted then send a message
 								// to subscription task otherwise rely on the drop impl.
-								if msg.success {
+								if msg.is_success() {
 									let _ = accepted_tx.send(());
 								}
 								Ok(msg)

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -261,7 +261,7 @@ impl PendingSubscriptionSink {
 			ResponsePayload::result_borrowed(&self.uniq_sub.sub_id),
 			self.inner.max_response_size() as usize,
 		);
-		let success = response.success;
+		let success = response.is_success();
 
 		// TODO: #1052
 		//

--- a/examples/examples/logger.rs
+++ b/examples/examples/logger.rs
@@ -28,6 +28,7 @@ use std::net::SocketAddr;
 use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
+use jsonrpsee::helpers::MethodResponseResult;
 use jsonrpsee::server::logger::{self, HttpRequest, MethodKind, Params, TransportProtocol};
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::WsClientBuilder;
@@ -52,8 +53,19 @@ impl logger::Logger for Timings {
 		println!("[Logger::on_call] method: '{}', params: {:?}, kind: {}", name, params, kind);
 	}
 
-	fn on_result(&self, name: &str, succeess: bool, started_at: Self::Instant, _t: TransportProtocol) {
-		println!("[Logger::on_result] '{}', worked? {}, time elapsed {:?}", name, succeess, started_at.elapsed());
+	fn on_result(
+		&self,
+		name: &str,
+		success_or_error: MethodResponseResult,
+		started_at: Self::Instant,
+		_t: TransportProtocol,
+	) {
+		println!(
+			"[Logger::on_result] '{}', worked? {}, time elapsed {:?}",
+			name,
+			success_or_error.is_success(),
+			started_at.elapsed()
+		);
 	}
 
 	fn on_response(&self, result: &str, started_at: Self::Instant, _t: TransportProtocol) {

--- a/examples/examples/logger.rs
+++ b/examples/examples/logger.rs
@@ -28,7 +28,7 @@ use std::net::SocketAddr;
 use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::server::logger::{self, HttpRequest, MethodKind, Params, TransportProtocol};
+use jsonrpsee::server::logger::{self, HttpRequest, MethodKind, Params, SuccessOrError, TransportProtocol};
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, RpcModule};
@@ -52,8 +52,19 @@ impl logger::Logger for Timings {
 		println!("[Logger::on_call] method: '{}', params: {:?}, kind: {}", name, params, kind);
 	}
 
-	fn on_result(&self, name: &str, succeess: bool, started_at: Self::Instant, _t: TransportProtocol) {
-		println!("[Logger::on_result] '{}', worked? {}, time elapsed {:?}", name, succeess, started_at.elapsed());
+	fn on_result(
+		&self,
+		name: &str,
+		success_or_error: SuccessOrError,
+		started_at: Self::Instant,
+		_t: TransportProtocol,
+	) {
+		println!(
+			"[Logger::on_result] '{}', worked? {}, time elapsed {:?}",
+			name,
+			success_or_error.is_success(),
+			started_at.elapsed()
+		);
 	}
 
 	fn on_response(&self, result: &str, started_at: Self::Instant, _t: TransportProtocol) {

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -32,7 +32,7 @@ use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::logger::{HttpRequest, MethodKind, TransportProtocol};
+use jsonrpsee::server::logger::{HttpRequest, MethodKind, SuccessOrError, TransportProtocol};
 use jsonrpsee::server::{logger, RpcModule, ServerBuilder};
 use jsonrpsee::types::Params;
 use jsonrpsee::ws_client::WsClientBuilder;
@@ -56,8 +56,19 @@ impl logger::Logger for Timings {
 		println!("[Timings:on_call] method: '{}', params: {:?}, kind: {}", name, params, kind);
 	}
 
-	fn on_result(&self, name: &str, success: bool, started_at: Self::Instant, _t: TransportProtocol) {
-		println!("[Timings] call={}, worked? {}, duration {:?}", name, success, started_at.elapsed());
+	fn on_result(
+		&self,
+		name: &str,
+		success_or_error: SuccessOrError,
+		started_at: Self::Instant,
+		_t: TransportProtocol,
+	) {
+		println!(
+			"[Timings] call={}, worked? {}, duration {:?}",
+			name,
+			success_or_error.is_success(),
+			started_at.elapsed()
+		);
 	}
 
 	fn on_response(&self, _result: &str, started_at: Self::Instant, _t: TransportProtocol) {
@@ -106,7 +117,13 @@ impl logger::Logger for ThreadWatcher {
 		threads as isize
 	}
 
-	fn on_result(&self, _name: &str, _succees: bool, started_at: Self::Instant, _t: TransportProtocol) {
+	fn on_result(
+		&self,
+		_name: &str,
+		_success_or_error: SuccessOrError,
+		started_at: Self::Instant,
+		_t: TransportProtocol,
+	) {
 		let current_nr_threads = Self::count_threads() as isize;
 		println!("[ThreadWatcher::on_result] {} threads", current_nr_threads - started_at);
 	}

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -31,7 +31,6 @@ use std::process::Command;
 use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::helpers::MethodResponseResult;
 use jsonrpsee::rpc_params;
 use jsonrpsee::server::logger::{HttpRequest, MethodKind, SuccessOrError, TransportProtocol};
 use jsonrpsee::server::{logger, RpcModule, ServerBuilder};

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -31,6 +31,7 @@ use std::process::Command;
 use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
+use jsonrpsee::helpers::MethodResponseResult;
 use jsonrpsee::rpc_params;
 use jsonrpsee::server::logger::{HttpRequest, MethodKind, TransportProtocol};
 use jsonrpsee::server::{logger, RpcModule, ServerBuilder};
@@ -56,8 +57,19 @@ impl logger::Logger for Timings {
 		println!("[Timings:on_call] method: '{}', params: {:?}, kind: {}", name, params, kind);
 	}
 
-	fn on_result(&self, name: &str, success: bool, started_at: Self::Instant, _t: TransportProtocol) {
-		println!("[Timings] call={}, worked? {}, duration {:?}", name, success, started_at.elapsed());
+	fn on_result(
+		&self,
+		name: &str,
+		success_or_error: MethodResponseResult,
+		started_at: Self::Instant,
+		_t: TransportProtocol,
+	) {
+		println!(
+			"[Timings] call={}, worked? {}, duration {:?}",
+			name,
+			success_or_error.is_success(),
+			started_at.elapsed()
+		);
 	}
 
 	fn on_response(&self, _result: &str, started_at: Self::Instant, _t: TransportProtocol) {
@@ -106,7 +118,13 @@ impl logger::Logger for ThreadWatcher {
 		threads as isize
 	}
 
-	fn on_result(&self, _name: &str, _succees: bool, started_at: Self::Instant, _t: TransportProtocol) {
+	fn on_result(
+		&self,
+		_name: &str,
+		_success_or_error: MethodResponseResult,
+		started_at: Self::Instant,
+		_t: TransportProtocol,
+	) {
 		let current_nr_threads = Self::count_threads() as isize;
 		println!("[ThreadWatcher::on_result] {} threads", current_nr_threads - started_at);
 	}

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -31,6 +31,7 @@ use std::net::SocketAddr;
 /// HTTP request.
 pub type HttpRequest = hyper::Request<Body>;
 pub use hyper::{Body, HeaderMap as Headers};
+pub use jsonrpsee_core::server::helpers::MethodResponseResult as SuccessOrError;
 pub use jsonrpsee_types::Params;
 
 /// The type JSON-RPC v2 call, it can be a subscription, method call or unknown.
@@ -99,7 +100,13 @@ pub trait Logger: Send + Sync + Clone + 'static {
 	fn on_call(&self, method_name: &str, params: Params, kind: MethodKind, transport: TransportProtocol);
 
 	/// Called on each JSON-RPC method completion, batch requests will trigger `on_result` multiple times.
-	fn on_result(&self, method_name: &str, success: bool, started_at: Self::Instant, transport: TransportProtocol);
+	fn on_result(
+		&self,
+		method_name: &str,
+		success_or_error: SuccessOrError,
+		started_at: Self::Instant,
+		transport: TransportProtocol,
+	);
 
 	/// Called once the JSON-RPC request is finished and response is sent to the output buffer.
 	fn on_response(&self, result: &str, started_at: Self::Instant, transport: TransportProtocol);
@@ -117,7 +124,7 @@ impl Logger for () {
 
 	fn on_call(&self, _: &str, _: Params, _: MethodKind, _p: TransportProtocol) {}
 
-	fn on_result(&self, _: &str, _: bool, _: Self::Instant, _p: TransportProtocol) {}
+	fn on_result(&self, _: &str, _: SuccessOrError, _: Self::Instant, _p: TransportProtocol) {}
 
 	fn on_response(&self, _: &str, _: Self::Instant, _p: TransportProtocol) {}
 
@@ -145,9 +152,15 @@ where
 		self.1.on_call(method_name, params, kind, transport);
 	}
 
-	fn on_result(&self, method_name: &str, success: bool, started_at: Self::Instant, transport: TransportProtocol) {
-		self.0.on_result(method_name, success, started_at.0, transport);
-		self.1.on_result(method_name, success, started_at.1, transport);
+	fn on_result(
+		&self,
+		method_name: &str,
+		success_or_error: SuccessOrError,
+		started_at: Self::Instant,
+		transport: TransportProtocol,
+	) {
+		self.0.on_result(method_name, success_or_error, started_at.0, transport);
+		self.1.on_result(method_name, success_or_error, started_at.1, transport);
 	}
 
 	fn on_response(&self, result: &str, started_at: Self::Instant, transport: TransportProtocol) {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -303,7 +303,7 @@ impl<B, L> Builder<B, L> {
 	/// ```
 	/// use std::{time::Instant, net::SocketAddr};
 	///
-	/// use jsonrpsee_server::logger::{Logger, HttpRequest, MethodKind, Params, TransportProtocol};
+	/// use jsonrpsee_server::logger::{Logger, HttpRequest, MethodKind, Params, TransportProtocol, SuccessOrError};
 	/// use jsonrpsee_server::ServerBuilder;
 	///
 	/// #[derive(Clone)]
@@ -324,8 +324,8 @@ impl<B, L> Builder<B, L> {
 	///          println!("[MyLogger::on_call] method: '{}' params: {:?}, kind: {:?}, transport: {}", method_name, params, kind, transport);
 	///     }
 	///
-	///     fn on_result(&self, method_name: &str, success: bool, started_at: Self::Instant, transport: TransportProtocol) {
-	///          println!("[MyLogger::on_result] '{}', worked? {}, time elapsed {:?}, transport: {}", method_name, success, started_at.elapsed(), transport);
+	///     fn on_result(&self, method_name: &str, success_or_error: SuccessOrError, started_at: Self::Instant, transport: TransportProtocol) {
+	///          println!("[MyLogger::on_result] '{}', worked? {}, time elapsed {:?}, transport: {}", method_name, success_or_error.is_success(), started_at.elapsed(), transport);
 	///     }
 	///
 	///     fn on_response(&self, result: &str, started_at: Self::Instant, transport: TransportProtocol) {

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -10,7 +10,9 @@ use futures_util::stream::{FuturesOrdered, StreamExt};
 use hyper::Method;
 use jsonrpsee_core::error::GenericTransportError;
 use jsonrpsee_core::http_helpers::read_body;
-use jsonrpsee_core::server::helpers::{batch_response_error, prepare_error, BatchResponseBuilder, MethodResponse};
+use jsonrpsee_core::server::helpers::{
+	batch_response_error, prepare_error, BatchResponseBuilder, MethodResponse, MethodResponseResult,
+};
 use jsonrpsee_core::server::{MethodCallback, Methods};
 use jsonrpsee_core::tracing::{rx_log_from_json, tx_log_from_str};
 use jsonrpsee_core::JsonRawValue;
@@ -257,14 +259,14 @@ pub(crate) async fn execute_call<L: Logger>(req: Request<'_>, call: CallData<'_,
 	};
 
 	tx_log_from_str(&response.result, max_log_length);
-	logger.on_result(name, response.success, request_start, TransportProtocol::Http);
+	logger.on_result(name, response.success_or_error, request_start, TransportProtocol::Http);
 	response
 }
 
 #[instrument(name = "notification", fields(method = notif.method.as_ref()), skip(notif, max_log_length), level = "TRACE")]
 fn execute_notification(notif: Notif, max_log_length: u32) -> MethodResponse {
 	rx_log_from_json(&notif, max_log_length);
-	let response = MethodResponse { result: String::new(), success: true };
+	let response = MethodResponse { result: String::new(), success_or_error: MethodResponseResult::Success };
 	tx_log_from_str(&response.result, max_log_length);
 	response
 }

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -220,7 +220,7 @@ pub(crate) async fn execute_call<'a, L: Logger>(req: Request<'a>, call: CallData
 	let r = response.as_response();
 
 	tx_log_from_str(&r.result, max_log_length);
-	logger.on_result(name, r.success, request_start, TransportProtocol::WebSocket);
+	logger.on_result(name, r.success_or_error, request_start, TransportProtocol::WebSocket);
 	response
 }
 

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -36,9 +36,9 @@ use jsonrpsee::core::{client::ClientT, Error};
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::logger::{HttpRequest, Logger, MethodKind, TransportProtocol};
+use jsonrpsee::server::logger::{HttpRequest, Logger, MethodKind, SuccessOrError, TransportProtocol};
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
-use jsonrpsee::types::Params;
+use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Params};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::RpcModule;
 use tokio::time::sleep;
@@ -82,8 +82,8 @@ impl Logger for Counter {
 		entry.0 += 1;
 	}
 
-	fn on_result(&self, name: &str, success: bool, n: u32, _t: TransportProtocol) {
-		if success {
+	fn on_result(&self, name: &str, success_or_error: SuccessOrError, n: u32, _t: TransportProtocol) {
+		if success_or_error.is_success() {
 			self.inner.lock().unwrap().calls.get_mut(name).unwrap().1.push(n);
 		}
 	}
@@ -104,6 +104,11 @@ fn test_module() -> RpcModule<()> {
 		async fn hello(&self) -> String {
 			sleep(Duration::from_millis(50)).await;
 			"hello".to_string()
+		}
+
+		#[method(name = "err")]
+		async fn err(&self) -> Result<String, ErrorObjectOwned> {
+			Err(ErrorObject::owned(1, "err", None::<()>))
 		}
 	}
 
@@ -154,12 +159,16 @@ async fn ws_server_logger() {
 	let res: Result<String, Error> = client.request("unknown_method", rpc_params![]).await;
 	assert!(res.is_err());
 
+	let res: Result<String, Error> = client.request("err", rpc_params![]).await;
+	assert!(res.is_err());
+
 	{
 		let inner = counter.inner.lock().unwrap();
 
 		assert_eq!(inner.connections, (1, 0));
-		assert_eq!(inner.requests, (5, 5));
+		assert_eq!(inner.requests, (6, 6));
 		assert_eq!(inner.calls["say_hello"], (3, vec![0, 2, 3]));
+		assert_eq!(inner.calls["err"], (1, vec![]));
 		assert_eq!(inner.calls["unknown_method"], (2, vec![]));
 	}
 
@@ -193,17 +202,20 @@ async fn http_server_logger() {
 	let res: Result<String, Error> = client.request("unknown_method", rpc_params![]).await;
 	assert!(res.is_err());
 
+	let res: Result<String, Error> = client.request("err", rpc_params![]).await;
+	assert!(res.is_err());
+
 	{
 		let inner = counter.inner.lock().unwrap();
-		assert_eq!(inner.requests, (5, 5));
+		assert_eq!(inner.requests, (6, 6));
 		assert_eq!(inner.calls["say_hello"], (3, vec![0, 2, 3]));
 		assert_eq!(inner.calls["unknown_method"], (2, vec![]));
+		assert_eq!(inner.calls["err"], (1, vec![]));
 	}
 
 	server_handle.stop().unwrap();
 	server_handle.stopped().await;
 
-	// HTTP server doesn't track connections
 	let inner = counter.inner.lock().unwrap();
-	assert_eq!(inner.connections, (5, 5));
+	assert_eq!(inner.connections, (6, 6));
 }

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -133,6 +133,7 @@ pub struct SubscriptionPayloadError<'a, T> {
 /// "result":<value>
 /// "error":{"code":<code>,"message":<msg>,"data":<data>}
 /// ```
+#[derive(Debug, Clone, PartialEq)]
 pub enum ResponsePayload<'a, T>
 where
 	T: Clone,
@@ -159,28 +160,6 @@ impl<'a, T: Clone> ResponsePayload<'a, T> {
 		match self {
 			Self::Error(e) => ResponsePayload::Error(e.into_owned()),
 			Self::Result(r) => ResponsePayload::Result(StdCow::Owned(r.into_owned())),
-		}
-	}
-}
-
-impl<'a, T> fmt::Debug for ResponsePayload<'a, T>
-where
-	T: fmt::Debug + Clone,
-{
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.write_fmt(format_args!("{:?}", self))
-	}
-}
-
-impl<'a, T> PartialEq for ResponsePayload<'a, T>
-where
-	T: PartialEq + Clone,
-{
-	fn eq(&self, other: &Self) -> bool {
-		match (self, other) {
-			(ResponsePayload::Error(a), ResponsePayload::Error(b)) => a == b,
-			(ResponsePayload::Result(a), ResponsePayload::Result(b)) => a == b,
-			_ => false,
 		}
 	}
 }


### PR DESCRIPTION
Close #1129 

In addition it contains a bug fix that were introduced by the `IntoResponse` trait and I forgot to check the outcome from the `ResponsePayload` where the user could inject there own JSON-RPC error codes etc.

Thanks to @wlmyng for spotting the bug.