### PR TITLE
refactor: update and turn `WsTransportClientBuilder` generic

### DIFF
--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -298,6 +298,19 @@ impl WsTransportClientBuilder {
 		self.try_connect_over_tcp(uri).await
 	}
 
+	/// Try to establish the connection over the given data stream.
+	pub async fn build_with_stream<T>(
+		self,
+		uri: Url,
+		data_stream: T,
+	) -> Result<(Sender<T>, Receiver<T>), WsHandshakeError>
+	where
+		T: AsyncRead + AsyncWrite + Unpin,
+	{
+		let target: Target = uri.try_into()?;
+		self.try_connect(&target, data_stream).await
+	}
+
 	// Try to establish the connection over TCP.
 	async fn try_connect_over_tcp(
 		&self,
@@ -399,19 +412,6 @@ impl WsTransportClientBuilder {
 			}
 		}
 		err.unwrap_or(Err(WsHandshakeError::NoAddressFound(target.host)))
-	}
-
-	/// Try to establish the connection over the given data stream.
-	pub async fn build_with_stream<T>(
-		self,
-		uri: Url,
-		data_stream: T,
-	) -> Result<(Sender<T>, Receiver<T>), WsHandshakeError>
-	where
-		T: AsyncRead + AsyncWrite + Unpin,
-	{
-		let target: Target = uri.try_into()?;
-		self.try_connect(&target, data_stream).await
 	}
 
 	/// Try to establish the handshake over the given data stream.

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -30,21 +30,21 @@ use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use futures_util::io::{BufReader, BufWriter};
 pub use futures_util::{AsyncRead, AsyncWrite};
+use futures_util::io::{BufReader, BufWriter};
+use jsonrpsee_core::{async_trait, Cow};
 use jsonrpsee_core::client::{CertificateStore, MaybeSend, ReceivedMessage, TransportReceiverT, TransportSenderT};
 use jsonrpsee_core::TEN_MB_SIZE_BYTES;
-use jsonrpsee_core::{async_trait, Cow};
+use soketto::{connection, Data, Incoming};
 use soketto::connection::Error::Utf8;
 use soketto::data::ByteSlice125;
 use soketto::handshake::client::{Client as WsHandshakeClient, ServerResponse};
-use soketto::{connection, Data, Incoming};
-use stream::EitherStream;
 use thiserror::Error;
 use tokio::net::TcpStream;
 
 pub use http::{uri::InvalidUri, HeaderMap, HeaderValue, Uri};
 pub use soketto::handshake::client::Header;
+pub use stream::EitherStream;
 pub use url::Url;
 
 /// Sending end of WebSocket transport.

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -30,15 +30,15 @@ use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-pub use futures_util::{AsyncRead, AsyncWrite};
 use futures_util::io::{BufReader, BufWriter};
-use jsonrpsee_core::{async_trait, Cow};
+pub use futures_util::{AsyncRead, AsyncWrite};
 use jsonrpsee_core::client::{CertificateStore, MaybeSend, ReceivedMessage, TransportReceiverT, TransportSenderT};
 use jsonrpsee_core::TEN_MB_SIZE_BYTES;
-use soketto::{connection, Data, Incoming};
+use jsonrpsee_core::{async_trait, Cow};
 use soketto::connection::Error::Utf8;
 use soketto::data::ByteSlice125;
 use soketto::handshake::client::{Client as WsHandshakeClient, ServerResponse};
+use soketto::{connection, Data, Incoming};
 use thiserror::Error;
 use tokio::net::TcpStream;
 

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -31,7 +31,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures_util::io::{BufReader, BufWriter};
-use futures_util::{AsyncRead, AsyncWrite};
+pub use futures_util::{AsyncRead, AsyncWrite};
 use jsonrpsee_core::client::{CertificateStore, MaybeSend, ReceivedMessage, TransportReceiverT, TransportSenderT};
 use jsonrpsee_core::TEN_MB_SIZE_BYTES;
 use jsonrpsee_core::{async_trait, Cow};

