### PR TITLE
refactor(client): support default port number

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0"
 tokio = { version = "1.16", features = ["time"] }
 tracing = "0.1.34"
 tower = { version = "0.4.13", features = ["util"] }
+url = "2.4.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -280,7 +280,7 @@ mod tests {
 	fn https_works() {
 		let client = HttpTransportClient::new(
 			80,
-			"https://localhost:9933",
+			"https://localhost",
 			80,
 			CertificateStore::Native,
 			80,
@@ -288,7 +288,7 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_eq!(&client.target, "https://localhost:9933/");
+		assert_eq!(&client.target, "https://localhost/");
 	}
 
 	#[cfg(not(feature = "__tls"))]
@@ -337,7 +337,7 @@ mod tests {
 	fn url_with_path_works() {
 		let client = HttpTransportClient::new(
 			1337,
-			"http://localhost:9944/my-special-path",
+			"http://localhost/my-special-path",
 			1337,
 			CertificateStore::Native,
 			80,
@@ -345,14 +345,14 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_eq!(&client.target, "http://localhost:9944/my-special-path");
+		assert_eq!(&client.target, "http://localhost/my-special-path");
 	}
 
 	#[test]
 	fn url_with_query_works() {
 		let client = HttpTransportClient::new(
 			u32::MAX,
-			"http://127.0.0.1:9999/my?name1=value1&name2=value2",
+			"http://127.0.0.1/my?name1=value1&name2=value2",
 			u32::MAX,
 			CertificateStore::Native,
 			80,
@@ -360,14 +360,14 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_eq!(&client.target, "http://127.0.0.1:9999/my?name1=value1&name2=value2");
+		assert_eq!(&client.target, "http://127.0.0.1/my?name1=value1&name2=value2");
 	}
 
 	#[test]
 	fn url_with_fragment_is_ignored() {
 		let client = HttpTransportClient::new(
 			999,
-			"http://127.0.0.1:9944/my.htm#ignore",
+			"http://127.0.0.1/my.htm#ignore",
 			999,
 			CertificateStore::Native,
 			80,
@@ -375,14 +375,14 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_eq!(&client.target, "http://127.0.0.1:9944/my.htm");
+		assert_eq!(&client.target, "http://127.0.0.1/my.htm");
 	}
 
 	#[test]
-	fn url_default_port_works() {
+	fn url_default_port_is_omitted() {
 		let client = HttpTransportClient::new(
 			999,
-			"http://127.0.0.1",
+			"http://127.0.0.1:80",
 			999,
 			CertificateStore::Native,
 			80,
@@ -391,6 +391,37 @@ mod tests {
 		)
 		.unwrap();
 		assert_eq!(&client.target, "http://127.0.0.1/");
+	}
+
+	#[cfg(feature = "__tls")]
+	#[test]
+	fn https_custom_port_works() {
+		let client = HttpTransportClient::new(
+			80,
+			"https://localhost:9999",
+			80,
+			CertificateStore::Native,
+			80,
+			HeaderMap::new(),
+			tower::ServiceBuilder::new(),
+		)
+		.unwrap();
+		assert_eq!(&client.target, "https://localhost:9999/");
+	}
+
+	#[test]
+	fn http_custom_port_works() {
+		let client = HttpTransportClient::new(
+			80,
+			"http://localhost:9999",
+			80,
+			CertificateStore::Native,
+			80,
+			HeaderMap::new(),
+			tower::ServiceBuilder::new(),
+		)
+		.unwrap();
+		assert_eq!(&client.target, "http://localhost:9999/");
 	}
 
 	#[tokio::test]

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -9,7 +9,6 @@
 use hyper::body::{Body, HttpBody};
 use hyper::client::{Client, HttpConnector};
 use hyper::http::{HeaderMap, HeaderValue};
-use hyper::Uri;
 use jsonrpsee_core::client::CertificateStore;
 use jsonrpsee_core::error::GenericTransportError;
 use jsonrpsee_core::http_helpers;
@@ -20,6 +19,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use thiserror::Error;
 use tower::{Layer, Service, ServiceExt};
+use url::Url;
 
 const CONTENT_TYPE_JSON: &str = "application/json";
 
@@ -77,7 +77,7 @@ where
 #[derive(Debug, Clone)]
 pub struct HttpTransportClient<S> {
 	/// Target to connect to.
-	target: ParsedUri,
+	target: String,
 	/// HTTP client
 	client: S,
 	/// Configurable max request body size
@@ -109,13 +109,17 @@ where
 		headers: HeaderMap,
 		service_builder: tower::ServiceBuilder<L>,
 	) -> Result<Self, Error> {
-		let uri = ParsedUri::try_from(target.as_ref())?;
+		let mut url = Url::parse(target.as_ref()).map_err(|e| Error::Url(format!("Invalid URL: {e}")))?;
+		if url.host_str().is_none() {
+			return Err(Error::Url("Invalid host".into()));
+		}
+		url.set_fragment(None);
 
-		let client = match uri.0.scheme_str() {
+		let client = match url.scheme() {
 			#[cfg(not(feature = "__tls"))]
-			Some("http") => HttpBackend::Http(Client::new()),
+			"http" => HttpBackend::Http(Client::new()),
 			#[cfg(feature = "__tls")]
-			Some("https") | Some("http") => {
+			"https" | "http" => {
 				let connector = match cert_store {
 					#[cfg(feature = "native-tls")]
 					CertificateStore::Native => hyper_rustls::HttpsConnectorBuilder::new()
@@ -155,7 +159,7 @@ where
 		}
 
 		Ok(Self {
-			target: uri,
+			target: url.as_str().to_owned(),
 			client: service_builder.service(client),
 			max_request_size,
 			max_response_size,
@@ -171,7 +175,7 @@ where
 			return Err(Error::RequestTooLarge);
 		}
 
-		let mut req = hyper::Request::post(&self.target.0);
+		let mut req = hyper::Request::post(&self.target);
 		if let Some(headers) = req.headers_mut() {
 			*headers = self.headers.clone();
 		}
@@ -201,22 +205,6 @@ where
 		let _ = self.inner_send(body).await?;
 
 		Ok(())
-	}
-}
-
-#[derive(Debug, Clone)]
-struct ParsedUri(Uri);
-
-impl TryFrom<&str> for ParsedUri {
-	type Error = Error;
-
-	fn try_from(target: &str) -> Result<Self, Self::Error> {
-		let uri: Uri = target.parse().map_err(|e| Error::Url(format!("Invalid URL: {e}")))?;
-		if uri.port_u16().is_none() {
-			Err(Error::Url("Port number is missing in the URL".into()))
-		} else {
-			Ok(ParsedUri(uri))
-		}
 	}
 }
 
@@ -272,21 +260,6 @@ mod tests {
 	use super::*;
 	use jsonrpsee_core::client::CertificateStore;
 
-	fn assert_target(
-		client: &HttpTransportClient<HttpBackend>,
-		host: &str,
-		scheme: &str,
-		path_and_query: &str,
-		port: u16,
-		max_request_size: u32,
-	) {
-		assert_eq!(client.target.0.scheme_str(), Some(scheme));
-		assert_eq!(client.target.0.path_and_query().map(|pq| pq.as_str()), Some(path_and_query));
-		assert_eq!(client.target.0.host(), Some(host));
-		assert_eq!(client.target.0.port_u16(), Some(port));
-		assert_eq!(client.max_request_size, max_request_size);
-	}
-
 	#[test]
 	fn invalid_http_url_rejected() {
 		let err = HttpTransportClient::new(
@@ -315,7 +288,7 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_target(&client, "localhost", "https", "/", 9933, 80);
+		assert_eq!(&client.target, "https://localhost:9933/");
 	}
 
 	#[cfg(not(feature = "__tls"))]
@@ -372,7 +345,7 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_target(&client, "localhost", "http", "/my-special-path", 9944, 1337);
+		assert_eq!(&client.target, "http://localhost:9944/my-special-path");
 	}
 
 	#[test]
@@ -387,7 +360,7 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_target(&client, "127.0.0.1", "http", "/my?name1=value1&name2=value2", 9999, u32::MAX);
+		assert_eq!(&client.target, "http://127.0.0.1:9999/my?name1=value1&name2=value2");
 	}
 
 	#[test]
@@ -402,7 +375,22 @@ mod tests {
 			tower::ServiceBuilder::new(),
 		)
 		.unwrap();
-		assert_target(&client, "127.0.0.1", "http", "/my.htm", 9944, 999);
+		assert_eq!(&client.target, "http://127.0.0.1:9944/my.htm");
+	}
+
+	#[test]
+	fn url_default_port_works() {
+		let client = HttpTransportClient::new(
+			999,
+			"http://127.0.0.1",
+			999,
+			CertificateStore::Native,
+			80,
+			HeaderMap::new(),
+			tower::ServiceBuilder::new(),
+		)
+		.unwrap();
+		assert_eq!(&client.target, "http://127.0.0.1/");
 	}
 
 	#[tokio::test]

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -25,6 +25,7 @@ http = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
 tokio = { version = "1.16", features = ["net", "time", "macros"], optional = true }
 pin-project = { version = "1", optional = true }
+url = { version = "2.4.0", optional = true }
 
 # tls
 rustls-native-certs = { version = "0.6", optional = true }
@@ -53,6 +54,7 @@ ws = [
     "soketto",
     "pin-project",
     "thiserror",
+    "url",
 ]
 web = [
     "gloo-net",

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -349,7 +349,7 @@ impl WsTransportClientBuilder {
 					}
 					Ok(ServerResponse::Redirect { status_code, location }) => {
 						tracing::debug!("Redirection: status_code: {}, location: {}", status_code, location);
-						match url::Url::parse(&location) {
+						match Url::parse(&location) {
 							// redirection with absolute path => need to lookup.
 							Ok(uri) => {
 								// Absolute URI.

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -372,9 +372,8 @@ impl WsTransportClientBuilder {
 								};
 							}
 
-							// Relative URI.
-							Err(url::ParseError::RelativeUrlWithoutBase)
-							| Err(url::ParseError::RelativeUrlWithCannotBeABaseBase) => {
+							// Relative URI such as `/foo/bar.html` or `cake.html`
+							Err(url::ParseError::RelativeUrlWithoutBase) => {
 								// Replace the entire path_and_query if `location` starts with `/` or `//`.
 								if location.starts_with('/') {
 									target.path_and_query = location;

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -18,6 +18,7 @@ jsonrpsee-types = { workspace = true }
 jsonrpsee-client-transport = { workspace = true, features = ["ws"] }
 jsonrpsee-core = { workspace = true, features = ["async-client"] }
 http = "0.2.0"
+url = "2.4.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -43,8 +43,9 @@ pub use jsonrpsee_types as types;
 
 pub use http::{HeaderMap, HeaderValue};
 use std::time::Duration;
+use url::Url;
 
-use jsonrpsee_client_transport::ws::{InvalidUri, Uri, WsTransportClientBuilder};
+use jsonrpsee_client_transport::ws::WsTransportClientBuilder;
 use jsonrpsee_core::client::{CertificateStore, ClientBuilder, IdKind};
 use jsonrpsee_core::{Error, TEN_MB_SIZE_BYTES};
 
@@ -243,7 +244,7 @@ impl WsClientBuilder {
 			max_redirections,
 		};
 
-		let uri: Uri = url.as_ref().parse().map_err(|e: InvalidUri| Error::Transport(e.into()))?;
+		let uri = Url::parse(url.as_ref()).map_err(|e| Error::Transport(e.into()))?;
 		let (sender, receiver) = transport_builder.build(uri).await.map_err(|e| Error::Transport(e.into()))?;
 
 		let mut client = ClientBuilder::default()

--- a/examples/examples/core_client.rs
+++ b/examples/examples/core_client.rs
@@ -26,7 +26,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::client_transport::ws::{Uri, WsTransportClientBuilder};
+use jsonrpsee::client_transport::ws::{Url, WsTransportClientBuilder};
 use jsonrpsee::core::client::{Client, ClientBuilder, ClientT};
 use jsonrpsee::rpc_params;
 use jsonrpsee::server::{RpcModule, Server};
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
 		.expect("setting default subscriber failed");
 
 	let addr = run_server().await?;
-	let uri: Uri = format!("ws://{}", addr).parse()?;
+	let uri = Url::parse(&format!("ws://{}", addr))?;
 
 	let (tx, rx) = WsTransportClientBuilder::default().build(uri).await?;
 	let client: Client = ClientBuilder::default().build_with_tokio(tx, rx);

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -330,7 +330,7 @@ async fn http_making_more_requests_than_allowed_should_not_deadlock() {
 async fn https_works() {
 	init_logger();
 
-	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io:443").unwrap();
+	let client = HttpClientBuilder::default().build("https://kusama-rpc.polkadot.io").unwrap();
 	let response: String = client.request("system_chain", rpc_params![]).await.unwrap();
 	assert_eq!(&response, "Kusama");
 }
@@ -339,25 +339,9 @@ async fn https_works() {
 async fn wss_works() {
 	init_logger();
 
-	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io:443").await.unwrap();
+	let client = WsClientBuilder::default().build("wss://kusama-rpc.polkadot.io").await.unwrap();
 	let response: String = client.request("system_chain", rpc_params![]).await.unwrap();
 	assert_eq!(&response, "Kusama");
-}
-
-#[tokio::test]
-async fn ws_with_non_ascii_url_doesnt_hang_or_panic() {
-	init_logger();
-
-	let err = WsClientBuilder::default().build("wss://♥♥♥♥♥♥∀∂").await;
-	assert!(matches!(err, Err(Error::Transport(_))));
-}
-
-#[tokio::test]
-async fn http_with_non_ascii_url_doesnt_hang_or_panic() {
-	init_logger();
-
-	let err = HttpClientBuilder::default().build("http://♥♥♥♥♥♥∀∂");
-	assert!(matches!(err, Err(Error::Transport(_))));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Close #1048 and https://github.com/paritytech/jsonrpsee/issues/1169

I switched to the `url` crate which supports default port numbers and once the `Url::parse` fails with `RelativeUrErrorl` on a redirection then it's treated as well-formed. If it fails then connection will be dropped anyway.