### PR TITLE
refactor: use `RootCertStore::add_trust_anchors`

### DIFF
--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -549,7 +549,7 @@ fn build_tls_config(cert_store: &CertificateStore) -> Result<tokio_rustls::TlsCo
 		}
 		#[cfg(feature = "webpki-tls")]
 		CertificateStore::WebPki => {
-			roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
+			roots.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
 				rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(ta.subject, ta.spki, ta.name_constraints)
 			}));
 		}


### PR DESCRIPTION
Fixes the warning for use of deprecated API:  

use of deprecated method `tokio_rustls::rustls::RootCertStore::add_server_trust_anchors`: 
Please use `add_trust_anchors` instead`