### PR TITLE
refactor(client): unify ws ping/pong API with the server

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,8 @@ parking_lot = { version = "0.12", optional = true }
 tokio = { version = "1.16", optional = true }
 wasm-bindgen-futures = { version = "0.4.19", optional = true }
 futures-timer = { version = "3", optional = true }
+tokio-stream = { version = "0.1", optional = true }
+pin-project = { version = "1", optional = true }
 
 [features]
 default = []
@@ -57,6 +59,8 @@ async-client = [
 	"tokio/rt",
 	"tokio/time",
 	"futures-timer",
+	"tokio-stream",
+	"pin-project",
 ]
 async-wasm-client = [
 	"async-lock",
@@ -67,6 +71,8 @@ async-wasm-client = [
 	"futures-timer/wasm-bindgen",
 	"tokio/macros",
 	"tokio/time",
+	"tokio-stream",
+	"pin-project",
 ]
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,7 +62,6 @@ async-client = [
 	"futures-timer",
 	"tokio-stream",
 	"pin-project",
-	"instant",
 ]
 async-wasm-client = [
 	"async-lock",
@@ -73,9 +72,7 @@ async-wasm-client = [
 	"futures-timer/wasm-bindgen",
 	"tokio/macros",
 	"tokio/time",
-	"tokio-stream",
 	"pin-project",
-	"instant/wasm-bindgen",
 ]
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,7 @@ wasm-bindgen-futures = { version = "0.4.19", optional = true }
 futures-timer = { version = "3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 pin-project = { version = "1", optional = true }
+instant = { version = "0.1", optional = true }
 
 [features]
 default = []
@@ -61,6 +62,7 @@ async-client = [
 	"futures-timer",
 	"tokio-stream",
 	"pin-project",
+	"instant",
 ]
 async-wasm-client = [
 	"async-lock",
@@ -73,6 +75,7 @@ async-wasm-client = [
 	"tokio/time",
 	"tokio-stream",
 	"pin-project",
+	"instant/wasm-bindgen",
 ]
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,6 @@ wasm-bindgen-futures = { version = "0.4.19", optional = true }
 futures-timer = { version = "3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 pin-project = { version = "1", optional = true }
-instant = { version = "0.1", optional = true }
 
 [features]
 default = []

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -74,12 +74,14 @@ const LOG_TARGET: &str = "jsonrpsee-client";
 /// an inactive connection.
 ///
 /// jsonrpsee doesn't associate the ping/pong frames just that if
-/// pong frame isn't received within `inactive_limit` then it's regarded
+/// a pong frame isn't received within the `inactive_limit` then it's regarded
 /// as missed.
 ///
 /// Such that the `inactive_limit` should be configured to longer than a single
 /// WebSocket ping takes or it might be missed and may end up
 /// terminating the connection.
+///
+/// Default: ping_interval: 30 seconds, max failures: 1 and inactive limit: 40 seconds.
 #[derive(Debug, Copy, Clone)]
 pub struct PingConfig {
 	/// Interval that the pings are sent.

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -58,7 +58,7 @@ const LOG_TARGET: &str = "jsonrpsee-client";
 /// terminating the connection.
 #[derive(Debug, Copy, Clone)]
 pub struct PingConfig {
-	/// Period which the server pings the connected client.
+	/// Interval that the pings are sent.
 	pub(crate) ping_interval: Duration,
 	/// Max allowed time for a connection to stay idle.
 	pub(crate) inactive_limit: Duration,
@@ -89,16 +89,16 @@ impl PingConfig {
 	}
 
 	/// Configure how long to wait for the WebSocket pong.
-	/// When this limit is expired it's regarded as the client is unresponsive.
+	/// When this limit is expired it's regarded as inresponsive.
 	///
-	/// You may configure how many times the client is allowed to be "inactive" by
-	/// [`PingConfig::max_failures`].
+	/// You may configure how many times the connection is allowed to
+	/// be inactive by [`PingConfig::max_failures`].
 	pub fn inactive_limit(mut self, inactivity_limit: Duration) -> Self {
 		self.inactive_limit = inactivity_limit;
 		self
 	}
 
-	/// Configure how many times the remote peer is allowed be
+	/// Configure how many times the connection is allowed be
 	/// inactive until the connection is closed.
 	pub fn max_failures(mut self, max: NonZeroUsize) -> Self {
 		self.max_failures = max;
@@ -983,7 +983,7 @@ where
 						missed += 1;
 
 						if missed >= p.max_failures.get() {
-							break Ok(());
+							break Err(Error::Custom("WebSocket ping/pong inactive".into()));
 						}
 					}
 				}

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -326,7 +326,7 @@ impl ClientBuilder {
 		let (to_back, from_front) = mpsc::channel(self.max_concurrent_requests);
 		let (err_to_front, err_from_back) = oneshot::channel::<Error>();
 		let max_buffer_capacity_per_subscription = self.max_buffer_capacity_per_subscription;
-		let ping_interval = self.ping_interval;
+		let ping_config = self.ping_config;
 		let (client_dropped_tx, client_dropped_rx) = oneshot::channel();
 		let (send_receive_task_sync_tx, send_receive_task_sync_rx) = mpsc::channel(1);
 		let manager = ThreadSafeRequestManager::new();
@@ -337,7 +337,7 @@ impl ClientBuilder {
 			close_tx: send_receive_task_sync_tx.clone(),
 			manager: manager.clone(),
 			max_buffer_capacity_per_subscription,
-			ping_interval,
+			ping_config,
 		}));
 
 		wasm_bindgen_futures::spawn_local(read_task(ReadTaskParams {
@@ -346,6 +346,7 @@ impl ClientBuilder {
 			to_send_task: to_back.clone(),
 			manager,
 			max_buffer_capacity_per_subscription: self.max_buffer_capacity_per_subscription,
+			ping_config,
 		}));
 
 		wasm_bindgen_futures::spawn_local(wait_for_shutdown(

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -950,14 +950,14 @@ where
 					if let Err(e) =
 						handle_frontend_messages(msg, &manager, &mut sender, max_buffer_capacity_per_subscription).await
 					{
-						tracing::error!(target: LOG_TARGET, "Could not send message: {e}");
+						tracing::error!(target: LOG_TARGET, "ws send failed: {e}");
 						break Err(Error::Transport(e.into()));
 					}
 				}
 				_ = ping_interval.next() => {
 					if let Err(err) = sender.send_ping().await {
-						tracing::error!(target: LOG_TARGET, "Could not send ping frame: {err}");
-						break Err(Error::Custom("Could not send ping frame".into()));
+						tracing::error!(target: LOG_TARGET, "Send ws ping failed: {err}");
+						break Err(Error::Transport(err.into()));
 					}
 				}
 			}
@@ -1025,7 +1025,7 @@ where
 			}
 			_ = inactivity_stream.next() => {
 				if inactivity_check.is_inactive() {
-					break Ok(());
+					break Err(Error::Transport(anyhow::anyhow!("WebSocket ping/pong inactive")));
 				}
 			}
 		}

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -372,7 +372,7 @@ impl ClientBuilder {
 	{
 		use futures_util::stream::Pending;
 
-		pub(crate) type PendingIntervalStream = IntervalStream<Pending<()>>;		
+		type PendingIntervalStream = IntervalStream<Pending<()>>;		
 		
 		let (to_back, from_front) = mpsc::channel(self.max_concurrent_requests);
 		let (err_to_front, err_from_back) = oneshot::channel::<Error>();

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -1079,4 +1079,3 @@ impl<Fut: Future> Stream for MaybePendingFutures<Fut> {
 	}
 }
 
-

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -17,7 +17,6 @@ use std::borrow::Cow as StdCow;
 
 use core::time::Duration;
 use std::num::NonZeroUsize;
-use std::time::Instant;
 use helpers::{
 	build_unsubscribe_message, call_with_timeout, process_batch_response, process_notification,
 	process_single_response, process_subscription_response, stop_subscription,
@@ -933,7 +932,7 @@ where
 {
 	let ReadTaskParams { receiver, close_tx, to_send_task, manager, max_buffer_capacity_per_subscription, ping_config } = params;
 
-	let mut last_active = Instant::now();
+	let mut last_active = instant::Instant::now();
 	let mut inactivity_check = match ping_config {
 		Some(p) => IntervalStream::new(interval_at(tokio::time::Instant::now() + p.ping_interval, p.ping_interval)),
 		None => IntervalStream::pending(),
@@ -964,7 +963,7 @@ where
 			_ = pending_unsubscribes.next() => (),
 			// New message received.
 			maybe_msg = backend_event.next() => {
-				last_active = Instant::now();
+				last_active = instant::Instant::now();
 				let Some(msg) = maybe_msg else { break Ok(()) };
 
 				match handle_backend_messages::<R>(Some(msg), &manager, max_buffer_capacity_per_subscription) {

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -315,7 +315,7 @@ impl ClientBuilder {
 		let (ping_interval, inactivity_stream, inactivity_check) = match self.ping_config {
 			None => (IntervalStream::pending(), IntervalStream::pending(), InactivityCheck::Disabled),
 			Some(p) => {
-				// NOTE: This emitts a tick immediately to sync how the `inactive_interval` works
+				// NOTE: This emits a tick immediately to sync how the `inactive_interval` works
 				// because it starts measuring when the client start-ups.
 				let ping_interval = IntervalStream::new(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(p.ping_interval)));
 

--- a/core/src/client/async_client/utils.rs
+++ b/core/src/client/async_client/utils.rs
@@ -1,0 +1,134 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+use std::time::Duration;
+
+use futures_util::stream::FuturesUnordered;
+use futures_util::{Stream, StreamExt, Future};
+use pin_project::pin_project;
+
+#[pin_project]
+pub(crate) struct IntervalStream<S>(#[pin] Option<S>);
+
+impl<S> IntervalStream<S> {
+	/// Creates a stream which never returns any elements.
+	pub(crate) fn pending() -> Self {
+		Self(None)
+	}
+
+	/// Creates a stream which produces elements with interval of `period`.
+	#[cfg(feature = "async-client")]
+	pub(crate) fn new(s: S) -> Self {
+    	Self(Some(s))
+	}
+}
+
+impl<S: Stream> Stream for IntervalStream<S> {
+	type Item = ();
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		if let Some(mut stream) = self.project().0.as_pin_mut() {
+			match stream.poll_next_unpin(cx) {
+				Poll::Pending => Poll::Pending,
+				Poll::Ready(Some(_)) => Poll::Ready(Some(())),
+				Poll::Ready(None) => Poll::Ready(None),
+			}
+		} else {
+			// NOTE: this will not be woken up again and it's by design
+			// to be a pending stream that never returns.
+			Poll::Pending
+		}
+	}
+}
+
+#[allow(unused)]
+pub(crate) enum InactivityCheck {
+	Disabled,
+	Enabled { inactive_dur: Duration, last_active: std::time::Instant, count: usize, max_count: usize }
+}
+
+impl InactivityCheck {
+	#[cfg(feature = "async-client")]
+	pub(crate) fn new(_inactive_dur: Duration, _max_count: usize) -> Self {
+		Self::Enabled { inactive_dur: _inactive_dur, last_active: std::time::Instant::now(), count: 0, max_count: _max_count }
+	}
+
+	pub(crate) fn is_inactive(&mut self) -> bool {
+		match self {
+			Self::Disabled => false,
+			Self::Enabled { inactive_dur, last_active, count, max_count, .. } => {
+				if last_active.elapsed() >= *inactive_dur {
+					*count += 1;
+				}
+
+				count >= max_count
+			}
+ 		}
+	}
+
+	pub(crate) fn mark_as_active(&mut self) {
+		if let Self::Enabled { last_active, .. } = self {
+			*last_active = std::time::Instant::now();
+		}
+	}
+}
+
+
+
+/// A wrapper around `FuturesUnordered` that doesn't return `None` when it's empty.
+pub(crate) struct MaybePendingFutures<Fut> {
+	futs: FuturesUnordered<Fut>,
+	waker: Option<Waker>,
+}
+
+impl<Fut> MaybePendingFutures<Fut> {
+	pub(crate) fn new() -> Self {
+		Self { futs: FuturesUnordered::new(), waker: None }
+	}
+
+	pub(crate) fn push(&mut self, fut: Fut) {
+		self.futs.push(fut);
+
+		if let Some(w) = self.waker.take() {
+			w.wake();
+		}
+	}
+}
+
+impl<Fut: Future> Stream for MaybePendingFutures<Fut> {
+	type Item = Fut::Output;
+
+	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		if self.futs.is_empty() {
+			self.waker = Some(cx.waker().clone());
+			return Poll::Pending;
+		}
+
+		self.futs.poll_next_unpin(cx)
+	}
+}

--- a/core/src/client/async_client/utils.rs
+++ b/core/src/client/async_client/utils.rs
@@ -44,7 +44,7 @@ impl<S> IntervalStream<S> {
 	/// Creates a stream which produces elements with interval of `period`.
 	#[cfg(feature = "async-client")]
 	pub(crate) fn new(s: S) -> Self {
-    	Self(Some(s))
+		Self(Some(s))
 	}
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -27,7 +27,6 @@
 use std::error::Error as StdError;
 use std::future::Future;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
-use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
@@ -294,16 +293,12 @@ pub struct PingConfig {
 	/// Max allowed time for a connection to stay idle.
 	pub(crate) inactive_limit: Duration,
 	/// Max failures.
-	pub(crate) max_failures: NonZeroUsize,
+	pub(crate) max_failures: usize,
 }
 
 impl Default for PingConfig {
 	fn default() -> Self {
-		Self {
-			ping_interval: Duration::from_secs(30),
-			max_failures: NonZeroUsize::new(1).expect("1 > 0; qed"),
-			inactive_limit: Duration::from_secs(40),
-		}
+		Self { ping_interval: Duration::from_secs(30), max_failures: 1, inactive_limit: Duration::from_secs(40) }
 	}
 }
 
@@ -331,7 +326,12 @@ impl PingConfig {
 
 	/// Configure how many times the remote peer is allowed be
 	/// inactive until the connection is closed.
-	pub fn max_failures(mut self, max: NonZeroUsize) -> Self {
+	///
+	/// # Panics
+	///
+	/// This method panics if `max` == 0.
+	pub fn max_failures(mut self, max: usize) -> Self {
+		assert!(max > 0);
 		self.max_failures = max;
 		self
 	}

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -273,19 +273,18 @@ impl ConnectionState {
 	}
 }
 
-/// Configuration for WebSocket ping/pong mechanism and it may be used to disconnect inactive
-/// clients.
-///
-/// It's possible to configure how often pings are sent out and how long the server will
-/// wait until a client is determined as "inactive".
+/// Configuration for WebSocket ping/pong mechanism and it may be used to disconnect
+/// an inactive connection.
 ///
 /// jsonrpsee doesn't associate the ping/pong frames just that if
-/// pong frame isn't received within `inactive_limit` then it's regarded
+/// a pong frame isn't received within the `inactive_limit` then it's regarded
 /// as missed.
 ///
 /// Such that the `inactive_limit` should be configured to longer than a single
 /// WebSocket ping takes or it might be missed and may end up
 /// terminating the connection.
+///
+/// Default: ping_interval: 30 seconds, max failures: 1 and inactive limit: 40 seconds.
 #[derive(Debug, Copy, Clone)]
 pub struct PingConfig {
 	/// Period which the server pings the connected client.

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -881,7 +881,7 @@ async fn server_with_infinite_call(
 ) -> (crate::ServerHandle, std::net::SocketAddr) {
 	let server = ServerBuilder::default()
 		// Make sure that the ping_interval doesn't force the connection to be closed
-		.enable_ws_ping(crate::server::PingConfig::new().max_failures(NonZeroUsize::MAX).ping_interval(timeout))
+		.enable_ws_ping(crate::PingConfig::new().max_failures(NonZeroUsize::MAX).ping_interval(timeout))
 		.build("127.0.0.1:0")
 		.with_default_timeout()
 		.await

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -24,7 +24,6 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use crate::tests::helpers::{deser_call, init_logger, server_with_context};
@@ -881,7 +880,7 @@ async fn server_with_infinite_call(
 ) -> (crate::ServerHandle, std::net::SocketAddr) {
 	let server = ServerBuilder::default()
 		// Make sure that the ping_interval doesn't force the connection to be closed
-		.enable_ws_ping(crate::PingConfig::new().max_failures(NonZeroUsize::MAX).ping_interval(timeout))
+		.enable_ws_ping(crate::PingConfig::new().max_failures(usize::MAX).ping_interval(timeout))
 		.build("127.0.0.1:0")
 		.with_default_timeout()
 		.await

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -282,7 +282,7 @@ where
 					if last_active.elapsed() > p.inactive_limit {
 						missed += 1;
 
-						if missed >= p.max_failures.get() {
+						if missed >= p.max_failures {
 							break Receive::ConnectionClosed;
 						}
 					}


### PR DESCRIPTION
This changes the clients to support a similar WebSocket ping/pong as the server which
was introduced in https://github.com/paritytech/jsonrpsee/pull/1248

The `PingConfig` type is duplicated in the server and client but I'm fine with that for now.

After introducing `Instant` in code I realized that the ping/pong interval would panic in wasm and I have removed ping/pongs completely because gloo-net doesn't support that anyway.

The other solution is to use some other crates where instants/interval stream are supported but it's not worth the effort IMHO and I think there was some reason in JS land where it's not possible to have client-side initiated pings.