### PR TITLE
WIP: refactor: migrate to native async trait

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 publish = true
 
 [dependencies]
-async-trait = "0.1"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.24", optional = true, default-features = false, features = ["http1", "http2", "tls12", "logging"] }
 jsonrpsee-types = { workspace = true }

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -31,9 +31,10 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures_util::io::{BufReader, BufWriter};
+use futures_util::Future;
 use jsonrpsee_core::client::{CertificateStore, MaybeSend, ReceivedMessage, TransportReceiverT, TransportSenderT};
+use jsonrpsee_core::Cow;
 use jsonrpsee_core::TEN_MB_SIZE_BYTES;
-use jsonrpsee_core::{async_trait, Cow};
 use soketto::connection::Error::Utf8;
 use soketto::data::ByteSlice125;
 use soketto::handshake::client::{Client as WsHandshakeClient, ServerResponse};
@@ -230,7 +231,6 @@ pub enum WsError {
 	MessageTooLarge,
 }
 
-#[async_trait]
 impl<T> TransportSenderT for Sender<T>
 where
 	T: futures_util::io::AsyncRead + futures_util::io::AsyncWrite + Unpin + MaybeSend + 'static,
@@ -239,37 +239,40 @@ where
 
 	/// Sends out a request. Returns a `Future` that finishes when the request has been
 	/// successfully sent.
-	async fn send(&mut self, body: String) -> Result<(), Self::Error> {
-		if body.len() > self.max_request_size as usize {
-			return Err(WsError::MessageTooLarge);
-		}
+	fn send(&mut self, body: String) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+		async {
+			if body.len() > self.max_request_size as usize {
+				return Err(WsError::MessageTooLarge);
+			}
 
-		self.inner.send_text(body).await?;
-		self.inner.flush().await?;
-		Ok(())
+			self.inner.send_text(body).await?;
+			self.inner.flush().await?;
+			Ok(())
+		}
 	}
 
 	/// Sends out a ping request. Returns a `Future` that finishes when the request has been
 	/// successfully sent.
-	async fn send_ping(&mut self) -> Result<(), Self::Error> {
-		tracing::debug!(target: LOG_TARGET, "Send ping");
-		// Submit empty slice as "optional" parameter.
-		let slice: &[u8] = &[];
-		// Byte slice fails if the provided slice is larger than 125 bytes.
-		let byte_slice = ByteSlice125::try_from(slice).expect("Empty slice should fit into ByteSlice125");
+	fn send_ping(&mut self) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+		async {
+			tracing::debug!(target: LOG_TARGET, "Send ping");
+			// Submit empty slice as "optional" parameter.
+			let slice: &[u8] = &[];
+			// Byte slice fails if the provided slice is larger than 125 bytes.
+			let byte_slice = ByteSlice125::try_from(slice).expect("Empty slice should fit into ByteSlice125");
 
-		self.inner.send_ping(byte_slice).await?;
-		self.inner.flush().await?;
-		Ok(())
+			self.inner.send_ping(byte_slice).await?;
+			self.inner.flush().await?;
+			Ok(())
+		}
 	}
 
 	/// Send a close message and close the connection.
-	async fn close(&mut self) -> Result<(), WsError> {
-		self.inner.close().await.map_err(Into::into)
+	fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+		async { self.inner.close().await.map_err(Into::into) }
 	}
 }
 
-#[async_trait]
 impl<T> TransportReceiverT for Receiver<T>
 where
 	T: futures_util::io::AsyncRead + futures_util::io::AsyncWrite + Unpin + MaybeSend + 'static,
@@ -277,19 +280,22 @@ where
 	type Error = WsError;
 
 	/// Returns a `Future` resolving when the server sent us something back.
