### PR TITLE
fix(server): fix leak in FuturesUnordered

### DIFF
--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -250,8 +250,8 @@ pub(crate) async fn background_task<L: Logger>(sender: Sender, mut receiver: Rec
 	let bounded_subscriptions = BoundedSubscriptions::new(max_subscriptions_per_connection);
 
 	// On each method call the `pending_calls` is cloned
-	// then all pending_calls are dropped then a graceful shutdown
-	// has occured.
+	// then when all pending_calls are dropped
+	// a graceful shutdown can has occur.
 	let (pending_calls, pending_calls_completed) = mpsc::channel::<()>(1);
 
 	// Spawn another task that sends out the responses on the Websocket.

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -560,8 +560,8 @@ async fn execute_unchecked_call<L: Logger>(
 		}
 	};
 
-    // NOTE: This channel is only used to indicate that a method call was completed
-    // thus the drop here tells the main task that method call was completed.
+	// NOTE: This channel is only used to indicate that a method call was completed
+	// thus the drop here tells the main task that method call was completed.
 	drop(drop_on_completion);
 }
 

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -560,6 +560,8 @@ async fn execute_unchecked_call<L: Logger>(
 		}
 	};
 
+    // NOTE: This channel is only used to indicate that a method call was completed
+    // thus the drop here tells the main task that method call was completed.
 	drop(drop_on_completion);
 }
 


### PR DESCRIPTION
FuturesUnordered was not getting polled until shutdown, so it was accumulating tasks forever. The change uses a channel instead to wait until all senders are closed before shutdown can happen.

Reduces the memory usage significantly but still slightly worse than v0.16.x, around 2x but that should be okay.

Close #1200 