### PR TITLE
fix(client): change to `AtomicU64` to `AtomicUsize`

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -50,13 +50,13 @@ pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpc_htt
 /// Run jsonrpc WebSocket server for benchmarks.
 #[cfg(feature = "jsonrpc-crate")]
 pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpc_ws_server::Server) {
-	use std::sync::atomic::{AtomicU64, Ordering};
+	use std::sync::atomic::{AtomicUsize, Ordering};
 
 	use jsonrpc_pubsub::{PubSubHandler, Session, Subscriber, SubscriptionId};
 	use jsonrpc_ws_server::jsonrpc_core::*;
 	use jsonrpc_ws_server::*;
 
-	static ID: AtomicU64 = AtomicU64::new(0);
+	static ID: AtomicUsize = AtomicUsize::new(0);
 
 	let handle2 = handle.clone();
 

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -78,7 +78,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpc_ws_se
 		SUB_METHOD_NAME,
 		(SUB_METHOD_NAME, move |_params: Params, _, subscriber: Subscriber| {
 			handle2.spawn(async move {
-				let id = ID.fetch_add(1, Ordering::Relaxed);
+				let id = ID.fetch_add(1, Ordering::Relaxed).try_into().unwrap();
 				let sink = subscriber.assign_id(SubscriptionId::Number(id)).unwrap();
 				// NOTE(niklasad1): the way jsonrpc works this is the only way to get this working
 				// -> jsonrpc responds to the request in background so not possible to know when the request

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -37,7 +37,7 @@ pub use error::Error;
 use std::fmt;
 use std::ops::Range;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task;
 
@@ -396,7 +396,7 @@ pub struct RequestIdManager {
 	/// Max concurrent pending requests allowed.
 	max_concurrent_requests: usize,
 	/// Get the next request ID.
-	current_id: AtomicU64,
+	current_id: CurrentId,
 	/// Request ID type.
 	id_kind: IdKind,
 }
@@ -404,7 +404,7 @@ pub struct RequestIdManager {
 impl RequestIdManager {
 	/// Create a new `RequestIdGuard` with the provided concurrency limit.
 	pub fn new(limit: usize, id_kind: IdKind) -> Self {
-		Self { current_pending: Arc::new(()), max_concurrent_requests: limit, current_id: AtomicU64::new(0), id_kind }
+		Self { current_pending: Arc::new(()), max_concurrent_requests: limit, current_id: CurrentId::new(), id_kind }
 	}
 
 	fn get_slot(&self) -> Result<Arc<()>, Error> {
@@ -421,7 +421,7 @@ impl RequestIdManager {
 	/// Fails if request limit has been exceeded.
 	pub fn next_request_id(&self) -> Result<RequestIdGuard<Id<'static>>, Error> {
 		let rc = self.get_slot()?;
-		let id = self.id_kind.into_id(self.current_id.fetch_add(1, Ordering::SeqCst));
+		let id = self.id_kind.into_id(self.current_id.next());
 
 		Ok(RequestIdGuard { _rc: rc, id })
 	}
@@ -432,8 +432,8 @@ impl RequestIdManager {
 	/// Fails if request limit has been exceeded.
 	pub fn next_request_two_ids(&self) -> Result<RequestIdGuard<(Id<'static>, Id<'static>)>, Error> {
 		let rc = self.get_slot()?;
-		let id1 = self.id_kind.into_id(self.current_id.fetch_add(1, Ordering::SeqCst));
-		let id2 = self.id_kind.into_id(self.current_id.fetch_add(1, Ordering::SeqCst));
+		let id1 = self.id_kind.into_id(self.current_id.next());
+		let id2 = self.id_kind.into_id(self.current_id.next());
 		Ok(RequestIdGuard { _rc: rc, id: (id1, id2) })
 	}
 
@@ -484,6 +484,22 @@ impl IdKind {
 			IdKind::Number => Id::Number(id),
 			IdKind::String => Id::Str(format!("{id}").into()),
 		}
+	}
+}
+
+#[derive(Debug)]
+struct CurrentId(AtomicUsize);
+
+impl CurrentId {
+	fn new() -> Self {
+		CurrentId(AtomicUsize::new(0))
+	}
+
+	fn next(&self) -> u64 {
+		self.0
+			.fetch_add(1, Ordering::Relaxed)
+			.try_into()
+			.expect("usize -> u64 infallible, there are no 128-bit CPUs; qed")
 	}
 }
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -499,7 +499,7 @@ impl CurrentId {
 		self.0
 			.fetch_add(1, Ordering::Relaxed)
 			.try_into()
-			.expect("usize -> u64 infallible, there are no 128-bit CPUs; qed")
+			.expect("usize -> u64 infallible, there are no CPUs > 64 bits; qed")
 	}
 }
 


### PR DESCRIPTION
Close #1290 

Some targets may not support AtomicU64.
This PR moves to `AtomicUsize` instead to support more targets.