### PR TITLE
make `Server::start` infallible and add `fn builder()`

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -125,7 +125,7 @@ pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::
 	let module = gen_rpc_module();
 
 	let addr = server.local_addr().unwrap();
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 	(format!("http://{}", addr), handle)
 }
 
@@ -161,7 +161,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::se
 		.unwrap();
 
 	let addr = format!("ws://{}", server.local_addr().unwrap());
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 	(addr, handle)
 }
 

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -233,6 +233,13 @@ impl Default for HttpClientBuilder<Identity> {
 	}
 }
 
+impl HttpClientBuilder<Identity> {
+	/// Create a new builder.
+	pub fn new() -> HttpClientBuilder<Identity> {
+		HttpClientBuilder::default()
+	}
+}
+
 /// JSON-RPC HTTP Client that provides functionality to perform method calls and notifications.
 #[derive(Debug, Clone)]
 pub struct HttpClient<S = HttpBackend> {
@@ -242,6 +249,13 @@ pub struct HttpClient<S = HttpBackend> {
 	request_timeout: Duration,
 	/// Request ID manager.
 	id_manager: Arc<RequestIdManager>,
+}
+
+impl<S> HttpClient<S> {
+	/// Create a builder for the HttpClient.
+	pub fn builder() -> HttpClientBuilder {
+		HttpClientBuilder::new()
+	}
 }
 
 #[async_trait]

--- a/client/wasm-client/src/lib.rs
+++ b/client/wasm-client/src/lib.rs
@@ -81,6 +81,11 @@ impl Default for WasmClientBuilder {
 }
 
 impl WasmClientBuilder {
+	/// Create a new WASM client builder.
+	pub fn new() -> WasmClientBuilder {
+		WasmClientBuilder::default()
+	}
+
 	/// See documentation [`ClientBuilder::request_timeout`] (default is 60 seconds).
 	pub fn request_timeout(mut self, timeout: Duration) -> Self {
 		self.request_timeout = timeout;

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -109,6 +109,11 @@ impl Default for WsClientBuilder {
 }
 
 impl WsClientBuilder {
+	/// Create a new WebSocket client builder.
+	pub fn new() -> WsClientBuilder {
+		WsClientBuilder::default()
+	}
+
 	/// Force to use the rustls native certificate store.
 	///
 	/// Since multiple certificate stores can be optionally enabled, this option will

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -92,6 +92,11 @@ impl Default for ClientBuilder {
 }
 
 impl ClientBuilder {
+	/// Create a builder for the client.
+	pub fn new() -> ClientBuilder {
+		ClientBuilder::default()
+	}
+
 	/// Set request timeout (default is 60 seconds).
 	pub fn request_timeout(mut self, timeout: Duration) -> Self {
 		self.request_timeout = timeout;
@@ -248,6 +253,11 @@ pub struct Client {
 }
 
 impl Client {
+	/// Create a builder for the server.
+	pub fn builder() -> ClientBuilder {
+		ClientBuilder::new()
+	}
+
 	/// Checks if the client is connected to the target.
 	pub fn is_connected(&self) -> bool {
 		!self.to_back.is_closed()

--- a/examples/examples/core_client.rs
+++ b/examples/examples/core_client.rs
@@ -55,7 +55,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	module.register_method("say_hello", |_, _| "lo")?;
 	let addr = server.local_addr()?;
 
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/core_client.rs
+++ b/examples/examples/core_client.rs
@@ -29,7 +29,7 @@ use std::net::SocketAddr;
 use jsonrpsee::client_transport::ws::{Uri, WsTransportClientBuilder};
 use jsonrpsee::core::client::{Client, ClientBuilder, ClientT};
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::server::{RpcModule, Server};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::default().build("127.0.0.1:0").await?;
+	let server = Server::builder().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 	let addr = server.local_addr()?;

--- a/examples/examples/cors_server.rs
+++ b/examples/examples/cors_server.rs
@@ -28,10 +28,9 @@
 //! with access control allowing requests from all hosts.
 
 use hyper::Method;
+use jsonrpsee::server::{AllowHosts, RpcModule, Server};
 use std::net::SocketAddr;
 use tower_http::cors::{Any, CorsLayer};
-
-use jsonrpsee::server::{AllowHosts, RpcModule, ServerBuilder};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -86,7 +85,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	// modifying requests / responses. These features are independent of one another
 	// and can also be used separately.
 	// In this example, we use both features.
-	let server = ServerBuilder::default()
+	let server = Server::builder()
 		.set_host_filtering(AllowHosts::Any)
 		.set_middleware(middleware)
 		.build("127.0.0.1:0".parse::<SocketAddr>()?)

--- a/examples/examples/cors_server.rs
+++ b/examples/examples/cors_server.rs
@@ -99,7 +99,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	})?;
 
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -31,7 +31,7 @@ use hyper::body::Bytes;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::server::{RpcModule, Server};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tower_http::LatencyUnit;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::default().build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
+	let server = Server::builder().build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -72,7 +72,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	module.register_method("say_hello", |_, _| "lo")?;
 
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -45,7 +45,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
 use jsonrpsee::server::middleware::proxy_get_request::ProxyGetRequestLayer;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::server::{RpcModule, Server};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -87,8 +87,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		.layer(ProxyGetRequestLayer::new("/health", "system_health")?)
 		.timeout(Duration::from_secs(2));
 
-	let server =
-		ServerBuilder::new().set_middleware(service_builder).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
+	let server = Server::builder().set_middleware(service_builder).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
 
 	let addr = server.local_addr()?;
 

--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -96,7 +96,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	module.register_method("say_hello", |_, _| "lo").unwrap();
 	module.register_method("system_health", |_, _| serde_json::json!({ "health": true })).unwrap();
 
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/logger.rs
+++ b/examples/examples/logger.rs
@@ -29,7 +29,7 @@ use std::time::Instant;
 
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::server::logger::{self, HttpRequest, MethodKind, Params, TransportProtocol};
-use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::server::Server;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, RpcModule};
 
@@ -85,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::new().set_logger(Timings).build("127.0.0.1:0").await?;
+	let server = Server::builder().set_logger(Timings).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 	let addr = server.local_addr()?;

--- a/examples/examples/logger.rs
+++ b/examples/examples/logger.rs
@@ -90,7 +90,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	module.register_method("say_hello", |_, _| "lo")?;
 	let addr = server.local_addr()?;
 
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/middleware.rs
+++ b/examples/examples/middleware.rs
@@ -42,7 +42,7 @@ use tower_http::LatencyUnit;
 
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::server::{RpcModule, Server};
 use jsonrpsee::ws_client::WsClientBuilder;
 
 #[tokio::main]
@@ -104,8 +104,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		.layer(cors)
 		.timeout(Duration::from_secs(2));
 
-	let server =
-		ServerBuilder::new().set_middleware(service_builder).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
+	let server = Server::builder().set_middleware(service_builder).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
 
 	let addr = server.local_addr()?;
 

--- a/examples/examples/middleware.rs
+++ b/examples/examples/middleware.rs
@@ -112,7 +112,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo").unwrap();
 
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -153,7 +153,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		""
 	})?;
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/multi_logger.rs
+++ b/examples/examples/multi_logger.rs
@@ -33,7 +33,7 @@ use std::time::Instant;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
 use jsonrpsee::server::logger::{HttpRequest, MethodKind, TransportProtocol};
-use jsonrpsee::server::{logger, RpcModule, ServerBuilder};
+use jsonrpsee::server::{logger, RpcModule, Server};
 use jsonrpsee::types::Params;
 use jsonrpsee::ws_client::WsClientBuilder;
 
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::new().set_logger((Timings, ThreadWatcher)).build("127.0.0.1:0").await?;
+	let server = Server::builder().set_logger((Timings, ThreadWatcher)).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 	module.register_method("thready", |params, _| {

--- a/examples/examples/proc_macro.rs
+++ b/examples/examples/proc_macro.rs
@@ -102,7 +102,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await?;
 
 	let addr = server.local_addr()?;
-	let handle = server.start(RpcServerImpl.into_rpc())?;
+	let handle = server.start(RpcServerImpl.into_rpc());
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/proc_macro.rs
+++ b/examples/examples/proc_macro.rs
@@ -28,7 +28,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, client::Subscription, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{PendingSubscriptionSink, ServerBuilder, SubscriptionMessage};
+use jsonrpsee::server::{PendingSubscriptionSink, Server, SubscriptionMessage};
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
 
@@ -99,7 +99,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::default().build("127.0.0.1:0").await?;
+	let server = Server::builder().build("127.0.0.1:0").await?;
 
 	let addr = server.local_addr()?;
 	let handle = server.start(RpcServerImpl.into_rpc());

--- a/examples/examples/proc_macro_bounds.rs
+++ b/examples/examples/proc_macro_bounds.rs
@@ -86,7 +86,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await?;
 
 	let addr = server.local_addr()?;
-	let handle = server.start(RpcServerImpl.into_rpc())?;
+	let handle = server.start(RpcServerImpl.into_rpc());
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/proc_macro_bounds.rs
+++ b/examples/examples/proc_macro_bounds.rs
@@ -28,7 +28,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::async_trait;
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
 
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::default().build("127.0.0.1:0").await?;
+	let server = Server::builder().build("127.0.0.1:0").await?;
 
 	let addr = server.local_addr()?;
 	let handle = server.start(RpcServerImpl.into_rpc());

--- a/examples/examples/tokio_console.rs
+++ b/examples/examples/tokio_console.rs
@@ -36,7 +36,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::server::Server;
 use jsonrpsee::RpcModule;
 
 #[tokio::main]
@@ -49,7 +49,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::default().build("127.0.0.1:9944").await?;
+	let server = Server::builder().build("127.0.0.1:9944").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 	module.register_method("memory_call", |_, _| "A".repeat(1024 * 1024))?;

--- a/examples/examples/tokio_console.rs
+++ b/examples/examples/tokio_console.rs
@@ -59,7 +59,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	})?;
 
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing a stopping the server so let it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/ws.rs
+++ b/examples/examples/ws.rs
@@ -54,7 +54,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/ws.rs
+++ b/examples/examples/ws.rs
@@ -27,7 +27,7 @@
 use std::net::SocketAddr;
 
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::server::Server;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, RpcModule};
 use tracing_subscriber::util::SubscriberInitExt;
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = ServerBuilder::default().build("127.0.0.1:0").await?;
+	let server = Server::builder().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 	let addr = server.local_addr()?;

--- a/examples/examples/ws_pubsub_broadcast.rs
+++ b/examples/examples/ws_pubsub_broadcast.rs
@@ -33,7 +33,7 @@ use futures::StreamExt;
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use jsonrpsee::core::server::SubscriptionMessage;
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::server::{RpcModule, Server};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::PendingSubscriptionSink;
 use tokio::sync::broadcast;
@@ -66,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	// let's configure the server only hold 5 messages in memory.
-	let server = ServerBuilder::default().set_message_buffer_capacity(5).build("127.0.0.1:0").await?;
+	let server = Server::builder().set_message_buffer_capacity(5).build("127.0.0.1:0").await?;
 	let (tx, _rx) = broadcast::channel::<usize>(16);
 
 	let mut module = RpcModule::new(tx.clone());

--- a/examples/examples/ws_pubsub_broadcast.rs
+++ b/examples/examples/ws_pubsub_broadcast.rs
@@ -82,7 +82,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		})
 		.unwrap();
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/examples/examples/ws_pubsub_with_params.rs
+++ b/examples/examples/ws_pubsub_with_params.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use jsonrpsee::core::Serialize;
-use jsonrpsee::server::{RpcModule, ServerBuilder, SubscriptionMessage, TrySendError};
+use jsonrpsee::server::{RpcModule, Server, SubscriptionMessage, TrySendError};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, PendingSubscriptionSink};
 use tokio::time::interval;
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	const LETTERS: &str = "abcdefghijklmnopqrstuvxyz";
-	let server = ServerBuilder::default().set_message_buffer_capacity(10).build("127.0.0.1:0").await?;
+	let server = Server::builder().set_message_buffer_capacity(10).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module
 		.register_subscription("sub_one_param", "sub_one_param", "unsub_one_param", |params, pending, _| async move {

--- a/examples/examples/ws_pubsub_with_params.rs
+++ b/examples/examples/ws_pubsub_with_params.rs
@@ -96,7 +96,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		.unwrap();
 
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	// In this example we don't care about doing shutdown so let's it run forever.
 	// You may use the `ServerHandle` to shut it down or manage it yourself.

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -357,7 +357,7 @@ pub(crate) mod visitor;
 /// pub async fn server() -> SocketAddr {
 ///     let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 ///     let addr = server.local_addr().unwrap();
-///     let server_handle = server.start(RpcServerImpl.into_rpc()).unwrap();
+///     let server_handle = server.start(RpcServerImpl.into_rpc());
 ///
 ///     // `into_rpc()` method was generated inside of the `RpcServer` trait under the hood.
 ///     tokio::spawn(server_handle.stopped());

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -97,7 +97,7 @@ impl RpcServer for RpcServerImpl {
 pub async fn server() -> SocketAddr {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(RpcServerImpl.into_rpc()).unwrap();
+	let server_handle = server.start(RpcServerImpl.into_rpc());
 
 	tokio::spawn(server_handle.stopped());
 

--- a/proc-macros/tests/ui/correct/custom_ret_types.rs
+++ b/proc-macros/tests/ui/correct/custom_ret_types.rs
@@ -112,7 +112,7 @@ pub trait RpcClient {
 pub async fn server() -> SocketAddr {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(RpcServerImpl.into_rpc()).unwrap();
+	let server_handle = server.start(RpcServerImpl.into_rpc());
 
 	tokio::spawn(server_handle.stopped());
 

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -41,7 +41,7 @@ impl RpcServer for RpcServerImpl {
 pub async fn server() -> SocketAddr {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(RpcServerImpl.into_rpc()).unwrap();
+	let server_handle = server.start(RpcServerImpl.into_rpc());
 
 	tokio::spawn(server_handle.stopped());
 	addr

--- a/proc-macros/tests/ui/correct/param_kind.rs
+++ b/proc-macros/tests/ui/correct/param_kind.rs
@@ -43,7 +43,7 @@ impl RpcServer for RpcServerImpl {
 pub async fn server() -> SocketAddr {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(RpcServerImpl.into_rpc()).unwrap();
+	let server_handle = server.start(RpcServerImpl.into_rpc());
 
 	tokio::spawn(server_handle.stopped());
 

--- a/proc-macros/tests/ui/correct/rpc_bounds.rs
+++ b/proc-macros/tests/ui/correct/rpc_bounds.rs
@@ -123,14 +123,14 @@ pub async fn websocket_servers() -> (SocketAddr, SocketAddr) {
 	// Start server from `MyRpcS` trait.
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr_server_only = server.local_addr().unwrap();
-	let server_handle = server.start(ServerOnlyImpl.into_rpc()).unwrap();
+	let server_handle = server.start(ServerOnlyImpl.into_rpc());
 
 	tokio::spawn(server_handle.stopped());
 
 	// Start server from `MyRpcSC` trait.
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr_server_client = server.local_addr().unwrap();
-	let server_handle = server.start(ServerClientServerImpl.into_rpc()).unwrap();
+	let server_handle = server.start(ServerClientServerImpl.into_rpc());
 
 	tokio::spawn(server_handle.stopped());
 

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
@@ -48,7 +48,7 @@ pub async fn server() -> SocketAddr {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = server.local_addr().unwrap();
 
-	server.start(DeprecatedServerImpl.into_rpc()).unwrap();
+	server.start(DeprecatedServerImpl.into_rpc());
 
 	addr
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -102,7 +102,7 @@ where
 	/// Start responding to connections requests.
 	///
 	/// This will run on the tokio runtime until the server is stopped or the `ServerHandle` is dropped.
-	pub fn start(mut self, methods: impl Into<Methods>) -> Result<ServerHandle, Error> {
+	pub fn start(mut self, methods: impl Into<Methods>) -> ServerHandle {
 		let methods = methods.into();
 		let (stop_tx, stop_rx) = watch::channel(());
 
@@ -113,7 +113,7 @@ where
 			None => tokio::spawn(self.start_inner(methods, stop_handle)),
 		};
 
-		Ok(ServerHandle::new(stop_tx))
+		ServerHandle::new(stop_tx)
 	}
 
 	async fn start_inner(self, methods: Methods, stop_handle: StopHandle) {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -82,6 +82,11 @@ impl<B, L> Server<B, L> {
 	pub fn local_addr(&self) -> Result<SocketAddr, Error> {
 		self.listener.local_addr().map_err(Into::into)
 	}
+
+	/// Create a builder for the server.
+	pub fn builder() -> Builder {
+		Builder::new()
+	}
 }
 
 impl<S, B, L> Server<S, L>

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -67,6 +67,13 @@ pub struct Server<B = Identity, L = ()> {
 	service_builder: tower::ServiceBuilder<B>,
 }
 
+impl Server<Identity, ()> {
+	/// Create a builder for the server.
+	pub fn builder() -> Builder {
+		Builder::new()
+	}
+}
+
 impl<L> std::fmt::Debug for Server<L> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Server")
@@ -81,11 +88,6 @@ impl<B, L> Server<B, L> {
 	/// Returns socket address to which the server is bound.
 	pub fn local_addr(&self) -> Result<SocketAddr, Error> {
 		self.listener.local_addr().map_err(Into::into)
-	}
-
-	/// Create a builder for the server.
-	pub fn builder() -> Builder {
-		Builder::new()
 	}
 }
 

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -118,7 +118,7 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 
 	let addr = server.local_addr().unwrap();
 
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 	(addr, server_handle)
 }
 
@@ -160,7 +160,7 @@ pub(crate) async fn server_with_context() -> SocketAddr {
 		.unwrap();
 
 	let addr = server.local_addr().unwrap();
-	let handle = server.start(rpc_module).unwrap();
+	let handle = server.start(rpc_module);
 
 	tokio::spawn(handle.stopped());
 	addr

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -85,7 +85,7 @@ async fn server() -> (SocketAddr, ServerHandle) {
 		})
 		.unwrap();
 
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 	(addr, server_handle)
 }
 
@@ -461,7 +461,7 @@ async fn can_set_the_max_request_body_size() {
 	module.register_method("anything", |_p, _cx| "a".repeat(100)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 
 	// Invalid: too long
 	let req = format!(r#"{{"jsonrpc":"2.0", "method":{}, "id":1}}"#, "a".repeat(100));
@@ -486,7 +486,7 @@ async fn can_set_the_max_response_size() {
 	module.register_method("anything", |_p, _cx| "a".repeat(101)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 
 	// Oversized response.
 	let req = r#"{"jsonrpc":"2.0", "method":"anything", "id":1}"#;
@@ -506,7 +506,7 @@ async fn can_set_the_max_response_size_to_batch() {
 	module.register_method("anything", |_p, _cx| "a".repeat(51)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 
 	// Two response will end up in a response of 102 bytes which is too big.
 	let req = r#"[{"jsonrpc":"2.0", "method":"anything", "id":1},{"jsonrpc":"2.0", "method":"anything", "id":2}]"#;
@@ -527,7 +527,7 @@ async fn disabled_batches() {
 	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 
 	// Send a valid batch.
 	let req = r#"[
@@ -551,7 +551,7 @@ async fn batch_limit_works() {
 	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 
 	// Send a valid batch.
 	let req = r#"[

--- a/server/src/tests/shared.rs
+++ b/server/src/tests/shared.rs
@@ -54,7 +54,7 @@ async fn http_only_works() {
 		.unwrap();
 
 	let addr = server.local_addr().unwrap();
-	let _server_handle = server.start(module).unwrap();
+	let _server_handle = server.start(module);
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id":1}"#;
 	let response = http_request(req.into(), to_http_uri(addr)).with_default_timeout().await.unwrap().unwrap();
@@ -79,7 +79,7 @@ async fn ws_only_works() {
 		.unwrap();
 
 	let addr = server.local_addr().unwrap();
-	let _server_handle = server.start(module).unwrap();
+	let _server_handle = server.start(module);
 
 	let req = r#"{"jsonrpc":"2.0","method":"say_hello","id":1}"#;
 	let response = http_request(req.into(), to_http_uri(addr)).with_default_timeout().await.unwrap().unwrap();

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -50,7 +50,7 @@ async fn can_set_the_max_request_body_size() {
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx| "a".repeat(100)).unwrap();
 	let addr = server.local_addr().unwrap();
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 
 	let mut client = WebSocketTestClient::new(addr).await.unwrap();
 
@@ -78,7 +78,7 @@ async fn can_set_the_max_response_body_size() {
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx| "a".repeat(101)).unwrap();
 	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 
 	let mut client = WebSocketTestClient::new(addr).await.unwrap();
 
@@ -101,7 +101,7 @@ async fn can_set_the_max_response_size_to_batch() {
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx| "a".repeat(51)).unwrap();
 	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 
 	let mut client = WebSocketTestClient::new(addr).await.unwrap();
 
@@ -125,7 +125,7 @@ async fn can_set_max_connections() {
 	module.register_method("anything", |_p, _cx| ()).unwrap();
 	let addr = server.local_addr().unwrap();
 
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 
 	let conn1 = WebSocketTestClient::new(addr).await;
 	let conn2 = WebSocketTestClient::new(addr).await;
@@ -575,7 +575,7 @@ async fn custom_subscription_id_works() {
 			}
 		})
 		.unwrap();
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
@@ -600,7 +600,7 @@ async fn disabled_batches() {
 	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 
 	// Send a valid batch.
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
@@ -630,7 +630,7 @@ async fn batch_limit_works() {
 	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 
 	// Send a valid batch.
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
@@ -767,7 +767,7 @@ async fn ws_server_backpressure_works() {
 		.unwrap();
 	let addr = server.local_addr().unwrap();
 
-	let _server_handle = server.start(module).unwrap();
+	let _server_handle = server.start(module);
 
 	// Send a valid batch.
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
@@ -899,5 +899,5 @@ async fn server_with_infinite_call(
 		.unwrap();
 	let addr = server.local_addr().unwrap();
 
-	(server.start(module).unwrap(), addr)
+	(server.start(module), addr)
 }

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -119,7 +119,7 @@ pub async fn server_with_subscription_and_handle() -> (SocketAddr, ServerHandle)
 		.unwrap();
 
 	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 
 	(addr, server_handle)
 }
@@ -158,7 +158,7 @@ pub async fn server() -> SocketAddr {
 
 	let addr = server.local_addr().unwrap();
 
-	let server_handle = server.start(module).unwrap();
+	let server_handle = server.start(module);
 
 	tokio::spawn(server_handle.stopped());
 
@@ -186,7 +186,7 @@ pub async fn server_with_sleeping_subscription(tx: futures::channel::mpsc::Sende
 			res.map_err(Into::into)
 		})
 		.unwrap();
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 
 	tokio::spawn(handle.stopped());
 
@@ -218,7 +218,7 @@ pub async fn server_with_access_control(allowed_hosts: AllowHosts, cors: CorsLay
 
 	module.register_method("system_health", |_, _| serde_json::json!({ "health": true })).unwrap();
 
-	let handle = server.start(module).unwrap();
+	let handle = server.start(module);
 	(addr, handle)
 }
 

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -458,7 +458,7 @@ async fn ws_server_should_stop_subscription_after_client_drop() {
 		)
 		.unwrap();
 
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
@@ -490,7 +490,7 @@ async fn ws_server_stop_subscription_when_dropped() {
 		.register_subscription("subscribe_nop", "h", "unsubscribe_nop", |_params, _pending, _ctx| async { Ok(()) })
 		.unwrap();
 
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	assert!(client.subscribe::<String, ArrayParams>("subscribe_nop", rpc_params![], "unsubscribe_nop").await.is_err());
@@ -754,7 +754,7 @@ async fn ws_server_limit_subs_per_conn_works() {
 			pipe_from_stream_and_drop(pending, stream).await.map_err(Into::into)
 		})
 		.unwrap();
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 
 	let c1 = WsClientBuilder::default().build(&server_url).await.unwrap();
 	let c2 = WsClientBuilder::default().build(&server_url).await.unwrap();
@@ -809,7 +809,7 @@ async fn ws_server_unsub_methods_should_ignore_sub_limit() {
 			pipe_from_stream_and_drop(pending, stream).await.map_err(Into::into)
 		})
 		.unwrap();
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
@@ -1031,7 +1031,7 @@ async fn ws_host_filtering_wildcard_works() {
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| "hello").unwrap();
 
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 
 	let server_url = format!("ws://{}", addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
@@ -1052,7 +1052,7 @@ async fn http_host_filtering_wildcard_works() {
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| "hello").unwrap();
 
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 
 	let server_url = format!("http://{}", addr);
 	let client = HttpClientBuilder::default().build(&server_url).unwrap();
@@ -1073,7 +1073,7 @@ async fn deny_invalid_host() {
 	let addr = server.local_addr().unwrap();
 	module.register_method("say_hello", |_, _| "hello").unwrap();
 
-	let _handle = server.start(module).unwrap();
+	let _handle = server.start(module);
 
 	// HTTP
 	{
@@ -1233,7 +1233,7 @@ async fn run_shutdown_test(transport: &str) {
 			.unwrap();
 		let addr = server.local_addr().unwrap();
 
-		(server.start(module).unwrap(), addr)
+		(server.start(module), addr)
 	};
 
 	match transport {

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -116,7 +116,7 @@ async fn websocket_server(module: RpcModule<()>, counter: Counter) -> Result<(So
 	let server = ServerBuilder::default().set_logger(counter).build("127.0.0.1:0").await?;
 
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	Ok((addr, handle))
 }
@@ -125,7 +125,7 @@ async fn http_server(module: RpcModule<()>, counter: Counter) -> Result<(SocketA
 	let server = ServerBuilder::default().set_logger(counter).build("127.0.0.1:0").await?;
 
 	let addr = server.local_addr()?;
-	let handle = server.start(module)?;
+	let handle = server.start(module);
 
 	Ok((addr, handle))
 }

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -195,7 +195,7 @@ use rpc_impl::{RpcClient, RpcServer, RpcServerImpl};
 pub async fn server() -> SocketAddr {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = server.local_addr().unwrap();
-	let handle = server.start(RpcServerImpl.into_rpc()).unwrap();
+	let handle = server.start(RpcServerImpl.into_rpc());
 
 	tokio::spawn(handle.stopped());
 
@@ -318,7 +318,7 @@ async fn subscriptions_do_not_work_for_http_servers() {
 	let htserver = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = htserver.local_addr().unwrap();
 	let htserver_url = format!("http://{}", addr);
-	let _handle = htserver.start(RpcServerImpl.into_rpc()).unwrap();
+	let _handle = htserver.start(RpcServerImpl.into_rpc());
 
 	let htclient = HttpClientBuilder::default().build(&htserver_url).unwrap();
 
@@ -385,7 +385,7 @@ async fn calls_with_object_params_works() {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 	let addr = server.local_addr().unwrap();
 	let server_url = format!("ws://{}", addr);
-	let _handle = server.start(RpcServerImpl.into_rpc()).unwrap();
+	let _handle = server.start(RpcServerImpl.into_rpc());
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	// snake_case params


### PR DESCRIPTION
`Server::start` was infallible to let's change the API to reflect that.