### PR TITLE
feat(client): add `disconnect_reason` API

### DIFF
--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -25,9 +25,10 @@
 // DEALINGS IN THE SOFTWARE.
 
 #![cfg(test)]
-use crate::types::error::{ErrorCode, ErrorObject};
 
+use crate::types::error::{ErrorCode, ErrorObject};
 use crate::WsClientBuilder;
+
 use jsonrpsee_core::client::{BatchResponse, ClientT, SubscriptionClientT};
 use jsonrpsee_core::client::{IdKind, Subscription};
 use jsonrpsee_core::params::BatchRequestBuilder;
@@ -68,12 +69,8 @@ async fn method_call_with_wrong_id_kind() {
 	let client =
 		WsClientBuilder::default().id_format(IdKind::String).build(&uri).with_default_timeout().await.unwrap().unwrap();
 
-	match client.request::<String, _>("o", rpc_params![]).with_default_timeout().await.unwrap() {
-		Err(Error::RestartNeeded(e)) => {
-			assert!(matches!(*e, Error::InvalidRequestId(_)));
-		}
-		_ => panic!("Test failed"),
-	};
+	let err: Result<String, _> = client.request::<String, _>("o", rpc_params![]).with_default_timeout().await.unwrap();
+	assert!(matches!(err, Err(Error::RestartNeeded(e)) if matches!(*e, Error::InvalidRequestId(_))));
 }
 
 #[tokio::test]

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -69,7 +69,7 @@ async fn method_call_with_wrong_id_kind() {
 	let client =
 		WsClientBuilder::default().id_format(IdKind::String).build(&uri).with_default_timeout().await.unwrap().unwrap();
 
-	let err: Result<String, _> = client.request::<String, _>("o", rpc_params![]).with_default_timeout().await.unwrap();
+	let err: Result<String, _> = client.request("o", rpc_params![]).with_default_timeout().await.unwrap();
 	assert!(matches!(err, Err(Error::RestartNeeded(e)) if matches!(*e, Error::InvalidRequestId(_))));
 }
 

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -68,8 +68,12 @@ async fn method_call_with_wrong_id_kind() {
 	let client =
 		WsClientBuilder::default().id_format(IdKind::String).build(&uri).with_default_timeout().await.unwrap().unwrap();
 
-	let err: Result<String, Error> = client.request("o", rpc_params![]).with_default_timeout().await.unwrap();
-	assert!(matches!(err, Err(Error::RestartNeeded(e)) if e == "request ID=0 is not a pending call"));
+	match client.request::<String, _>("o", rpc_params![]).with_default_timeout().await.unwrap() {
+		Err(Error::RestartNeeded(e)) => {
+			assert!(matches!(*e, Error::InvalidRequestId(_)));
+		}
+		_ => panic!("Test failed"),
+	};
 }
 
 #[tokio::test]

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -286,7 +286,7 @@ impl ClientBuilder {
 		Client {
 			to_back,
 			request_timeout: self.request_timeout,
-			error: AsyncMutex::new(ErrorFromBack::Unread(err_from_back)),
+			error: ErrorFromBack::new(err_from_back),
 			id_manager: RequestIdManager::new(self.max_concurrent_requests, self.id_kind),
 			max_log_length: self.max_log_length,
 			on_exit: Some(client_dropped_tx),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use jsonrpsee_types::{params::InvalidRequestId, ErrorObjectOwned};
 
@@ -57,7 +57,7 @@ pub enum Error {
 	InvalidResponse(Mismatch<String>),
 	/// The background task has been terminated.
 	#[error("The background task been terminated because: {0}; restart required")]
-	RestartNeeded(String),
+	RestartNeeded(Arc<Error>),
 	/// Failed to parse the data.
 	#[error("Parse error: {0}")]
 	ParseError(#[from] serde_json::Error),


### PR DESCRIPTION
This commit adds an API to get the error reason why the backend was disconnected.

Close #1196