### PR TITLE
[RFC] Server: add optional connection_guard in config

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -864,7 +864,7 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 			rpc_middleware: self.rpc_middleware,
 			http_middleware: self.http_middleware,
 			conn_id: Arc::new(AtomicU32::new(0)),
-			conn_guard: conn_guard
+			conn_guard,
 		}
 	}
 


### PR DESCRIPTION
While it is very nice to have a [log](https://github.com/paritytech/jsonrpsee/blob/68b4ccb72edfc59d902a376b060ea617a3f320b8/server/src/server.rs#L993) which shows current number of connections, during prod outages and incident investigation it would be much better to have it exported as a metric (i.e. now you can plot it over time and correlate with other metrics easier).

I assume we want to leave the metrics service and setup to the user so we just have to expose this data.

I chose to allow the user to provide it's own `ConnectionGuard` so that he can keep a record for himself to poll later.

I reckon that this might not be the best way to do this (a more sound solution would be to pass a `mpsc` for tower to send connection events through), hence the request for comment with a simple solution.