-	async fn receive(&mut self) -> Result<ReceivedMessage, Self::Error> {
-		loop {
-			let mut message = Vec::new();
-			let recv = self.inner.receive(&mut message).await?;
+	fn receive(&mut self) -> impl Future<Output = Result<ReceivedMessage, Self::Error>> {
+		async {
+			loop {
+				let mut message = Vec::new();
+				let recv = self.inner.receive(&mut message).await?;
 
-			match recv {
-				Incoming::Data(Data::Text(_)) => {
-					let s = String::from_utf8(message).map_err(|err| WsError::Connection(Utf8(err.utf8_error())))?;
-					break Ok(ReceivedMessage::Text(s));
+				match recv {
+					Incoming::Data(Data::Text(_)) => {
+						let s =
+							String::from_utf8(message).map_err(|err| WsError::Connection(Utf8(err.utf8_error())))?;
+						break Ok(ReceivedMessage::Text(s));
+					}
+					Incoming::Data(Data::Binary(_)) => break Ok(ReceivedMessage::Bytes(message)),
+					Incoming::Pong(_) => break Ok(ReceivedMessage::Pong),
+					_ => continue,
 				}
-				Incoming::Data(Data::Binary(_)) => break Ok(ReceivedMessage::Bytes(message)),
-				Incoming::Pong(_) => break Ok(ReceivedMessage::Pong),
-				_ => continue,
 			}
 		}
 	}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,6 @@ publish = true
 
 [dependencies]
 anyhow = "1"
-async-trait = "0.1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 jsonrpsee-types = { workspace = true }
 thiserror = "1"

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -33,6 +33,7 @@ cfg_async_client! {
 
 pub mod error;
 pub use error::Error;
+use futures_util::Future;
 
 use std::fmt;
 use std::ops::Range;
@@ -43,7 +44,6 @@ use std::task;
 
 use crate::params::BatchRequestBuilder;
 use crate::traits::ToRpcParams;
-use async_trait::async_trait;
 use core::marker::PhantomData;
 use futures_util::stream::{Stream, StreamExt};
 use jsonrpsee_types::{ErrorObject, Id, SubscriptionId};
@@ -61,15 +61,14 @@ pub mod __reexports {
 }
 
 /// [JSON-RPC](https://www.jsonrpc.org/specification) client interface that can make requests and notifications.
-#[async_trait]
 pub trait ClientT {
 	/// Send a [notification request](https://www.jsonrpc.org/specification#notification)
-	async fn notification<Params>(&self, method: &str, params: Params) -> Result<(), Error>
+	fn notification<Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<(), Error>> + Send
 	where
 		Params: ToRpcParams + Send;
 
 	/// Send a [method call request](https://www.jsonrpc.org/specification#request_object).
-	async fn request<R, Params>(&self, method: &str, params: Params) -> Result<R, Error>
+	fn request<R, Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<R, Error>> + Send
 	where
 		R: DeserializeOwned,
 		Params: ToRpcParams + Send;
@@ -81,13 +80,15 @@ pub trait ClientT {
 	///
 	/// Returns `Ok` if all requests in the batch were answered.
 	/// Returns `Error` if the network failed or any of the responses could be parsed a valid JSON-RPC response.
-	async fn batch_request<'a, R>(&self, batch: BatchRequestBuilder<'a>) -> Result<BatchResponse<'a, R>, Error>
+	fn batch_request<'a, R>(
+		&self,
+		batch: BatchRequestBuilder<'a>,
+	) -> impl Future<Output = Result<BatchResponse<'a, R>, Error>> + Send
 	where
 		R: DeserializeOwned + fmt::Debug + 'a;
 }
 
 /// [JSON-RPC](https://www.jsonrpc.org/specification) client interface that can make requests, notifications and subscriptions.
-#[async_trait]
 pub trait SubscriptionClientT: ClientT {
 	/// Initiate a subscription by performing a JSON-RPC method call where the server responds with
 	/// a `Subscription ID` that is used to fetch messages on that subscription,
@@ -101,12 +102,12 @@ pub trait SubscriptionClientT: ClientT {
 	///
 	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further
 	/// documentation.
-	async fn subscribe<'a, Notif, Params>(
+	fn subscribe<'a, Notif, Params>(
 		&self,
 		subscribe_method: &'a str,
 		params: Params,
 		unsubscribe_method: &'a str,
-	) -> Result<Subscription<Notif>, Error>
+	) -> impl Future<Output = Result<Subscription<Notif>, Error>> + Send
 	where
 		Params: ToRpcParams + Send,
 		Notif: DeserializeOwned;
@@ -115,7 +116,10 @@ pub trait SubscriptionClientT: ClientT {
 	///
 	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further
 	/// documentation.
-	async fn subscribe_to_method<'a, Notif>(&self, method: &'a str) -> Result<Subscription<Notif>, Error>
+	fn subscribe_to_method<'a, Notif>(
+		&self,
+		method: &'a str,
+	) -> impl Future<Output = Result<Subscription<Notif>, Error>> + Send
 	where
 		Notif: DeserializeOwned;
 }
@@ -135,29 +139,27 @@ impl<T: Send> MaybeSend for T {}
 impl<T> MaybeSend for T {}
 
 /// Transport interface to send data asynchronous.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait TransportSenderT: MaybeSend + 'static {
 	/// Error that may occur during sending a message.
 	type Error: std::error::Error + Send + Sync;
 
 	/// Send.
-	async fn send(&mut self, msg: String) -> Result<(), Self::Error>;
+	fn send(&mut self, msg: String) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend;
 
 	/// This is optional because it's most likely relevant for WebSocket transports only.
 	/// You should only implement this is your transport supports sending periodic pings.
 	///
 	/// Send ping frame (opcode of 0x9).
-	async fn send_ping(&mut self) -> Result<(), Self::Error> {
-		Ok(())
+	fn send_ping(&mut self) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+		async { Ok(()) }
 	}
 
 	/// This is optional because it's most likely relevant for WebSocket transports only.
 	/// You should only implement this is your transport supports being closed.
 	///
 	/// Send customized close message.
-	async fn close(&mut self) -> Result<(), Self::Error> {
-		Ok(())
+	fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+		async { Ok(()) }
 	}
 }
 
@@ -174,14 +176,12 @@ pub enum ReceivedMessage {
 }
 
 /// Transport interface to receive data asynchronous.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait TransportReceiverT: 'static {
 	/// Error that may occur during receiving a message.
 	type Error: std::error::Error + Send + Sync;
 
 	/// Receive.
-	async fn receive(&mut self) -> Result<ReceivedMessage, Self::Error>;
+	fn receive(&mut self) -> impl Future<Output = Result<ReceivedMessage, Self::Error>> + MaybeSend;
 }
 
 /// Convert the given values to a [`crate::params::ArrayParams`] as expected by a

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,7 +59,6 @@ cfg_client! {
 
 /// Shared tracing helpers to trace RPC calls.
 pub mod tracing;
-pub use async_trait::async_trait;
 pub use error::{GenericTransportError, RegisterMethodError, StringError};
 
 /// JSON-RPC result.
@@ -72,7 +71,6 @@ pub type EmptyServerParams = Vec<()>;
 /// dependencies to be explicitly added on the client side.
 #[doc(hidden)]
 pub mod __reexports {
-	pub use async_trait::async_trait;
 	pub use serde;
 	pub use serde_json;
 }

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -32,18 +32,19 @@ use std::sync::Arc;
 
 use crate::error::RegisterMethodError;
 use crate::id_providers::RandomIntegerIdProvider;
-use crate::server::LOG_TARGET;
 use crate::server::helpers::{MethodResponse, MethodSink};
 use crate::server::subscription::{
 	sub_message_to_json, BoundedSubscriptions, IntoSubscriptionCloseResponse, PendingSubscriptionSink,
 	SubNotifResultOrError, Subscribers, Subscription, SubscriptionCloseResponse, SubscriptionKey, SubscriptionPermit,
 	SubscriptionState,
 };
+use crate::server::LOG_TARGET;
 use crate::traits::ToRpcParams;
 use futures_util::{future::BoxFuture, FutureExt};
 use jsonrpsee_types::error::{ErrorCode, ErrorObject};
 use jsonrpsee_types::{
-	Id, Params, Request, Response, ResponsePayload, ResponseSuccess, SubscriptionId as RpcSubscriptionId, ErrorObjectOwned,
+	ErrorObjectOwned, Id, Params, Request, Response, ResponsePayload, ResponseSuccess,
+	SubscriptionId as RpcSubscriptionId,
 };
 use rustc_hash::FxHashMap;
 use serde::de::DeserializeOwned;
@@ -77,7 +78,6 @@ pub type MaxResponseSize = usize;
 ///   - Call result as a `String`,
 ///   - a [`mpsc::UnboundedReceiver<String>`] to receive future subscription results
 pub type RawRpcResponse = (MethodResponse, mpsc::Receiver<String>);
-
 
 /// The error that can occur when [`Methods::call`] or [`Methods::subscribe`] is invoked.
 #[derive(thiserror::Error, Debug)]
@@ -430,7 +430,8 @@ impl Methods {
 		let as_success: ResponseSuccess<serde_json::Value> =
 			serde_json::from_str::<Response<_>>(&resp.result)?.try_into()?;
 
-		let sub_id = as_success.result.try_into().map_err(|_| MethodsError::InvalidSubscriptionId(resp.result.clone()))?;
+		let sub_id =
+			as_success.result.try_into().map_err(|_| MethodsError::InvalidSubscriptionId(resp.result.clone()))?;
 
 		Ok(Subscription { sub_id, rx })
 	}

--- a/examples/examples/jsonrpsee_as_service.rs
+++ b/examples/examples/jsonrpsee_as_service.rs
@@ -36,10 +36,10 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use futures::Future;
 use hyper::header::AUTHORIZATION;
 use hyper::server::conn::AddrStream;
 use hyper::HeaderMap;
-use jsonrpsee::core::async_trait;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::{ResponseFuture, RpcServiceBuilder, RpcServiceT};
@@ -94,10 +94,9 @@ pub trait Rpc {
 	async fn trusted_call(&self) -> Result<String, ErrorObjectOwned>;
 }
 
-#[async_trait]
 impl RpcServer for () {
-	async fn trusted_call(&self) -> Result<String, ErrorObjectOwned> {
-		Ok("mysecret".to_string())
+	fn trusted_call(&self) -> impl Future<Output = Result<String, ErrorObjectOwned>> + Send {
+		async { Ok("mysecret".to_string()) }
 	}
 }
 

--- a/examples/examples/jsonrpsee_server_low_level_api.rs
+++ b/examples/examples/jsonrpsee_server_low_level_api.rs
@@ -40,6 +40,7 @@
 
 use std::collections::HashSet;
 use std::convert::Infallible;
+use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -47,7 +48,6 @@ use std::sync::{Arc, Mutex};
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use hyper::server::conn::AddrStream;
-use jsonrpsee::core::async_trait;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::RpcServiceT;
@@ -105,10 +105,9 @@ pub trait Rpc {
 	async fn say_hello(&self) -> Result<String, ErrorObjectOwned>;
 }
 
-#[async_trait]
 impl RpcServer for () {
-	async fn say_hello(&self) -> Result<String, ErrorObjectOwned> {
-		Ok("lo".to_string())
+	fn say_hello(&self) -> impl Future<Output = Result<String, ErrorObjectOwned>> {
+		async { Ok("lo".to_string()) }
 	}
 }
 

--- a/examples/examples/proc_macro_bounds.rs
+++ b/examples/examples/proc_macro_bounds.rs
@@ -26,7 +26,6 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::async_trait;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
@@ -59,7 +58,6 @@ pub trait Rpc<T: Config> {
 
 pub struct RpcServerImpl;
 
-#[async_trait]
 impl RpcServer<ExampleHash> for RpcServerImpl {
 	fn method(&self) -> Result<<ExampleHash as Config>::Hash, ErrorObjectOwned> {
 		Ok([0u8; 32])

--- a/examples/examples/rpc_middleware.rs
+++ b/examples/examples/rpc_middleware.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use jsonrpsee::core::{async_trait, client::ClientT};
+use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
 use jsonrpsee::server::middleware::rpc::{RpcServiceBuilder, RpcServiceT};
 use jsonrpsee::server::{MethodResponse, RpcModule, Server};
@@ -85,7 +85,6 @@ pub struct GlobalCalls<S> {
 	count: Arc<AtomicUsize>,
 }
 
-#[async_trait]
 impl<'a, S> RpcServiceT<'a> for GlobalCalls<S>
 where
 	S: RpcServiceT<'a> + Send + Sync + Clone + 'static,

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::params::ArrayParams;
-use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
+use jsonrpsee::core::{RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{ServerBuilder, SubscriptionMessage};
 use jsonrpsee::ws_client::*;
@@ -41,7 +41,6 @@ pub trait Rpc {
 
 pub struct RpcServerImpl;
 
-#[async_trait]
 impl RpcServer for RpcServerImpl {
 	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)

--- a/proc-macros/tests/ui/correct/custom_ret_types.rs
+++ b/proc-macros/tests/ui/correct/custom_ret_types.rs
@@ -2,7 +2,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, ClientError, Serialize};
+use jsonrpsee::core::{ClientError, Serialize};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{IntoResponse, ServerBuilder};
 use jsonrpsee::types::ResponsePayload;
@@ -58,7 +58,6 @@ pub trait Rpc {
 
 pub struct RpcServerImpl;
 
-#[async_trait]
 impl RpcServer for RpcServerImpl {
 	async fn async_method1(&self) -> CustomError {
 		CustomError::One

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
+use jsonrpsee::core::{RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{PendingSubscriptionSink, ServerBuilder};
 
@@ -18,7 +18,6 @@ pub trait Rpc {
 
 pub struct RpcServerImpl;
 
-#[async_trait]
 impl RpcServer for RpcServerImpl {
 	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)

--- a/proc-macros/tests/ui/correct/param_kind.rs
+++ b/proc-macros/tests/ui/correct/param_kind.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::*;
@@ -19,7 +19,6 @@ pub trait Rpc {
 
 pub struct RpcServerImpl;
 
-#[async_trait]
 impl RpcServer for RpcServerImpl {
 	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
 		assert_eq!(param_a, 0);

--- a/proc-macros/tests/ui/correct/rpc_bounds.rs
+++ b/proc-macros/tests/ui/correct/rpc_bounds.rs
@@ -2,7 +2,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
+use jsonrpsee::core::{RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::*;
@@ -103,7 +103,7 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 
 /// Implementation for the `MyRpcS` trait (server only).
 pub struct ServerOnlyImpl;
-#[async_trait]
+
 impl MyRpcSServer<ExampleHash> for ServerOnlyImpl {
 	fn method(&self) -> RpcResult<<ExampleHash as Config>::Hash> {
 		Ok([0u8; 32])
@@ -112,7 +112,7 @@ impl MyRpcSServer<ExampleHash> for ServerOnlyImpl {
 
 /// Implementation for the `MyRpcSC` trait (client server rpc).
 pub struct ServerClientServerImpl;
-#[async_trait]
+
 impl MyRpcSCServer<ExampleHash> for ServerClientServerImpl {
 	fn method(&self) -> RpcResult<<ExampleHash as Config>::Hash> {
 		Ok([0u8; 32])

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
@@ -5,7 +5,7 @@
 
 use std::net::SocketAddr;
 
-use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::*;
@@ -29,7 +29,6 @@ pub trait Deprecated {
 
 pub struct DeprecatedServerImpl;
 
-#[async_trait]
 impl DeprecatedServer for DeprecatedServerImpl {
 	async fn async_method(&self) -> RpcResult<u8> {
 		Ok(16u8)

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -604,7 +604,6 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 	///
 	/// use jsonrpsee_server::middleware::rpc::{RpcServiceT, RpcService, RpcServiceBuilder};
 	/// use jsonrpsee_server::{ServerBuilder, MethodResponse};
-	/// use jsonrpsee_core::async_trait;
 	/// use jsonrpsee_types::Request;
 	/// use futures_util::future::BoxFuture;
 	///

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use helpers::init_logger;
-use jsonrpsee::core::{async_trait, client::ClientT, ClientError};
+use jsonrpsee::core::{client::ClientT, ClientError};
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::{RpcServiceBuilder, RpcServiceT};
@@ -62,7 +62,6 @@ pub struct CounterMiddleware<S> {
 	counter: Arc<Mutex<Counter>>,
 }
 
-#[async_trait]
 impl<'a, S> RpcServiceT<'a> for CounterMiddleware<S>
 where
 	S: RpcServiceT<'a> + Send + Sync + Clone + 'static,
@@ -105,13 +104,15 @@ fn test_module() -> RpcModule<()> {
 	pub trait Rpc {
 		#[method(name = "say_hello")]
 		async fn hello(&self) -> String {
-			sleep(Duration::from_millis(50)).await;
-			"hello".to_string()
+			async {
+				sleep(Duration::from_millis(50)).await;
+				"hello".to_string()
+			}
 		}
 
 		#[method(name = "err")]
 		async fn err(&self) -> Result<String, ErrorObjectOwned> {
-			Err(ErrorObject::owned(1, "err", None::<()>))
+			async { Err(ErrorObject::owned(1, "err", None::<()>)) }
 		}
 	}
 

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -46,7 +46,7 @@ mod rpc_impl {
 	use jsonrpsee::core::server::{
 		IntoSubscriptionCloseResponse, PendingSubscriptionSink, SubscriptionCloseResponse, SubscriptionMessage,
 	};
-	use jsonrpsee::core::{async_trait, SubscriptionResult};
+	use jsonrpsee::core::SubscriptionResult;
 	use jsonrpsee::proc_macros::rpc;
 	use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 
@@ -152,7 +152,6 @@ mod rpc_impl {
 
 	pub struct RpcServerImpl;
 
-	#[async_trait]
 	impl RpcServer for RpcServerImpl {
 		async fn async_method(&self, _param_a: u8, _param_b: String) -> Result<u16, ErrorObjectOwned> {
 			Ok(42)

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -139,7 +139,7 @@ async fn calling_method_without_server() {
 
 #[tokio::test]
 async fn calling_method_without_server_using_proc_macro() {
-	use jsonrpsee::{core::async_trait, proc_macros::rpc};
+	use jsonrpsee::proc_macros::rpc;
 	// Setup
 	#[derive(Debug, Deserialize, Serialize)]
 	#[allow(unreachable_pub)]
@@ -174,7 +174,6 @@ async fn calling_method_without_server_using_proc_macro() {
 
 	struct CoolServerImpl;
 
-	#[async_trait]
 	impl CoolServer for CoolServerImpl {
 		fn rebel_without_cause(&self) -> RpcResult<bool> {
 			Ok(false)


### PR DESCRIPTION
Close https://github.com/paritytech/jsonrpsee/issues/1229

This PR removes all usage of the async trait crate to get rid of a bunch extra allocations for boxing each future.
In order to make it work this PR modifies the original async methods to add send bounds to each method.

```rust
#[rpc(server, client)]
pub trait Rpc
{
	#[method(name = "async")]
	async fn async(
		&self,
	) -> Result<Vec<u8>, ErrorObjectOwned>;

	#[method(name = "sync")]
	fn sync(
		&self,
	) -> Result<Vec<u8>, ErrorObjectOwned>;
}
```

-> the actual generated trait for the server is:

```rust
#[rpc(server)]
pub trait RpcServer
{
	fn async(
		&self,
	) -> impl Future<Output = Result<Vec<u8>, ErrorObjectOwned>> + Send;

	fn sync(
		&self,
	) -> Result<Vec<u8>, ErrorObjectOwned>;
}
```

-> the actual generated trait for the client is:

```rust
#[rpc(server)]
pub trait RpcClient
{
	fn async(
		&self,
	) -> impl Future<Output = Result<Vec<u8>,  client::Error>> + Send;

	fn sync(
		&self,
	) -> impl Future<Output = Result<Vec<u8>, client::Error>> + Send;
}
```

I noticed that there is already a crate that helps with these conversions which make more ergonomic to implement for users, https://docs.rs/trait-variant/latest/trait_variant/attr.make.html

