### PR TITLE
Enable all http versions

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 [dependencies]
 async-trait = "0.1"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.24", optional = true, default-features = false, features = ["http1", "tls12", "logging"] }
+hyper-rustls = { version = "0.24", optional = true, default-features = false, features = ["http1", "http2", "tls12", "logging"] }
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["client", "http-helpers"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -124,13 +124,13 @@ where
 					CertificateStore::Native => hyper_rustls::HttpsConnectorBuilder::new()
 						.with_native_roots()
 						.https_or_http()
-						.enable_http1()
+						.enable_all_versions()
 						.build(),
 					#[cfg(feature = "webpki-tls")]
 					CertificateStore::WebPki => hyper_rustls::HttpsConnectorBuilder::new()
 						.with_webpki_roots()
 						.https_or_http()
-						.enable_http1()
+						.enable_all_versions()
 						.build(),
 					_ => return Err(Error::InvalidCertficateStore),
 				};


### PR DESCRIPTION
Fixing HTTP2 client.  When creating the HTTPS connector with hyper_rustls::HttpsConnectorBuilder, the use of enable_http1() was preventing the initiation of an HTTP2 connection. Switching to enable_all_versions() successfully initiates HTTP2. 

I've successfully tested this with my local fork.