### PR TITLE
ci: use latest nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: nightly-2023-02-11
+          toolchain: nightly
           override: true
 
       - name: Check rustdoc


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/107950 is fixed and no need to use a very old nightly version anymore.