### PR TITLE
client: downgrade log for unknown subscription to `DEBUG`

### DIFF
--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -101,7 +101,7 @@ pub(crate) fn process_subscription_response(
 	let request_id = match manager.get_request_id_by_subscription_id(&sub_id) {
 		Some(request_id) => request_id,
 		None => {
-			tracing::warn!("Subscription {:?} is not active", sub_id);
+			tracing::debug!("Subscription {:?} is not active", sub_id);
 			return Err(None);
 		}
 	};
@@ -115,7 +115,7 @@ pub(crate) fn process_subscription_response(
 			}
 		},
 		None => {
-			tracing::warn!("Subscription {:?} is not active", sub_id);
+			tracing::debug!("Subscription {:?} is not active", sub_id);
 			Err(None)
 		}
 	}


### PR DESCRIPTION
Why this is a warning? It is not possible to completely eliminate such case and there is not really anything to be worried about when this happens.