### PR TITLE
graceful shutdown: terminate on error

### DIFF
--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -565,13 +565,11 @@ async fn graceful_shutdown<S>(
 		let graceful_shutdown = pending_calls.for_each(|_| async {});
 		let disconnect = ws_stream.try_for_each(|_| async { Ok(()) });
 
-		// All pending calls has been finished or the connection closed.
-		// Fine to terminate
 		tokio::select! {
 			_ = graceful_shutdown => {}
 			res = disconnect => {
 				if let Err(err) = res {
-					tracing::info!("Graceful shutdown terminated because of error: `{err}`");
+					tracing::warn!("Graceful shutdown terminated because of error: `{err}`");
 				}
 			}
 			_ = conn_tx.closed() => {}


### PR DESCRIPTION
This fixes a `soketto::Receiver` drop issue where two streams were created and this PR uses the same stream for both receiving messages and shutdown.

In addition, this PR reverts the behavior to keep the socket alive despite errors and the server will only perform the graceful shutdown if a shutdown was requested. 

master:

```bash
2023-10-19T08:46:52.456649Z  INFO jsonrpsee_server::transport::ws: server is closed because: Ok(Stopped)
// This is not a message that is sent by the client i.e, read as empty......
2023-10-19T08:46:52.456664Z TRACE soketto::connection: 5627ceca: recv: (Continue (fin 0) (rsv 000) (mask (0 0)) (len 0))
2023-10-19T08:46:52.456671Z DEBUG soketto::connection: 5627ceca: continue frame while not processing message fragments
2023-10-19T08:46:52.456678Z  WARN jsonrpsee_server::transport::ws: Graceful shutdown got WebSocket error: unexpected opcode: Continue but polling until the connection closed or all pending calls has been executed
// Websocket Close handshake .... 
```

This branch:

```bash
2023-10-19T08:52:19.060822Z  INFO jsonrpsee_server::transport::ws: server is closed because: Ok(Stopped)
2023-10-19T08:52:19.162134Z TRACE method_call{method="sleep_20s"}: jsonrpsee_core::tracing: send="{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"sleep_20s\"}"
2023-10-19T08:52:19.162269Z TRACE jsonrpsee_client_transport::ws: send: {"jsonrpc":"2.0","id":10,"method":"sleep_20s"}
2023-10-19T08:52:19.162301Z TRACE soketto::connection: 2425d827: send: (Text (fin 1) (rsv 000) (mask (1 1e4e0b66)) (len 46))
2023-10-19T08:52:19.162341Z TRACE soketto::connection: 2425d827: Sender flushing connection
2023-10-19T08:52:19.162486Z TRACE soketto: read 2 bytes
2023-10-19T08:52:19.162511Z TRACE soketto: read 4 bytes
2023-10-19T08:52:19.162524Z TRACE soketto::connection: 33584b71: recv: (Text (fin 1) (rsv 000) (mask (1 1e4e0b66)) (len 46))
// Websocket Close handshake happend but no empty message is read above....
```

On errors we just terminate the connection for simplicity as it did before.