### PR TITLE
feat(server): add `TowerService::on_session_close`

### DIFF
--- a/examples/examples/jsonrpsee_as_service.rs
+++ b/examples/examples/jsonrpsee_as_service.rs
@@ -36,6 +36,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use futures::FutureExt;
 use hyper::header::AUTHORIZATION;
 use hyper::server::conn::AddrStream;
 use hyper::HeaderMap;
@@ -45,16 +46,18 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::{ResponseFuture, RpcServiceBuilder, RpcServiceT};
 use jsonrpsee::server::{stop_channel, ServerHandle, StopHandle, TowerServiceBuilder};
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Request};
-use jsonrpsee::ws_client::HeaderValue;
+use jsonrpsee::ws_client::{HeaderValue, WsClientBuilder};
 use jsonrpsee::{MethodResponse, Methods};
 use tower::Service;
 use tower_http::cors::CorsLayer;
 use tracing_subscriber::util::SubscriberInitExt;
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 struct Metrics {
-	ws_connections: Arc<AtomicUsize>,
-	http_connections: Arc<AtomicUsize>,
+	opened_ws_connections: Arc<AtomicUsize>,
+	closed_ws_connections: Arc<AtomicUsize>,
+	http_calls: Arc<AtomicUsize>,
+	success_http_calls: Arc<AtomicUsize>,
 }
 
 #[derive(Clone)]
@@ -106,11 +109,21 @@ async fn main() -> anyhow::Result<()> {
 	let filter = tracing_subscriber::EnvFilter::try_from_default_env()?;
 	tracing_subscriber::FmtSubscriber::builder().with_env_filter(filter).finish().try_init()?;
 
-	let handle = run_server();
+	let metrics = Metrics::default();
+
+	let handle = run_server(metrics.clone());
 	tokio::spawn(handle.stopped());
 
 	{
 		let client = HttpClientBuilder::default().build("http://127.0.0.1:9944").unwrap();
+
+		// Fails because the authorization header is missing.
+		let x = client.trusted_call().await.unwrap_err();
+		tracing::info!("response: {x}");
+	}
+
+	{
+		let client = WsClientBuilder::default().build("ws://127.0.0.1:9944").await.unwrap();
 
 		// Fails because the authorization header is missing.
 		let x = client.trusted_call().await.unwrap_err();
@@ -127,10 +140,12 @@ async fn main() -> anyhow::Result<()> {
 		tracing::info!("response: {x}");
 	}
 
+	tracing::info!("{:?}", metrics);
+
 	Ok(())
 }
 
-fn run_server() -> ServerHandle {
+fn run_server(metrics: Metrics) -> ServerHandle {
 	use hyper::service::{make_service_fn, service_fn};
 
 	let addr = SocketAddr::from(([127, 0, 0, 1], 9944));
@@ -159,7 +174,7 @@ fn run_server() -> ServerHandle {
 	let per_conn = PerConnection {
 		methods: ().into_rpc().into(),
 		stop_handle: stop_handle.clone(),
-		metrics: Metrics::default(),
+		metrics,
 		svc_builder: jsonrpsee::server::Server::builder()
 			.set_http_middleware(tower::ServiceBuilder::new().layer(CorsLayer::permissive()))
 			.max_connections(33)
@@ -183,17 +198,40 @@ fn run_server() -> ServerHandle {
 					AuthorizationMiddleware { inner: service, headers: headers.clone(), transport_label }
 				});
 
-				let mut svc = svc_builder.set_rpc_middleware(rpc_middleware).build(methods, stop_handle);
+				if is_websocket {
+					// Utilize the session close future to know when the actual WebSocket
+					// session was closed.
+					let (mut svc, session_close) = svc_builder
+						.set_rpc_middleware(rpc_middleware)
+						.build_and_notify_on_session_close(methods, stop_handle);
 
-				async move {
-					// You can't determine whether the websocket upgrade handshake failed or not here.
-					let rp = svc.call(req).await;
-					if is_websocket {
-						metrics.ws_connections.fetch_add(1, Ordering::Relaxed);
-					} else {
-						metrics.http_connections.fetch_add(1, Ordering::Relaxed);
+					// A little bit weird API but the response to HTTP request must be returned below
+					// and we spawn a task to register when the session is closed.
+					tokio::spawn(async move {
+						session_close.await;
+						metrics.closed_ws_connections.fetch_add(1, Ordering::Relaxed);
+					});
+
+					async move {
+						metrics.opened_ws_connections.fetch_add(1, Ordering::Relaxed);
+						svc.call(req).await
 					}
-					rp
+					.boxed()
+				} else {
+					// HTTP.
+					let mut svc = svc_builder.set_rpc_middleware(rpc_middleware).build(methods, stop_handle);
+
+					async move {
+						metrics.http_calls.fetch_add(1, Ordering::Relaxed);
+						let rp = svc.call(req).await;
+
+						if rp.is_ok() {
+							metrics.success_http_calls.fetch_add(1, Ordering::Relaxed);
+						}
+
+						rp
+					}
+					.boxed()
 				}
 			}))
 		}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 soketto = { version = "0.7.1", features = ["http"] }
 tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
-tokio-stream = "0.1.7"
+tokio-stream = { version = "0.1.7", features = ["sync"] }
 hyper = { version = "0.14", features = ["server", "http1", "http2"] }
 tower = "0.4.13"
 thiserror = "1"

--- a/server/src/future.rs
+++ b/server/src/future.rs
@@ -182,11 +182,9 @@ impl Future for SessionClosedFuture {
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
 		match self.0.poll_next_unpin(cx) {
 			Poll::Pending => Poll::Pending,
-			// A message is only sent when
-			Poll::Ready(x) => {
-				tracing::info!("{:?}", x);
-				Poll::Ready(())
-			}
+			// Only message is only sent and
+			// ignore can't keep up errors.
+			Poll::Ready(_) => Poll::Ready(()),
 		}
 	}
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -945,10 +945,9 @@ pub struct TowerService<RpcMiddleware, HttpMiddleware> {
 impl<RpcMiddleware, HttpMiddleware> TowerService<RpcMiddleware, HttpMiddleware> {
 	/// A future that returns when the connection has been closed.
 	///
-	/// It's possible to call this many times but internally it uses
-	/// a bounded buffer of 4 such that if one creates more than 4
-	/// SessionCloseFuture's. Then any of these 4 first futures
-	/// must be polled or dropped to make any progress.
+	/// This method must be called before every [`TowerService::call`]
+	/// because the `SessionClosedFuture` may already been consumed or
+	/// not used.
 	pub fn on_session_closed(&mut self) -> SessionClosedFuture {
 		if let Some(n) = self.rpc_middleware.on_session_close.as_mut() {
 			// If it's called more then once another listener is created.


### PR DESCRIPTION
This PR adds another builder option to the `TowerServiceBuilder` get subscribe to when the connection/session has closed because when `TowerService::call` resolves it means that HTTP call has been finished but doesn't mean that WebSocket connection has closed. 

Thus, to know that we need another future sadly but worth the effort because otherwise the only way for folks it use the low-level API.

Resolves #1264