--- a/client/transport/src/ws/stream.rs
+++ b/client/transport/src/ws/stream.rs
@@ -41,7 +41,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 #[pin_project(project = EitherStreamProj)]
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum EitherStream {
+pub enum EitherStream {
 	/// Unencrypted socket stream.
 	Plain(#[pin] TcpStream),
 	/// Encrypted socket stream.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,15 +10,19 @@ publish = false
 [dev-dependencies]
 anyhow = "1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
+fast-socks5 = { version = "0.9.1" }
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.14", default-features = false, features = ["alloc"]}
+hyper = { version = "0.14", features = ["http1", "client"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "client-core", "http-client", "ws-client", "macros"] }
 jsonrpsee-test-utils = { path = "../test-utils" }
-tokio = { version = "1.16", features = ["full"] }
-tracing = "0.1.34"
 serde = "1"
 serde_json = "1"
-hyper = { version = "0.14", features = ["http1", "client"] }
-tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
+tokio = { version = "1.16", features = ["full"] }
 tokio-stream = "0.1"
-tower-http = { version = "0.4.0", features = ["full"] }
+tokio-util = { version = "0.7", features = ["compat"]}
 tower = { version = "0.4.13", features = ["full"] }
+tower-http = { version = "0.4.0", features = ["full"] }
+tracing = "0.1.34"
+tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
+pin-project = { version = "1" }

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -83,7 +83,7 @@ async fn ws_subscription_works_over_proxy_stream() {
 	let target_url = format!("ws://{}", server_addr);
 
 	let socks_stream = connect_over_socks_stream(server_addr).await;
-	let data_stream = DataStream::Socks5(socks_stream);
+	let data_stream = DataStream::new(socks_stream);
 
 	let client = WsClientBuilder::default().build_with_stream(target_url, data_stream).await.unwrap();
 
@@ -141,7 +141,7 @@ async fn ws_unsubscription_works_over_proxy_stream() {
 	let server_url = format!("ws://{}", server_addr);
 
 	let socks_stream = connect_over_socks_stream(server_addr).await;
-	let data_stream = DataStream::Socks5(socks_stream);
+	let data_stream = DataStream::new(socks_stream);
 
 	let client = WsClientBuilder::default()
 		.max_concurrent_requests(1)
@@ -198,7 +198,7 @@ async fn ws_subscription_with_input_works_over_proxy_stream() {
 	let server_url = format!("ws://{}", server_addr);
 
 	let socks_stream = connect_over_socks_stream(server_addr).await;
-	let data_stream = DataStream::Socks5(socks_stream);
+	let data_stream = DataStream::new(socks_stream);
 
 	let client = WsClientBuilder::default().build_with_stream(&server_url, data_stream).await.unwrap();
 
@@ -230,7 +230,7 @@ async fn ws_method_call_works_over_proxy_stream() {
 	let server_url = format!("ws://{}", server_addr);
 
 	let socks_stream = connect_over_socks_stream(server_addr).await;
-	let data_stream = DataStream::Socks5(socks_stream);
+	let data_stream = DataStream::new(socks_stream);
 
 	let client = WsClientBuilder::default().build_with_stream(&server_url, data_stream).await.unwrap();
 	let response: String = client.request("say_hello", rpc_params![]).await.unwrap();
@@ -256,7 +256,7 @@ async fn ws_method_call_str_id_works_over_proxy_stream() {
 	let server_url = format!("ws://{}", server_addr);
 
 	let socks_stream = connect_over_socks_stream(server_addr).await;
-	let data_stream = DataStream::Socks5(socks_stream);
+	let data_stream = DataStream::new(socks_stream);
 
 	let client =
 		WsClientBuilder::default().id_format(IdKind::String).build_with_stream(&server_url, data_stream).await.unwrap();

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -36,8 +36,8 @@ use std::time::Duration;
 use futures::stream::FuturesUnordered;
 use futures::{channel::mpsc, StreamExt, TryStreamExt};
 use helpers::{
-	init_logger, pipe_from_stream_and_drop, server, server_with_cors, server_with_health_api, server_with_subscription,
-	server_with_subscription_and_handle,
+	connect_over_socks_stream, init_logger, pipe_from_stream_and_drop, server, server_with_cors,
+	server_with_health_api, server_with_subscription, server_with_subscription_and_handle, DataStream,
 };
 use hyper::http::HeaderValue;
 use jsonrpsee::core::client::{ClientT, IdKind, Subscription, SubscriptionClientT};
@@ -62,6 +62,31 @@ async fn ws_subscription_works() {
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
+	let mut hello_sub: Subscription<String> =
+		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+	let mut foo_sub: Subscription<u64> =
+		client.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo").await.unwrap();
+
+	for _ in 0..10 {
+		let hello = hello_sub.next().await.unwrap().unwrap();
+		let foo = foo_sub.next().await.unwrap().unwrap();
+		assert_eq!(hello, "hello from subscription".to_string());
+		assert_eq!(foo, 1337);
+	}
+}
+
+#[tokio::test]
+async fn ws_subscription_works_over_proxy_stream() {
+	init_logger();
+
+	let server_addr = server_with_subscription().await;
+	let target_url = format!("ws://{}", server_addr);
+
+	let socks_stream = connect_over_socks_stream(server_addr).await;
+	let data_stream = DataStream::Socks5(socks_stream);
+
+	let client = WsClientBuilder::default().build_with_stream(target_url, data_stream).await.unwrap();
+
 	let mut hello_sub: Subscription<String> =
 		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
 	let mut foo_sub: Subscription<u64> =
@@ -109,12 +134,74 @@ async fn ws_unsubscription_works() {
 }
 
 #[tokio::test]
+async fn ws_unsubscription_works_over_proxy_stream() {
+	init_logger();
+
+	let server_addr = server_with_subscription().await;
+	let server_url = format!("ws://{}", server_addr);
+
+	let socks_stream = connect_over_socks_stream(server_addr).await;
+	let data_stream = DataStream::Socks5(socks_stream);
+
+	let client = WsClientBuilder::default()
+		.max_concurrent_requests(1)
+		.build_with_stream(&server_url, data_stream)
+		.await
+		.unwrap();
+
+	let mut sub: Subscription<usize> =
+		client.subscribe("subscribe_foo", rpc_params![], "unsubscribe_foo").await.unwrap();
+
+	// It's technically possible to have race-conditions between the notifications and the unsubscribe message.
+	// So let's wait for the first notification and then unsubscribe.
+	let _item = sub.next().await.unwrap().unwrap();
+
+	sub.unsubscribe().await.unwrap();
+
+	let mut success = false;
+
+	// Wait until a slot is available, as only one concurrent call is allowed.
+	// Then when this finishes we know that unsubscribe call has been finished.
+	for _ in 0..30 {
+		let res: Result<String, _> = client.request("say_hello", rpc_params![]).await;
+		if res.is_ok() {
+			success = true;
+			break;
+		}
+		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+	}
+
+	assert!(success);
+}
+
+#[tokio::test]
 async fn ws_subscription_with_input_works() {
 	init_logger();
 
 	let server_addr = server_with_subscription().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
+	let mut add_one: Subscription<u64> =
+		client.subscribe("subscribe_add_one", rpc_params![1], "unsubscribe_add_one").await.unwrap();
+
+	for i in 2..4 {
+		let next = add_one.next().await.unwrap().unwrap();
+		assert_eq!(next, i);
+	}
+}
+
+#[tokio::test]
+async fn ws_subscription_with_input_works_over_proxy_stream() {
+	init_logger();
+
+	let server_addr = server_with_subscription().await;
+	let server_url = format!("ws://{}", server_addr);
+
+	let socks_stream = connect_over_socks_stream(server_addr).await;
+	let data_stream = DataStream::Socks5(socks_stream);
+
+	let client = WsClientBuilder::default().build_with_stream(&server_url, data_stream).await.unwrap();
+
 	let mut add_one: Subscription<u64> =
 		client.subscribe("subscribe_add_one", rpc_params![1], "unsubscribe_add_one").await.unwrap();
 
@@ -136,12 +223,43 @@ async fn ws_method_call_works() {
 }
 
 #[tokio::test]
+async fn ws_method_call_works_over_proxy_stream() {
+	init_logger();
+
+	let server_addr = server().await;
+	let server_url = format!("ws://{}", server_addr);
+
+	let socks_stream = connect_over_socks_stream(server_addr).await;
+	let data_stream = DataStream::Socks5(socks_stream);
+
+	let client = WsClientBuilder::default().build_with_stream(&server_url, data_stream).await.unwrap();
+	let response: String = client.request("say_hello", rpc_params![]).await.unwrap();
+	assert_eq!(&response, "hello");
+}
+
+#[tokio::test]
 async fn ws_method_call_str_id_works() {
 	init_logger();
 
 	let server_addr = server().await;
 	let server_url = format!("ws://{}", server_addr);
 	let client = WsClientBuilder::default().id_format(IdKind::String).build(&server_url).await.unwrap();
+	let response: String = client.request("say_hello", rpc_params![]).await.unwrap();
+	assert_eq!(&response, "hello");
+}
+
+#[tokio::test]
+async fn ws_method_call_str_id_works_over_proxy_stream() {
+	init_logger();
+
+	let server_addr = server().await;
+	let server_url = format!("ws://{}", server_addr);
+
+	let socks_stream = connect_over_socks_stream(server_addr).await;
+	let data_stream = DataStream::Socks5(socks_stream);
+
+	let client =
+		WsClientBuilder::default().id_format(IdKind::String).build_with_stream(&server_url, data_stream).await.unwrap();
 	let response: String = client.request("say_hello", rpc_params![]).await.unwrap();
 	assert_eq!(&response, "hello");
 }
@@ -256,7 +374,7 @@ async fn ws_subscription_several_clients_with_drop() {
 }
 
 #[tokio::test]
-async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
+async fn ws_subscription_without_polling_does_not_make_client_unusable() {
 	init_logger();
 
 	let server_addr = server_with_subscription().await;
@@ -273,7 +391,7 @@ async fn ws_subscription_without_polling_doesnt_make_client_unuseable() {
 		assert!(hello_sub.next().await.unwrap().is_ok());
 	}
 
-	// NOTE: this is now unuseable and unregistered.
+	// NOTE: this is now unusable and unregistered.
 	assert!(hello_sub.next().await.is_none());
 
 	// The client should still be useable => make sure it still works.

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -24,6 +24,8 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![cfg(test)]
+
 mod helpers;
 
 use std::collections::HashMap;

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -26,6 +26,8 @@
 
 //! Example of using proc macro to generate working client and server.
 
+#![cfg(test)]
+
 mod helpers;
 
 use std::net::SocketAddr;

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -24,6 +24,8 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![cfg(test)]
+
 mod helpers;
 
 use std::collections::{HashMap, VecDeque};


### PR DESCRIPTION
e7ecb9d5bc41ee0cb018a0d4a97c20ed8cb46966 refactor(jsonrpsee-client-transport): update and turn `WsTransportClientBuilder` generic 

- fix(docs): typo on `WsTransportClientBuilder` doc on `Receiver`
  reference.
- refactor: add initial fn signatures for `build_with_stream`,
  `try_connect_over_tcp`, and `try_connect`.
- refactor: expose `EitherStream` visibility to public.
- refactor: make `Sender` and `Receiver` generic over T, a data stream.
- refactor: make `TransportSenderT` and `TransportReceiverT`
  implementations over generic `Sender` and `Receiver`, bound to
`AsyncRead`, `AsyncRead`, `MaybeSend` and `'static`.
- refactor: turn old `try_connect` TCP steps into
  `try_connect_over_tcp`.
- feat: implement `build_with_stream` and `try_connect` to handle and
  handle the handshake for a generic data stream `T`.
- feat: add new `Redirected` error variant to `WsHandshakeError`, as it
  should be handled by the client when using a generic data stream `T`.

c7ae7dd79c781dc87e169838c0336c06b1f5e62f refactor(jsonrpsee-ws-client): add new fns to WsClientBuilder 

- feat: add new `WsClientBuilder::build_with_transport` that builds and
  returns a `WsClient` with the given `Sender` and `Receiver`.
- feat: add new `WsClientBuilder::build_with_stream` that uses the new
  `WsTransportClientBuilder::build_with_stream`, building and returning
  the `WsClient` with the given `data_stream` as transport layer.
- refactor: update the `WsClientBuilder::build` to use the new
  `build_with_transport`, it helps not having duplicated code.
  
10e78a045cc07d5b39f8609f13a7ace8284e741f refactor: re-export EitherStream & sort current list

53641d1ec73c0f4a17191cd7f32b52f646226895 test: add integration tests and helper fns

- add new helper fns to spawn a socks5 server, using `fast-socks5`
- add new helper enum for `DataStream` that acts as a wrapper to
  `Socks5Stream<T>`, similar to what a client would need to do.
- impl AsyncRead + AsyncWrite for the helper `DataStream` enum, to make
  it compatible between futures::io and tokio::io.
- add new tests that connects over a socks5 proxy, and use the new
  `WsClientBuilder::default()::build_with_stream(...) fn.


fixes #1162 #870 