### PR TITLE
graceful shutdown: distinguish between stopped and conn closed

### DIFF
--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -288,7 +288,8 @@ pub(crate) async fn background_task<L: Logger>(sender: Sender, receiver: Receive
 			// Return the `Closed` error to avoid logging unnecessary warnings on clean shutdown.
 			Err(e) => Some((Err(e), receiver)),
 		}
-	});
+	})
+	.fuse();
 
 	tokio::pin!(ws_stream);
 


### PR DESCRIPTION
Follow-up on #1218 

Basically, I missed that we must ensure that the stream is not polled after `Poll::Ready(None)` which can happen
if the stream is closed but since `Receive::Shutdown was mapped to Shutdown::Stopped` where the connection could already have been closed and thus the stream had already return `Poll::Ready(None)`