### PR TITLE
refactor: cleanup logging

### DIFF
--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -285,8 +285,6 @@ where
 		}
 	}
 
-	/// Perform a request towards the server.
-
 	#[instrument(name = "method_call", skip(self, params), level = "trace")]
 	async fn request<R, Params>(&self, method: &str, params: Params) -> Result<R, Error>
 	where

--- a/client/transport/src/web.rs
+++ b/client/transport/src/web.rs
@@ -50,7 +50,6 @@ impl TransportSenderT for Sender {
 	type Error = Error;
 
 	async fn send(&mut self, msg: String) -> Result<(), Self::Error> {
-		tracing::trace!("tx: {:?}", msg);
 		self.0.send(Message::Text(msg)).await.map_err(|e| Error::WebSocket(e))?;
 		Ok(())
 	}
@@ -62,14 +61,10 @@ impl TransportReceiverT for Receiver {
 
 	async fn receive(&mut self) -> Result<ReceivedMessage, Self::Error> {
 		match self.0.next().await {
-			Some(Ok(msg)) => {
-				tracing::trace!("rx: {:?}", msg);
-
-				match msg {
-					Message::Bytes(bytes) => Ok(ReceivedMessage::Bytes(bytes)),
-					Message::Text(txt) => Ok(ReceivedMessage::Text(txt)),
-				}
-			}
+			Some(Ok(msg)) => match msg {
+				Message::Bytes(bytes) => Ok(ReceivedMessage::Bytes(bytes)),
+				Message::Text(txt) => Ok(ReceivedMessage::Text(txt)),
+			},
 			Some(Err(err)) => Err(Error::WebSocket(err)),
 			None => Err(Error::SenderDisconnected),
 		}

--- a/core/src/http_helpers.rs
+++ b/core/src/http_helpers.rs
@@ -56,14 +56,14 @@ where
 
 	futures_util::pin_mut!(body);
 
-	// only allocate up to 16KB initially
+	// Allocate up to 16KB initially.
 	let mut received_data = Vec::with_capacity(std::cmp::min(body_size as usize, 16 * 1024));
 	let mut is_single = None;
 
 	while let Some(d) = body.data().await {
 		let data = d.map_err(|e| GenericTransportError::Inner(anyhow!(e.into())))?;
 
-		// if it's the first chunk, trim the whitespaces to determine whether it's valid JSON-RPC call.
+		// If it's the first chunk, trim the whitespaces to determine whether it's valid JSON-RPC call.
 		if received_data.is_empty() {
 			let first_non_whitespace =
 				data.chunk().iter().enumerate().take(128).find(|(_, byte)| !byte.is_ascii_whitespace());
@@ -98,6 +98,7 @@ where
 	match is_single {
 		Some(single) if !received_data.is_empty() => {
 			tracing::trace!(
+				target: "jsonrpsee-http",
 				"HTTP response body: {}",
 				std::str::from_utf8(&received_data).unwrap_or("Invalid UTF-8 data")
 			);

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -42,6 +42,8 @@ pub use subscription::*;
 
 use jsonrpsee_types::{ErrorObjectOwned, ResponsePayload};
 
+const LOG_TARGET: &str = "jsonrpsee-server";
+
 /// Something that can be converted into a JSON-RPC method call response.
 ///
 /// If the value couldn't be serialized/encoded, jsonrpsee will sent out an error

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -27,6 +27,7 @@
 //! Subscription related types and traits for server implementations.
 
 use super::helpers::{MethodResponse, MethodSink};
+use crate::server::LOG_TARGET;
 use crate::server::error::{DisconnectError, PendingSubscriptionAcceptError, SendTimeoutError, TrySendError};
 use crate::server::rpc_module::ConnectionId;
 use crate::{traits::IdProvider, Error, StringError};
@@ -424,7 +425,7 @@ pub struct Subscription {
 impl Subscription {
 	/// Close the subscription channel.
 	pub fn close(&mut self) {
-		tracing::trace!("[Subscription::close] Notifying");
+		tracing::trace!(target: LOG_TARGET, "[Subscription::close] Notifying");
 		self.rx.close();
 	}
 
@@ -437,7 +438,7 @@ impl Subscription {
 	pub async fn next<T: DeserializeOwned>(&mut self) -> Option<Result<(T, SubscriptionId<'static>), Error>> {
 		let raw = self.rx.recv().await?;
 
-		tracing::debug!("[Subscription::next]: rx {}", raw);
+		tracing::debug!(target: LOG_TARGET, "[Subscription::next]: rx {}", raw);
 
 		// clippy complains about this but it doesn't compile without the extra res binding.
 		#[allow(clippy::let_and_return)]

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -1,45 +1,100 @@
 use serde::Serialize;
 use tracing::Level;
 
-/// Helper for writing trace logs from str.
-pub fn tx_log_from_str(s: impl AsRef<str>, max: u32) {
-	if tracing::enabled!(Level::TRACE) {
-		let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
-		tracing::trace!(send = msg);
+const CLIENT: &str = "jsonrpsee-client";
+const SERVER: &str = "jsonrpsee-server";
+
+/// Logging with jsonrpsee client target.
+pub mod client {
+	use super::*;
+
+	/// Helper for writing trace logs from str.
+	pub fn tx_log_from_str(s: impl AsRef<str>, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
+			tracing::trace!(target: CLIENT, send = msg);
+		}
+	}
+
+	/// Helper for writing trace logs from JSON.
+	pub fn tx_log_from_json(s: &impl Serialize, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let json = serde_json::to_string(s).unwrap_or_default();
+			let msg = truncate_at_char_boundary(&json, max as usize);
+			tracing::trace!(target: CLIENT, send = msg);
+		}
+	}
+
+	/// Helper for writing trace logs from str.
+	pub fn rx_log_from_str(s: impl AsRef<str>, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
+			tracing::trace!(target: CLIENT, recv = msg);
+		}
+	}
+
+	/// Helper for writing trace logs from JSON.
+	pub fn rx_log_from_json(s: &impl Serialize, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let res = serde_json::to_string(s).unwrap_or_default();
+			let msg = truncate_at_char_boundary(res.as_str(), max as usize);
+			tracing::trace!(target: CLIENT, recv = msg);
+		}
+	}
+
+	/// Helper for writing trace logs from bytes.
+	pub fn rx_log_from_bytes(bytes: &[u8], max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let res = serde_json::from_slice::<serde_json::Value>(bytes).unwrap_or_default();
+			rx_log_from_json(&res, max);
+		}
 	}
 }
 
-/// Helper for writing trace logs from JSON.
-pub fn tx_log_from_json(s: &impl Serialize, max: u32) {
-	if tracing::enabled!(Level::TRACE) {
-		let json = serde_json::to_string(s).unwrap_or_default();
-		let msg = truncate_at_char_boundary(&json, max as usize);
-		tracing::trace!(send = msg);
-	}
-}
+/// Logging with jsonrpsee server target.
+pub mod server {
+	use super::*;
 
-/// Helper for writing trace logs from str.
-pub fn rx_log_from_str(s: impl AsRef<str>, max: u32) {
-	if tracing::enabled!(Level::TRACE) {
-		let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
-		tracing::trace!(recv = msg);
+	/// Helper for writing trace logs from str.
+	pub fn tx_log_from_str(s: impl AsRef<str>, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
+			tracing::trace!(target: SERVER, send = msg);
+		}
 	}
-}
 
-/// Helper for writing trace logs from JSON.
-pub fn rx_log_from_json(s: &impl Serialize, max: u32) {
-	if tracing::enabled!(Level::TRACE) {
-		let res = serde_json::to_string(s).unwrap_or_default();
-		let msg = truncate_at_char_boundary(res.as_str(), max as usize);
-		tracing::trace!(recv = msg);
+	/// Helper for writing trace logs from JSON.
+	pub fn tx_log_from_json(s: &impl Serialize, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let json = serde_json::to_string(s).unwrap_or_default();
+			let msg = truncate_at_char_boundary(&json, max as usize);
+			tracing::trace!(target: SERVER, send = msg);
+		}
 	}
-}
 
-/// Helper for writing trace logs from bytes.
-pub fn rx_log_from_bytes(bytes: &[u8], max: u32) {
-	if tracing::enabled!(Level::TRACE) {
-		let res = serde_json::from_slice::<serde_json::Value>(bytes).unwrap_or_default();
-		rx_log_from_json(&res, max);
+	/// Helper for writing trace logs from str.
+	pub fn rx_log_from_str(s: impl AsRef<str>, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
+			tracing::trace!(target: SERVER, recv = msg);
+		}
+	}
+
+	/// Helper for writing trace logs from JSON.
+	pub fn rx_log_from_json(s: &impl Serialize, max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let res = serde_json::to_string(s).unwrap_or_default();
+			let msg = truncate_at_char_boundary(res.as_str(), max as usize);
+			tracing::trace!(target: SERVER, recv = msg);
+		}
+	}
+
+	/// Helper for writing trace logs from bytes.
+	pub fn rx_log_from_bytes(bytes: &[u8], max: u32) {
+		if tracing::enabled!(Level::TRACE) {
+			let res = serde_json::from_slice::<serde_json::Value>(bytes).unwrap_or_default();
+			rx_log_from_json(&res, max);
+		}
 	}
 }
 

--- a/examples/examples/ws.rs
+++ b/examples/examples/ws.rs
@@ -27,7 +27,7 @@
 use std::net::SocketAddr;
 
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::server::Server;
+use jsonrpsee::server::{RpcServiceBuilder, Server};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, RpcModule};
 use tracing_subscriber::util::SubscriberInitExt;
@@ -50,7 +50,8 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = Server::builder().build("127.0.0.1:0").await?;
+	let rpc_middleware = RpcServiceBuilder::new().rpc_logger(1024);
+	let server = Server::builder().set_rpc_middleware(rpc_middleware).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _| "lo")?;
 	let addr = server.local_addr()?;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -53,3 +53,5 @@ pub use tracing;
 
 pub use transport::http;
 pub use transport::ws;
+
+pub(crate) const LOG_TARGET: &str = "jsonrpsee-server";

--- a/server/src/middleware/http/host_filter.rs
+++ b/server/src/middleware/http/host_filter.rs
@@ -28,6 +28,7 @@
 
 use crate::middleware::http::authority::{Authority, AuthorityError, Port};
 use crate::transport::http;
+use crate::LOG_TARGET;
 use futures_util::{Future, FutureExt, TryFutureExt};
 use hyper::{Body, Request, Response};
 use route_recognizer::Router;
@@ -117,7 +118,7 @@ where
 		if self.filter.as_ref().map_or(true, |f| f.recognize(&authority)) {
 			Box::pin(self.inner.call(request).map_err(Into::into))
 		} else {
-			tracing::debug!("Denied request: {:?}", request);
+			tracing::debug!(target: LOG_TARGET, "Denied request: {:?}", request);
 			async { Ok(http::response::host_not_allowed()) }.boxed()
 		}
 	}

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -37,6 +37,7 @@ use crate::future::{ConnectionGuard, ServerHandle, StopHandle};
 use crate::middleware::rpc::{RpcService, RpcServiceBuilder, RpcServiceCfg, RpcServiceT};
 use crate::transport::ws::BackgroundTaskParams;
 use crate::transport::{http, ws};
+use crate::LOG_TARGET;
 
 use futures_util::future::{self, Either, FutureExt};
 use futures_util::io::{BufReader, BufWriter};
@@ -159,7 +160,7 @@ where
 					stopped = stop;
 				}
 				AcceptConnection::Err((e, stop)) => {
-					tracing::debug!("Error while awaiting a new connection: {:?}", e);
+					tracing::debug!(target: LOG_TARGET, "Error while awaiting a new connection: {:?}", e);
 					stopped = stop;
 				}
 				AcceptConnection::Shutdown => break,
@@ -979,7 +980,7 @@ where
 		let stop_handle = self.inner.stop_handle.clone();
 		let conn_id = self.inner.conn_id;
 
-		tracing::trace!("{:?}", request);
+		tracing::trace!(target: LOG_TARGET, "{:?}", request);
 
 		let Some(conn_permit) = conn_guard.try_acquire() else {
 			return async move { Ok(http::response::too_many_requests()) }.boxed();
@@ -989,7 +990,7 @@ where
 
 		let max_conns = conn_guard.max_connections();
 		let curr_conns = max_conns - conn_guard.available_connections();
-		tracing::debug!("Accepting new connection {}/{}", curr_conns, max_conns);
+		tracing::debug!(target: LOG_TARGET, "Accepting new connection {}/{}", curr_conns, max_conns);
 
 		let is_upgrade_request = is_upgrade_request(&request);
 
@@ -1031,7 +1032,7 @@ where
 							let upgraded = match hyper::upgrade::on(request).await {
 								Ok(u) => u,
 								Err(e) => {
-									tracing::debug!("Could not upgrade connection: {}", e);
+									tracing::debug!(target: LOG_TARGET, "Could not upgrade connection: {}", e);
 									return;
 								}
 							};
@@ -1060,7 +1061,7 @@ where
 					response.map(|()| hyper::Body::empty())
 				}
 				Err(e) => {
-					tracing::debug!("Could not upgrade connection: {}", e);
+					tracing::debug!(target: LOG_TARGET, "Could not upgrade connection: {}", e);
 					hyper::Response::new(hyper::Body::from(format!("Could not upgrade connection: {e}")))
 				}
 			};
@@ -1137,7 +1138,7 @@ fn process_connection<'a, RpcMiddleware, HttpMiddleware, U>(
 	} = params;
 
 	if let Err(e) = socket.set_nodelay(true) {
-		tracing::warn!("Could not set NODELAY on socket: {:?}", e);
+		tracing::warn!(target: LOG_TARGET, "Could not set NODELAY on socket: {:?}", e);
 		return;
 	}
 
@@ -1186,7 +1187,7 @@ where
 	};
 
 	if let Err(e) = res {
-		tracing::debug!("HTTP serve connection failed {:?}", e);
+		tracing::debug!(target: LOG_TARGET, "HTTP serve connection failed {:?}", e);
 	}
 }
 

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -4,7 +4,7 @@ use jsonrpsee_core::{http_helpers::read_body, server::Methods, GenericTransportE
 use crate::{
 	middleware::rpc::{RpcService, RpcServiceBuilder, RpcServiceCfg, RpcServiceT},
 	server::{handle_rpc_call, ServerConfig},
-	BatchRequestConfig, ConnectionState,
+	BatchRequestConfig, ConnectionState, LOG_TARGET,
 };
 
 /// Checks that content type of received request is valid for JSON-RPC.
@@ -77,7 +77,7 @@ where
 				Err(GenericTransportError::TooLarge) => return response::too_large(max_request_size),
 				Err(GenericTransportError::Malformed) => return response::malformed(),
 				Err(GenericTransportError::Inner(e)) => {
-					tracing::warn!("Internal error reading request body: {}", e);
+					tracing::warn!(target: LOG_TARGET, "Internal error reading request body: {}", e);
 					return response::internal_error();
 				}
 			};

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -16,7 +16,6 @@ publish = true
 [dependencies]
 anyhow = "1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
