### PR TITLE
Revert "chore(deps): update http requirement from 0.2 to 1.0 (#1237)"

### DIFF
--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1.34"
 thiserror = { version = "1", optional = true }
 futures-channel = { version = "0.3.14", default-features = false, optional = true }
 futures-util = { version = "0.3.14", default-features = false, features = ["alloc"], optional = true }
-http = { version = "1.0", optional = true }
+http = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
 tokio = { version = "1.16", features = ["net", "time", "macros"], optional = true }
 pin-project = { version = "1", optional = true }

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 jsonrpsee-types = { workspace = true }
 jsonrpsee-client-transport = { workspace = true, features = ["ws"] }
 jsonrpsee-core = { workspace = true, features = ["async-client"] }
-http = "1.0.0"
+http = "0.2.0"
 url = "2.4.0"
 
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,7 +28,7 @@ tokio-stream = "0.1.7"
 hyper = { version = "0.14", features = ["server", "http1", "http2"] }
 tower = { version = "0.4.13", features = ["util"] }
 route-recognizer = "0.3.1"
-http = "1.0.0"
+http = "0.2.9"
 thiserror = "1.0.44"
 pin-project = "1.1.3"
 


### PR DESCRIPTION
This reverts commit c811810bf4e4ba7ee4368a6213ef4376a5a4f893.

http v1.0 doesn't work well with hyper v0.14, so let's bump both in the same commit.
This makes master compile again