### PR TITLE
refactor(rpc_module): RpcModule::raw_json_request -> String

### DIFF
--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -37,11 +37,10 @@ use jsonrpsee::server::middleware::http::ProxyGetRequestLayer;
 use jsonrpsee::server::{
 	PendingSubscriptionSink, RpcModule, Server, ServerBuilder, ServerHandle, SubscriptionMessage, TrySendError,
 };
-use jsonrpsee::types::{ErrorCode, ErrorObject, ErrorObjectOwned};
-use jsonrpsee::{MethodResponseError, ResponsePayload, SubscriptionCloseResponse};
-use serde::{Deserialize, Serialize};
+use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
+use jsonrpsee::SubscriptionCloseResponse;
+use serde::Serialize;
 use tokio::net::TcpStream;
-use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 use tower_http::cors::CorsLayer;
@@ -287,54 +286,4 @@ pub async fn connect_over_socks_stream(server_addr: SocketAddr) -> Socks5Stream<
 	)
 	.await
 	.unwrap()
-}
-
-#[derive(Copy, Clone, Deserialize, Serialize)]
-pub enum Notify {
-	Success,
-	Error,
-	All,
-}
-
-pub type NotifyRpcModule = RpcModule<UnboundedSender<Result<(), MethodResponseError>>>;
-pub type Sender = tokio::sync::mpsc::UnboundedSender<Result<(), MethodResponseError>>;
-pub type Receiver = tokio::sync::mpsc::UnboundedReceiver<Result<(), MethodResponseError>>;
-
-pub async fn run_test_notify_test(
-	module: &NotifyRpcModule,
-	server_rx: &mut Receiver,
-	kind: Notify,
-) -> Result<(), MethodResponseError> {
-	use jsonrpsee_test_utils::mocks::Id;
-
-	let req = jsonrpsee_test_utils::helpers::call("hey", vec![kind], Id::Num(1));
-	let _ = module.raw_json_request(&req, 1).await.unwrap();
-	server_rx.recv().await.expect("Channel is not dropped")
-}
-
-/// Helper module that will send the results on the channel passed in.
-pub fn rpc_module_notify_on_response(tx: Sender) -> NotifyRpcModule {
-	let mut module = RpcModule::new(tx);
-
-	module
-		.register_method("hey", |params, ctx| {
-			let kind: Notify = params.one().unwrap();
-			let server_sender = ctx.clone();
-
-			let (rp, rp_future) = match kind {
-				Notify::All => ResponsePayload::success("lo").notify_on_completion(),
-				Notify::Success => ResponsePayload::success("lo").notify_on_completion(),
-				Notify::Error => ResponsePayload::error(ErrorCode::InvalidParams).notify_on_completion(),
-			};
-
-			tokio::spawn(async move {
-				let rp = rp_future.await;
-				server_sender.send(rp).unwrap();
-			});
-
-			rp
-		})
-		.unwrap();
-
-	module
 }

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -303,15 +303,12 @@ pub type Receiver = tokio::sync::mpsc::UnboundedReceiver<Result<(), MethodRespon
 pub async fn run_test_notify_test(
 	module: &NotifyRpcModule,
 	server_rx: &mut Receiver,
-	is_success: bool,
 	kind: Notify,
 ) -> Result<(), MethodResponseError> {
 	use jsonrpsee_test_utils::mocks::Id;
 
 	let req = jsonrpsee_test_utils::helpers::call("hey", vec![kind], Id::Num(1));
-	let (rp, _) = module.raw_json_request(&req, 1).await.unwrap();
-	let (_, notify_rx) = rp.into_parts();
-	notify_rx.unwrap().notify(is_success);
+	let _ = module.raw_json_request(&req, 1).await.unwrap();
 	server_rx.recv().await.expect("Channel is not dropped")
 }
 

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -266,7 +266,7 @@ async fn macro_optional_param_parsing() {
 		.raw_json_request(r#"{"jsonrpc":"2.0","method":"foo_optional_params","params":{"a":22,"c":50},"id":0}"#, 1)
 		.await
 		.unwrap();
-	assert_eq!(resp.into_result(), r#"{"jsonrpc":"2.0","result":"Called with: 22, None, Some(50)","id":0}"#);
+	assert_eq!(resp, r#"{"jsonrpc":"2.0","result":"Called with: 22, None, Some(50)","id":0}"#);
 }
 
 #[tokio::test]
@@ -290,14 +290,14 @@ async fn macro_zero_copy_cow() {
 		.unwrap();
 
 	// std::borrow::Cow<str> always deserialized to owned variant here
-	assert_eq!(resp.into_result(), r#"{"jsonrpc":"2.0","result":"Zero copy params: false, true","id":0}"#);
+	assert_eq!(resp, r#"{"jsonrpc":"2.0","result":"Zero copy params: false, true","id":0}"#);
 
 	// serde_json will have to allocate a new string to replace `\t` with byte 0x09 (tab)
 	let (resp, _) = module
 		.raw_json_request(r#"{"jsonrpc":"2.0","method":"foo_zero_copy_cow","params":["\tfoo", "\tbar"],"id":0}"#, 1)
 		.await
 		.unwrap();
-	assert_eq!(resp.into_result(), r#"{"jsonrpc":"2.0","result":"Zero copy params: false, false","id":0}"#);
+	assert_eq!(resp, r#"{"jsonrpc":"2.0","result":"Zero copy params: false, false","id":0}"#);
 }
 
 // Disabled on MacOS as GH CI timings on Mac vary wildly (~100ms) making this test fail.

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -38,7 +38,6 @@ use jsonrpsee::core::{server::*, RpcResult};
 use jsonrpsee::types::error::{ErrorCode, ErrorObject, INVALID_PARAMS_MSG, PARSE_ERROR_CODE};
 use jsonrpsee::types::{ErrorObjectOwned, Params, Response, ResponsePayload};
 use jsonrpsee::SubscriptionMessage;
-use jsonrpsee_test_utils::mocks::Id;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::time::interval;
@@ -387,13 +386,13 @@ async fn subscribe_unsubscribe_without_server() {
 		let unsub_req = format!("{{\"jsonrpc\":\"2.0\",\"method\":\"my_unsub\",\"params\":[{}],\"id\":1}}", ser_id);
 		let (resp, _) = module.raw_json_request(&unsub_req, 1).await.unwrap();
 
-		assert_eq!(resp.into_result(), r#"{"jsonrpc":"2.0","result":true,"id":1}"#);
+		assert_eq!(resp, r#"{"jsonrpc":"2.0","result":true,"id":1}"#);
 
 		// Unsubscribe already performed; should be error.
 		let unsub_req = format!("{{\"jsonrpc\":\"2.0\",\"method\":\"my_unsub\",\"params\":[{}],\"id\":1}}", ser_id);
 		let (resp, _) = module.raw_json_request(&unsub_req, 2).await.unwrap();
 
-		assert_eq!(resp.into_result(), r#"{"jsonrpc":"2.0","result":false,"id":1}"#);
+		assert_eq!(resp, r#"{"jsonrpc":"2.0","result":false,"id":1}"#);
 	}
 
 	let sub1 = subscribe_and_assert(&module);
@@ -433,7 +432,7 @@ async fn reject_works() {
 		.unwrap();
 
 	let (rp, mut stream) = module.raw_json_request(r#"{"jsonrpc":"2.0","method":"my_sub","id":0}"#, 1).await.unwrap();
-	assert_eq!(rp.into_result(), r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"rejected"},"id":0}"#);
+	assert_eq!(rp, r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"rejected"},"id":0}"#);
 	assert!(stream.recv().await.is_none());
 }
 
@@ -524,7 +523,7 @@ async fn serialize_sub_error_adds_extra_string_quotes() {
 		.unwrap();
 
 	let (rp, mut stream) = module.raw_json_request(r#"{"jsonrpc":"2.0","method":"my_sub","id":0}"#, 1).await.unwrap();
-	let resp = serde_json::from_str::<Response<u64>>(rp.as_result()).unwrap();
+	let resp = serde_json::from_str::<Response<u64>>(&rp).unwrap();
 	let sub_resp = stream.recv().await.unwrap();
 
 	let resp = match resp.payload {
@@ -569,7 +568,7 @@ async fn subscription_close_response_works() {
 	{
 		let (rp, mut stream) =
 			module.raw_json_request(r#"{"jsonrpc":"2.0","method":"my_sub","params":[1],"id":0}"#, 1).await.unwrap();
-		let resp = serde_json::from_str::<Response<u64>>(rp.as_result()).unwrap();
+		let resp = serde_json::from_str::<Response<u64>>(&rp).unwrap();
 
 		let sub_id = match resp.payload {
 			ResponsePayload::Success(val) => val,
@@ -598,33 +597,12 @@ async fn method_response_notify_on_completion() {
 	let module = rpc_module_notify_on_response(tx);
 
 	assert!(
-		run_test_notify_test(&module, &mut rx, true, Notify::Success).await.is_ok(),
+		run_test_notify_test(&module, &mut rx, Notify::Success).await.is_ok(),
 		"Successful response should be notified"
 	);
-	assert!(matches!(
-		run_test_notify_test(&module, &mut rx, false, Notify::Success).await,
-		Err(MethodResponseError::JsonRpcError),
-	));
 
 	assert!(matches!(
-		run_test_notify_test(&module, &mut rx, false, Notify::Error).await,
+		run_test_notify_test(&module, &mut rx, Notify::Error).await,
 		Err(MethodResponseError::JsonRpcError),
 	));
-}
-
-#[tokio::test]
-async fn method_response_dropped() {
-	init_logger();
-
-	let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-	let module = rpc_module_notify_on_response(tx);
-
-	let req = jsonrpsee_test_utils::helpers::call("hey", vec![Notify::Success], Id::Num(1));
-
-	// Make a call and drop the method response including its "notify sender"
-	// This could happen if the connection is closed.
-	let (rp, _) = module.raw_json_request(&req, 1).await.unwrap();
-	drop(rp);
-
-	assert!(matches!(rx.recv().await, Some(Err(MethodResponseError::Closed))));
 }


### PR DESCRIPTION
This PR changes the RpcModule to support the new async API in the MethodResponse and RpcModule::raw_json_request now returns a String instead of MethodResponse as consequence of this change.