### PR TITLE
refactor: make ErrorObject::borrowed accept `&str`

### DIFF
--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -73,7 +73,7 @@ impl<'a> ErrorObject<'a> {
 	}
 
 	/// Create a new [`ErrorObject`] with optional data.
-	pub fn borrowed(code: i32, message: &'a impl AsRef<str>, data: Option<&'a RawValue>) -> ErrorObject<'a> {
+	pub fn borrowed(code: i32, message: &'a (impl AsRef<str> + ?Sized), data: Option<&'a RawValue>) -> ErrorObject<'a> {
 		ErrorObject { code: code.into(), message: StdCow::Borrowed(message.as_ref()), data: data.map(StdCow::Borrowed) }
 	}
 

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -74,7 +74,7 @@ impl<'a> ErrorObject<'a> {
 
 	/// Create a new [`ErrorObject`] with optional data.
 	pub fn borrowed(code: i32, message: &'a str, data: Option<&'a RawValue>) -> ErrorObject<'a> {
-		ErrorObject { code: code.into(), message: StdCow::Borrowed(message.as_ref()), data: data.map(StdCow::Borrowed) }
+		ErrorObject { code: code.into(), message: StdCow::Borrowed(message), data: data.map(StdCow::Borrowed) }
 	}
 
 	/// Take ownership of the parameters within, if we haven't already.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -73,7 +73,7 @@ impl<'a> ErrorObject<'a> {
 	}
 
 	/// Create a new [`ErrorObject`] with optional data.
-	pub fn borrowed(code: i32, message: &'a (impl AsRef<str> + ?Sized), data: Option<&'a RawValue>) -> ErrorObject<'a> {
+	pub fn borrowed(code: i32, message: &'a str, data: Option<&'a RawValue>) -> ErrorObject<'a> {
 		ErrorObject { code: code.into(), message: StdCow::Borrowed(message.as_ref()), data: data.map(StdCow::Borrowed) }
 	}
 


### PR DESCRIPTION
If you pass DST reference type as message to `ErrorObject::borrowed`, you'll get error like this:
```
error[E0277]: the size for values of type `str` cannot be known at compilation time
  --> src/main.rs:2:50
   |
2  |     jsonrpsee::types::ErrorObjectOwned::borrowed(0, "ok", None);
   |     --------------------------------------------    ^^^^ doesn't have a size known at compile-time
   |     |
   |     required by a bound introduced by this call
   |
   = help: the trait `Sized` is not implemented for `str`
```
It could be more intuitive to accept such usage.