### PR TITLE
add uptest new rust lib as a jsonrpsee user

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ If your project uses `jsonrpsee` we would like to know. Please open a pull reque
 - [subwasm](https://github.com/chevdor/subwasm)
 - [subway](https://github.com/AcalaNetwork/subway)
 - [subxt](https://github.com/paritytech/subxt)
-- [Trin](https://github.com/ethereum/trin)
+- [Trin](https://github.com/ethereum/trin)   
+- [Uptest](https://github.com/uptest-sc/uptest)   
 
 ## Benchmarks
 


### PR DESCRIPTION
A newly released client library named uptest is utilizing JsonRpsee under the hood