-tracing = { version = "0.1.34", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -197,15 +197,8 @@ impl<'a> ParamsSequence<'a> {
 				Some(Ok(value))
 			}
 			Err(e) => {
-				let err = format!(
-					"Deserialization to {:?} failed. Error: {:?}, input JSON: {:?}",
-					std::any::type_name::<T>(),
-					e,
-					json
-				);
 				self.0 = "";
-
-				Some(Err(invalid_params(err)))
+				Some(Err(invalid_params(e)))
 			}
 		}
 	}

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -176,18 +176,14 @@ impl<'a> ParamsSequence<'a> {
 		T: Deserialize<'a>,
 	{
 		let mut json = self.0;
-		tracing::trace!("[next_inner] Params JSON: {:?}", json);
 		match json.as_bytes().first()? {
 			b']' => {
 				self.0 = "";
-
-				tracing::trace!("[next_inner] Reached end of sequence.");
 				return None;
 			}
 			b'[' | b',' => json = &json[1..],
 			_ => {
 				let errmsg = format!("Invalid params. Expected one of '[', ']' or ',' but found {json:?}");
-				tracing::trace!("[next_inner] {}", errmsg);
 				return Some(Err(invalid_params(errmsg)));
 			}
 		}
@@ -201,15 +197,15 @@ impl<'a> ParamsSequence<'a> {
 				Some(Ok(value))
 			}
 			Err(e) => {
-				tracing::trace!(
-					"[next_inner] Deserialization to {:?} failed. Error: {:?}, input JSON: {:?}",
+				let err = format!(
+					"Deserialization to {:?} failed. Error: {:?}, input JSON: {:?}",
 					std::any::type_name::<T>(),
 					e,
 					json
 				);
 				self.0 = "";
 
-				Some(Err(invalid_params(e)))
+				Some(Err(invalid_params(err)))
 			}
 		}
 	}


### PR DESCRIPTION
This PR introduces two different logging targets to close #1233 :

1. "jsonrpsee-server" for all server logs
2. "jsonrpsee-client" for all client logs

In addition this PR also removes to log every message sent on the MethodSink to close #1003.
Thus, this changes that the subscription notifications are no longer emitted as "logs but users can log it themselves instead.


Before this PR:

```bash
2023-11-29T12:09:43.483594Z DEBUG jsonrpsee_client_transport::ws: Connecting to target: Target { sockaddrs: [127.0.0.1:34681], host: "127.0.0.1", host_header: "127.0.0.1:34681", _mode: Plain, path_and_query: "/" }
2023-11-29T12:09:43.484064Z TRACE jsonrpsee_server::server: Request { method: GET, uri: /, version: HTTP/1.1, headers: {"host": "127.0.0.1:34681", "upgrade": "websocket", "connection": "Upgrade", "sec-websocket-key": "Ka3LkOxV6umD1ZHqhJ86Eg==", "sec-websocket-version": "13"}, body: Body(Empty) }
2023-11-29T12:09:43.484095Z DEBUG jsonrpsee_server::server: Accepting new connection 1/100
2023-11-29T12:09:43.484371Z DEBUG jsonrpsee_client_transport::ws: Connection established to target: Target { sockaddrs: [], host: "127.0.0.1", host_header: "127.0.0.1:34681", _mode: Plain, path_and_query: "/" }
2023-11-29T12:09:43.484478Z TRACE method_call{method="say_hello"}: jsonrpsee_core::tracing: send="{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"say_hello\"}"
2023-11-29T12:09:43.484530Z TRACE jsonrpsee_client_transport::ws: send: {"jsonrpc":"2.0","id":0,"method":"say_hello"}
2023-11-29T12:09:43.484686Z TRACE jsonrpsee_core::tracing: send="{\"jsonrpc\":\"2.0\",\"result\":\"lo\",\"id\":0}"
2023-11-29T12:09:43.484977Z TRACE method_call{method="say_hello"}: jsonrpsee_core::tracing: recv="{\"jsonrpc\":\"2.0\",\"result\":\"lo\",\"id\":0}"
```


After this PR: 

```bash
2023-11-29T12:06:01.489897Z DEBUG jsonrpsee-client: Connecting to target: Target { sockaddrs: [127.0.0.1:36999], host: "127.0.0.1", host_header: "127.0.0.1:36999", _mode: Plain, path_and_query: "/" }
2023-11-29T12:06:01.490351Z TRACE jsonrpsee-server: Request { method: GET, uri: /, version: HTTP/1.1, headers: {"host": "127.0.0.1:36999", "upgrade": "websocket", "connection": "Upgrade", "sec-websocket-key": "6riOnxx98yWWEj9VMkAYJw==", "sec-websocket-version": "13"}, body: Body(Empty) }
2023-11-29T12:06:01.490375Z DEBUG jsonrpsee-server: Accepting new connection 1/100
2023-11-29T12:06:01.490652Z DEBUG jsonrpsee-client: Connection established to target: Target { sockaddrs: [], host: "127.0.0.1", host_header: "127.0.0.1:36999", _mode: Plain, path_and_query: "/" }
2023-11-29T12:06:01.490763Z TRACE method_call{method="say_hello"}: jsonrpsee-client: send="{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"say_hello\"}"
2023-11-29T12:06:01.491010Z TRACE method_call{method="say_hello"}: jsonrpsee-server: recv="{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"say_hello\",\"params\":null}"
2023-11-29T12:06:01.491049Z TRACE method_call{method="say_hello"}: jsonrpsee-server: send="{\"jsonrpc\":\"2.0\",\"result\":\"lo\",\"id\":0}"
2023-11-29T12:06:01.491198Z TRACE method_call{method="say_hello"}: jsonrpsee-client: recv="{\"jsonrpc\":\"2.0\",\"result\":\"lo\",\"id\":0}"
```
