### PR TITLE
feat: get connection id from PendingSubscriptionSink

### DIFF
--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -287,6 +287,11 @@ impl PendingSubscriptionSink {
 			panic!("The subscription response was too big; adjust the `max_response_size` or change Subscription ID generation");
 		}
 	}
+
+	/// Returns connection identifier, which was used to perform pending subscription request
+	pub fn connection_id(&self) -> ConnectionId {
+		self.uniq_sub.conn_id
+	}
 }
 
 /// Represents a single subscription that hasn't been processed yet.


### PR DESCRIPTION
adds public associated method to PendingSubscriptionSink, which allows for retrieval of connection identifier, which was used to perform subscription request

motivation: sometimes it's useful to have a link between websocket subscription and websocket connection, e.g. for preventing duplicate subscriptions on the same connection. Currently there's no API exposing underlying connection identifier, so this PR adds a public method just for this purpose. 