### PR TITLE
Fix part of proc-macro documentation not rendering correctly in IDE

### DIFF
--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -285,7 +285,6 @@ pub(crate) mod visitor;
 ///         #[subscription(name = "subscribe", item = String)]
 ///         async fn sub(&self) -> SubscriptionResult;
 ///
-
 ///         #[subscription(name = "sub_custom_close_msg", unsubscribe = "unsub_custom_close_msg", item = String)]
 ///         async fn sub_custom_close_msg(&self) -> CloseResponse;
 ///     }


### PR DESCRIPTION
Fix this 
![image](https://github.com/paritytech/jsonrpsee/assets/16986685/85f6d567-16bc-408e-98f7-6ca0d396cc72)

I am not 100% sure if it is the IDE (RustRover) issue or the code. But this was an easy fix so here we go.