### PR TITLE
refactor: set `tcp_nodelay == true` by default and explicit APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [v0.21.0] - 2023-12-11
+## [v0.21.0] - 2023-12-13
 
 This release contains big changes and let's go over the main ones:
 
@@ -100,6 +100,7 @@ and [@venugopv](https://github.com/venugopv) who contributed to this release.
 - refactor(server): change ws ping API  ([#1248](https://github.com/paritytech/jsonrpsee/pull/1248))
 - refactor(ws client): generic over data stream ([#1168](https://github.com/paritytech/jsonrpsee/pull/1168))
 - refactor(client): unify ws ping/pong API with the server ([#1258](https://github.com/paritytech/jsonrpsee/pull/1258)
+- refactor: set `tcp_nodelay == true` by default ([#1263])(https://github.com/paritytech/jsonrpsee/pull/1263)
 
 ### [Added]
 - feat(client): add `disconnect_reason` API ([#1246](https://github.com/paritytech/jsonrpsee/pull/1246))

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -49,7 +49,7 @@ use tower::layer::util::Identity;
 use tower::{Layer, Service};
 use tracing::instrument;
 
-/// Http Client Builder.
+/// HttpClient Builder.
 ///
 /// # Examples
 ///
@@ -83,6 +83,7 @@ pub struct HttpClientBuilder<L = Identity> {
 	max_log_length: u32,
 	headers: HeaderMap,
 	service_builder: tower::ServiceBuilder<L>,
+	tcp_no_delay: bool,
 }
 
 impl<L> HttpClientBuilder<L> {
@@ -160,6 +161,14 @@ impl<L> HttpClientBuilder<L> {
 		self
 	}
 
+	/// Configure `TCP_NODELAY` on the socket to the supplied value `nodelay`.
+	///
+	/// Default is `true`.
+	pub fn set_tcp_no_delay(mut self, no_delay: bool) -> Self {
+		self.tcp_no_delay = no_delay;
+		self
+	}
+
 	/// Set custom tower middleware.
 	pub fn set_http_middleware<T>(self, service_builder: tower::ServiceBuilder<T>) -> HttpClientBuilder<T> {
 		HttpClientBuilder {
@@ -172,6 +181,7 @@ impl<L> HttpClientBuilder<L> {
 			max_response_size: self.max_response_size,
 			service_builder,
 			request_timeout: self.request_timeout,
+			tcp_no_delay: self.tcp_no_delay,
 		}
 	}
 }
@@ -196,6 +206,7 @@ where
 			headers,
 			max_log_length,
 			service_builder,
+			tcp_no_delay,
 			..
 		} = self;
 
@@ -207,6 +218,7 @@ where
 			max_log_length,
 			headers,
 			service_builder,
+			tcp_no_delay,
 		)
 		.map_err(|e| Error::Transport(e.into()))?;
 		Ok(HttpClient {
@@ -229,6 +241,7 @@ impl Default for HttpClientBuilder<Identity> {
 			max_log_length: 4096,
 			headers: HeaderMap::new(),
 			service_builder: tower::ServiceBuilder::new(),
+			tcp_no_delay: true,
 		}
 	}
 }

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -396,7 +396,7 @@ mod tests {
 
 	#[test]
 	fn faulty_port() {
-		let err = HttpTransportClientBuilder::new().build("ws://localhost:-43").unwrap_err();
+		let err = HttpTransportClientBuilder::new().build("http://localhost:-43").unwrap_err();
 		assert!(matches!(err, Error::Url(_)));
 
 		let err = HttpTransportClientBuilder::new().build("http://localhost:-99999").unwrap_err();

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -90,6 +90,7 @@ pub struct WsClientBuilder {
 	max_redirections: usize,
 	id_kind: IdKind,
 	max_log_length: u32,
+	tcp_no_delay: bool,
 }
 
 impl Default for WsClientBuilder {
@@ -107,6 +108,7 @@ impl Default for WsClientBuilder {
 			max_redirections: 5,
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
+			tcp_no_delay: true,
 		}
 	}
 }
@@ -221,6 +223,12 @@ impl WsClientBuilder {
 		self
 	}
 
+	/// See documentation [`ClientBuilder::set_tcp_no_delay`] (default is true).
+	pub fn set_tcp_no_delay(mut self, no_delay: bool) -> Self {
+		self.tcp_no_delay = no_delay;
+		self
+	}
+
 	/// Build the [`WsClient`] with specified [`TransportSenderT`] [`TransportReceiverT`] parameters
 	///
 	/// ## Panics
@@ -238,6 +246,7 @@ impl WsClientBuilder {
 			max_buffer_capacity_per_subscription,
 			id_kind,
 			max_log_length,
+			tcp_no_delay,
 			..
 		} = self;
 
@@ -246,7 +255,8 @@ impl WsClientBuilder {
 			.request_timeout(request_timeout)
 			.max_concurrent_requests(max_concurrent_requests)
 			.id_format(id_kind)
-			.set_max_logging_length(max_log_length);
+			.set_max_logging_length(max_log_length)
+			.set_tcp_no_delay(tcp_no_delay);
 
 		if let Some(cfg) = ping_config {
 			client = client.enable_ws_ping(cfg);
@@ -271,6 +281,7 @@ impl WsClientBuilder {
 			max_request_size: self.max_request_size,
 			max_response_size: self.max_response_size,
 			max_redirections: self.max_redirections,
+			tcp_no_delay: self.tcp_no_delay,
 		};
 
 		let uri = Url::parse(url.as_ref()).map_err(|e| Error::Transport(e.into()))?;
@@ -295,6 +306,7 @@ impl WsClientBuilder {
 			max_request_size: self.max_request_size,
 			max_response_size: self.max_response_size,
 			max_redirections: self.max_redirections,
+			tcp_no_delay: self.tcp_no_delay,
 		};
 
 		let uri = Url::parse(url.as_ref()).map_err(|e| Error::Transport(e.into()))?;

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -299,10 +299,10 @@ impl ClientBuilder {
 	}
 
 	/// Configure `TCP_NODELAY` on the socket to the supplied value `nodelay`.
-	/// 
+	///
 	/// On some transports this may have no effect.
-    ///
-    /// Default is `true`.
+	///
+	/// Default is `true`.
 	pub fn set_tcp_no_delay(mut self, no_delay: bool) -> Self {
 		self.tcp_no_delay = no_delay;
 		self

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -215,6 +215,7 @@ pub struct ClientBuilder {
 	id_kind: IdKind,
 	max_log_length: u32,
 	ping_config: Option<PingConfig>,
+	tcp_no_delay: bool,
 }
 
 impl Default for ClientBuilder {
@@ -226,6 +227,7 @@ impl Default for ClientBuilder {
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
 			ping_config: None,
+			tcp_no_delay: true,
 		}
 	}
 }
@@ -293,6 +295,16 @@ impl ClientBuilder {
 	/// Default: pings are disabled.
 	pub fn disable_ws_ping(mut self) -> Self {
 		self.ping_config = None;
+		self
+	}
+
+	/// Configure `TCP_NODELAY` on the socket to the supplied value `nodelay`.
+	/// 
+	/// On some transports this may have no effect.
+    ///
+    /// Default is `true`.
+	pub fn set_tcp_no_delay(mut self, no_delay: bool) -> Self {
+		self.tcp_no_delay = no_delay;
 		self
 	}
 


### PR DESCRIPTION
Close #1262 