### PR TITLE
fix: allow application/json-rpc http content type

### DIFF
--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -18,6 +18,9 @@ pub fn is_json(content_type: Option<&hyper::header::HeaderValue>) -> bool {
 		content.eq_ignore_ascii_case("application/json")
 			|| content.eq_ignore_ascii_case("application/json; charset=utf-8")
 			|| content.eq_ignore_ascii_case("application/json;charset=utf-8")
+			|| content.eq_ignore_ascii_case("application/json-rpc")
+			|| content.eq_ignore_ascii_case("application/json-rpc;charset=utf-8")
+			|| content.eq_ignore_ascii_case("application/json-rpc; charset=utf-8")
 	})
 }
 


### PR DESCRIPTION
Hi, consider allowing 'application/json-rpc' content type.

I came across [this](https://www.jsonrpc.org/historical/json-rpc-over-http.html) (deprecated?) JSON-RPC over HTTP specification file that indicates that content-type should be 'application/json-rpc'.
Also, several widely used libraries, such as jsonrpc4j [use](https://github.com/briandilley/jsonrpc4j/blob/755cccdf325f8996d89cbaaca82de0b4ae3acf85/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java#L37) it.


