### PR TITLE
ci-unified with rust 1.71.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
-  CI_IMAGE:                        "paritytech/ci-linux:production"
+  CI_IMAGE:                        "paritytech/ci-unified:bullseye-1.71.0-2023-05-23"
 
 .common-refs:                      &common-refs
   rules:


### PR DESCRIPTION
update CI_IMAGE to paritytech/ci-unified:bullseye-1.71.0-2023-05-23
relates to [Update gitlab rust version to 1.17.1 #849](https://github.com/paritytech/ci_cd/issues/849)