### PR TITLE
refactor(http client): use HTTP connector on http URLs

### DIFF
--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -116,10 +116,9 @@ where
 		url.set_fragment(None);
 
 		let client = match url.scheme() {
-			#[cfg(not(feature = "__tls"))]
 			"http" => HttpBackend::Http(Client::new()),
 			#[cfg(feature = "__tls")]
-			"https" | "http" => {
+			"https" => {
 				let connector = match cert_store {
 					#[cfg(feature = "native-tls")]
 					CertificateStore::Native => hyper_rustls::HttpsConnectorBuilder::new()


### PR DESCRIPTION
The HTTP connector is much faster than the HTTPS connector so if the URL is a `http:://<....>` let's us it.

This can be enforced by disabling the TLS feature but as it's part of the default features, thus worth having.