### PR TITLE
fix(server): host filter via URI read authority

### DIFF
--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -9,7 +9,7 @@ use futures_util::future::Either;
 use futures_util::stream::{FuturesOrdered, StreamExt};
 use hyper::Method;
 use jsonrpsee_core::error::GenericTransportError;
-use jsonrpsee_core::http_helpers::read_body;
+use jsonrpsee_core::http_helpers::{self, read_body};
 use jsonrpsee_core::server::helpers::{
 	batch_response_error, prepare_error, BatchResponseBuilder, MethodResponse, MethodResponseResult,
 };
@@ -47,6 +47,20 @@ pub(crate) async fn reject_connection(socket: tokio::net::TcpStream) {
 	if let Err(e) = hyper::server::conn::Http::new().serve_connection(socket, hyper::service::service_fn(reject)).await
 	{
 		tracing::debug!("HTTP serve connection failed {:?}", e);
+	}
+}
+
+/// The `Authority` can be sent by the client in the `Host header` or in the `URI`
+/// such that we must check both.
+pub(crate) fn fetch_authority(request: &hyper::Request<hyper::Body>) -> Option<&str> {
+	let host_header = http_helpers::read_header_value(request.headers(), hyper::header::HOST);
+	let uri = request.uri().authority();
+
+	match (host_header, uri) {
+		(Some(a1), Some(a2)) if a1 == a2.as_str() => Some(a1),
+		(Some(a), None) => Some(a),
+		(None, Some(a)) => Some(a.as_str()),
+		_ => None,
 	}
 }
 


### PR DESCRIPTION
It is possible that the HOST is sent via the URI and when that is the case the server should read the `Authority (host:port)` not only the host