### PR TITLE
feat: add `Extensions` to Request/MethodResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -450,7 +450,7 @@ After this release one must do something like:
 
 
 	module
-		.register_subscription("sub", "s", "unsub", |_, pending, _| async move {
+		.register_subscription("sub", "s", "unsub", |_, pending, _, _| async move {
 			let stream = stream();
 			pipe_from_stream(sink, stream).await
 		})
@@ -493,7 +493,7 @@ Example:
 
 ```rust
 	module
-		.register_subscription::<RpcResult<(), _, _>::("sub", "s", "unsub", |_, pending, _| async move {
+		.register_subscription::<RpcResult<(), _, _>::("sub", "s", "unsub", |_, pending, _, _| async move {
 			// This just answers the RPC call and if this fails => no close notification is sent out.
 			pending.accept().await?;
 			// This is sent out as a `close notification/message`.

--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -150,7 +150,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::se
 			SUB_METHOD_NAME,
 			SUB_METHOD_NAME,
 			UNSUB_METHOD_NAME,
-			|_params, pending, _ctx| async move {
+			|_params, pending, _ctx, _| async move {
 				let sink = pending.accept().await?;
 				let msg = SubscriptionMessage::from("Hello");
 				sink.send(msg).await?;
@@ -169,22 +169,22 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::se
 fn gen_rpc_module() -> jsonrpsee::RpcModule<()> {
 	let mut module = jsonrpsee::RpcModule::new(());
 
-	module.register_method(SYNC_FAST_CALL, |_, _| "lo").unwrap();
-	module.register_async_method(ASYNC_FAST_CALL, |_, _| async { "lo" }).unwrap();
+	module.register_method(SYNC_FAST_CALL, |_, _, _| "lo").unwrap();
+	module.register_async_method(ASYNC_FAST_CALL, |_, _, _| async { "lo" }).unwrap();
 
-	module.register_method(SYNC_MEM_CALL, |_, _| "A".repeat(MIB)).unwrap();
+	module.register_method(SYNC_MEM_CALL, |_, _, _| "A".repeat(MIB)).unwrap();
 
-	module.register_async_method(ASYNC_MEM_CALL, |_, _| async move { "A".repeat(MIB) }).unwrap();
+	module.register_async_method(ASYNC_MEM_CALL, |_, _, _| async move { "A".repeat(MIB) }).unwrap();
 
 	module
-		.register_method(SYNC_SLOW_CALL, |_, _| {
+		.register_method(SYNC_SLOW_CALL, |_, _, _| {
 			std::thread::sleep(SLOW_CALL);
 			"slow call"
 		})
 		.unwrap();
 
 	module
-		.register_async_method(ASYNC_SLOW_CALL, |_, _| async move {
+		.register_async_method(ASYNC_SLOW_CALL, |_, _, _| async move {
 			tokio::time::sleep(SLOW_CALL).await;
 			"slow call async"
 		})

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,8 +41,9 @@ default = []
 http-helpers = ["hyper", "futures-util"]
 server = [
 	"futures-util/alloc",
-	"rustc-hash/std",
+	"hyper",
 	"parking_lot",
+	"rustc-hash/std",
 	"rand",
 	"tokio/rt",
 	"tokio/sync",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,7 +49,6 @@ cfg_http_helpers! {
 cfg_server! {
 	pub mod id_providers;
 	pub mod server;
-
 }
 
 cfg_client! {

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -39,6 +39,7 @@ mod subscription;
 
 pub use error::*;
 pub use helpers::*;
+pub use http::Extensions;
 pub use method_response::*;
 pub use rpc_module::*;
 pub use subscription::*;

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -42,6 +42,7 @@ use crate::server::subscription::{
 use crate::server::{ResponsePayload, LOG_TARGET};
 use crate::traits::ToRpcParams;
 use futures_util::{future::BoxFuture, FutureExt};
+use http::Extensions;
 use jsonrpsee_types::error::{ErrorCode, ErrorObject};
 use jsonrpsee_types::{
 	ErrorObjectOwned, Id, Params, Request, Response, ResponseSuccess, SubscriptionId as RpcSubscriptionId,
@@ -56,20 +57,27 @@ use super::IntoResponse;
 /// implemented as a function pointer to a `Fn` function taking four arguments:
 /// the `id`, `params`, a channel the function uses to communicate the result (or error)
 /// back to `jsonrpsee`, and the connection ID (useful for the websocket transport).
-pub type SyncMethod = Arc<dyn Send + Sync + Fn(Id, Params, MaxResponseSize) -> MethodResponse>;
+pub type SyncMethod = Arc<dyn Send + Sync + Fn(Id, Params, MaxResponseSize, Extensions) -> MethodResponse>;
 /// Similar to [`SyncMethod`], but represents an asynchronous handler.
-pub type AsyncMethod<'a> =
-	Arc<dyn Send + Sync + Fn(Id<'a>, Params<'a>, ConnectionId, MaxResponseSize) -> BoxFuture<'a, MethodResponse>>;
+pub type AsyncMethod<'a> = Arc<
+	dyn Send
+		+ Sync
+		+ Fn(Id<'a>, Params<'a>, ConnectionId, MaxResponseSize, Extensions) -> BoxFuture<'a, MethodResponse>,
+>;
 
 /// Similar to [`AsyncMethod`], but represents an asynchronous handler with connection details.
 #[doc(hidden)]
-pub type AsyncMethodWithDetails<'a> =
-	Arc<dyn Send + Sync + Fn(Id<'a>, Params<'a>, ConnectionDetails, MaxResponseSize) -> BoxFuture<'a, MethodResponse>>;
+pub type AsyncMethodWithDetails<'a> = Arc<
+	dyn Send
+		+ Sync
+		+ Fn(Id<'a>, Params<'a>, ConnectionDetails, MaxResponseSize, Extensions) -> BoxFuture<'a, MethodResponse>,
+>;
 /// Method callback for subscriptions.
 pub type SubscriptionMethod<'a> =
-	Arc<dyn Send + Sync + Fn(Id, Params, MethodSink, SubscriptionState) -> BoxFuture<'a, MethodResponse>>;
+	Arc<dyn Send + Sync + Fn(Id, Params, MethodSink, SubscriptionState, Extensions) -> BoxFuture<'a, MethodResponse>>;
 // Method callback to unsubscribe.
-type UnsubscriptionMethod = Arc<dyn Send + Sync + Fn(Id, Params, ConnectionId, MaxResponseSize) -> MethodResponse>;
+type UnsubscriptionMethod =
+	Arc<dyn Send + Sync + Fn(Id, Params, ConnectionId, MaxResponseSize, Extensions) -> MethodResponse>;
 
 /// Connection ID, used for stateful protocol such as WebSockets.
 /// For stateless protocols such as http it's unused, so feel free to set it some hardcoded value.
@@ -378,20 +386,22 @@ impl Methods {
 		subscription_permit: SubscriptionPermit,
 	) -> RawRpcResponse {
 		let (tx, mut rx) = mpsc::channel(buf_size);
-		let id = req.id.clone();
-		let params = Params::new(req.params.as_ref().map(|params| params.as_ref().get()));
+		let Request { id, method, params, extensions, .. } = req;
+		let params = Params::new(params.as_ref().map(|params| params.as_ref().get()));
 
-		let response = match self.method(&req.method) {
-			None => MethodResponse::error(req.id, ErrorObject::from(ErrorCode::MethodNotFound)),
-			Some(MethodCallback::Sync(cb)) => (cb)(id, params, usize::MAX),
-			Some(MethodCallback::Async(cb)) => (cb)(id.into_owned(), params.into_owned(), 0, usize::MAX).await,
+		let response = match self.method(&method) {
+			None => MethodResponse::error(id, ErrorObject::from(ErrorCode::MethodNotFound)),
+			Some(MethodCallback::Sync(cb)) => (cb)(id, params, usize::MAX, extensions),
+			Some(MethodCallback::Async(cb)) => {
+				(cb)(id.into_owned(), params.into_owned(), 0, usize::MAX, extensions).await
+			}
 			Some(MethodCallback::AsyncWithDetails(cb)) => {
-				(cb)(id.into_owned(), params.into_owned(), ConnectionDetails::_new(0), usize::MAX).await
+				(cb)(id.into_owned(), params.into_owned(), ConnectionDetails::_new(0), usize::MAX, extensions).await
 			}
 			Some(MethodCallback::Subscription(cb)) => {
 				let conn_state =
 					SubscriptionState { conn_id: 0, id_provider: &RandomIntegerIdProvider, subscription_permit };
-				let res = (cb)(id, params, MethodSink::new(tx.clone()), conn_state).await;
+				let res = (cb)(id, params, MethodSink::new(tx.clone()), conn_state, extensions).await;
 
 				// This message is not used because it's used for metrics so we discard in other to
 				// not read once this is used for subscriptions.
@@ -401,7 +411,7 @@ impl Methods {
 
 				res
 			}
-			Some(MethodCallback::Unsubscription(cb)) => (cb)(id, params, 0, usize::MAX),
+			Some(MethodCallback::Unsubscription(cb)) => (cb)(id, params, 0, usize::MAX, extensions),
 		};
 
 		let is_success = response.is_success();
@@ -411,7 +421,7 @@ impl Methods {
 			n.notify(is_success);
 		}
 
-		tracing::trace!(target: LOG_TARGET, "[Methods::inner_call] Method: {}, response: {}", req.method, rp);
+		tracing::trace!(target: LOG_TARGET, "[Methods::inner_call] Method: {}, response: {}", method, rp);
 
 		(rp, rx)
 	}
@@ -555,9 +565,9 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		let ctx = self.ctx.clone();
 		self.methods.verify_and_insert(
 			method_name,
-			MethodCallback::Sync(Arc::new(move |id, params, max_response_size| {
+			MethodCallback::Sync(Arc::new(move |id, params, max_response_size, extensions| {
 				let rp = callback(params, &*ctx).into_response();
-				MethodResponse::response(id, rp, max_response_size)
+				MethodResponse::response_with_extensions(id, rp, max_response_size, extensions)
 			})),
 		)
 	}
@@ -587,13 +597,13 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		let ctx = self.ctx.clone();
 		self.methods.verify_and_insert(
 			method_name,
-			MethodCallback::Async(Arc::new(move |id, params, _, max_response_size| {
+			MethodCallback::Async(Arc::new(move |id, params, _, max_response_size, extensions| {
 				let ctx = ctx.clone();
 				let callback = callback.clone();
 
 				let future = async move {
 					let rp = callback(params, ctx).await.into_response();
-					MethodResponse::response(id, rp, max_response_size)
+					MethodResponse::response_with_extensions(id, rp, max_response_size, extensions)
 				};
 				future.boxed()
 			})),
@@ -616,19 +626,24 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		let ctx = self.ctx.clone();
 		let callback = self.methods.verify_and_insert(
 			method_name,
-			MethodCallback::Async(Arc::new(move |id, params, _, max_response_size| {
+			MethodCallback::Async(Arc::new(move |id, params, _, max_response_size, extensions| {
 				let ctx = ctx.clone();
 				let callback = callback.clone();
 
+				let extensions2 = extensions.clone();
 				tokio::task::spawn_blocking(move || {
 					let rp = callback(params, ctx).into_response();
-					MethodResponse::response(id, rp, max_response_size)
+					MethodResponse::response_with_extensions(id, rp, max_response_size, extensions2)
 				})
 				.map(|result| match result {
 					Ok(r) => r,
 					Err(err) => {
 						tracing::error!(target: LOG_TARGET, "Join error for blocking RPC method: {:?}", err);
-						MethodResponse::error(Id::Null, ErrorObject::from(ErrorCode::InternalError))
+						MethodResponse::error_with_extensions(
+							Id::Null,
+							ErrorObject::from(ErrorCode::InternalError),
+							extensions,
+						)
 					}
 				})
 				.boxed()
@@ -662,16 +677,18 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		let ctx = self.ctx.clone();
 		self.methods.verify_and_insert(
 			method_name,
-			MethodCallback::AsyncWithDetails(Arc::new(move |id, params, connection_details, max_response_size| {
-				let ctx = ctx.clone();
-				let callback = callback.clone();
+			MethodCallback::AsyncWithDetails(Arc::new(
+				move |id, params, connection_details, max_response_size, extensions| {
+					let ctx = ctx.clone();
+					let callback = callback.clone();
 
-				let future = async move {
-					let rp = callback(params, connection_details, ctx).await.into_response();
-					MethodResponse::response(id, rp, max_response_size)
-				};
-				future.boxed()
-			})),
+					let future = async move {
+						let rp = callback(params, connection_details, ctx).await.into_response();
+						MethodResponse::response_with_extensions(id, rp, max_response_size, extensions)
+					};
+					future.boxed()
+				},
+			)),
 		)
 	}
 
@@ -789,7 +806,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		let callback = {
 			self.methods.verify_and_insert(
 				subscribe_method_name,
-				MethodCallback::Subscription(Arc::new(move |id, params, method_sink, conn| {
+				MethodCallback::Subscription(Arc::new(move |id, params, method_sink, conn, extensions| {
 					let uniq_sub = SubscriptionKey { conn_id: conn.conn_id, sub_id: conn.id_provider.next_id() };
 
 					// response to the subscription call.
@@ -840,15 +857,16 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 
 					Box::pin(async move {
 						match rx.await {
-							Ok(rp) => {
+							Ok(mut rp) => {
 								// If the subscription was accepted then send a message
 								// to subscription task otherwise rely on the drop impl.
 								if rp.is_success() {
 									let _ = accepted_tx.send(());
 								}
+								*rp.extensions_mut() = extensions;
 								rp
 							}
-							Err(_) => MethodResponse::error(id, ErrorCode::InternalError),
+							Err(_) => MethodResponse::error_with_extensions(id, ErrorCode::InternalError, extensions),
 						}
 					})
 				})),
@@ -922,7 +940,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		let callback = {
 			self.methods.verify_and_insert(
 				subscribe_method_name,
-				MethodCallback::Subscription(Arc::new(move |id, params, method_sink, conn| {
+				MethodCallback::Subscription(Arc::new(move |id, params, method_sink, conn, extensions| {
 					let uniq_sub = SubscriptionKey { conn_id: conn.conn_id, sub_id: conn.id_provider.next_id() };
 
 					// response to the subscription call.
@@ -944,8 +962,11 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 
 					Box::pin(async move {
 						match rx.await {
-							Ok(rp) => rp,
-							Err(_) => MethodResponse::error(id, ErrorCode::InternalError),
+							Ok(mut rp) => {
+								*rp.extensions_mut() = extensions;
+								rp
+							}
+							Err(_) => MethodResponse::error_with_extensions(id, ErrorCode::InternalError, extensions),
 						}
 					})
 				})),
@@ -976,7 +997,7 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 			let subscribers = subscribers.clone();
 			self.methods.mut_callbacks().insert(
 				unsubscribe_method_name,
-				MethodCallback::Unsubscription(Arc::new(move |id, params, conn_id, max_response_size| {
+				MethodCallback::Unsubscription(Arc::new(move |id, params, conn_id, max_response_size, extensions| {
 					let sub_id = match params.one::<RpcSubscriptionId>() {
 						Ok(sub_id) => sub_id,
 						Err(_) => {
@@ -988,7 +1009,12 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 								id
 							);
 
-							return MethodResponse::response(id, ResponsePayload::success(false), max_response_size);
+							return MethodResponse::response_with_extensions(
+								id,
+								ResponsePayload::success(false),
+								max_response_size,
+								extensions,
+							);
 						}
 					};
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dev-dependencies]
 anyhow = "1"
 http-body-util = "0.1"
+http-body = "1"
 futures = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-native-tls"] }
 tracing = "0.1.34"

--- a/examples/examples/client_subscription_drop_oldest_item.rs
+++ b/examples/examples/client_subscription_drop_oldest_item.rs
@@ -103,7 +103,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = Server::builder().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module
-		.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", |_, pending, _| async move {
+		.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", |_, pending, _, _| async move {
 			let sub = pending.accept().await.unwrap();
 
 			for i in 0..usize::MAX {

--- a/examples/examples/core_client.rs
+++ b/examples/examples/core_client.rs
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = Server::builder().build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
+	module.register_method("say_hello", |_, _, _| "lo")?;
 	let addr = server.local_addr()?;
 
 	let handle = server.start(module);

--- a/examples/examples/cors_server.rs
+++ b/examples/examples/cors_server.rs
@@ -88,7 +88,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = Server::builder().set_http_middleware(middleware).build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
 
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| {
+	module.register_method("say_hello", |_, _, _| {
 		println!("say_hello method called!");
 		"Hello there!!"
 	})?;

--- a/examples/examples/host_filter_middleware.rs
+++ b/examples/examples/host_filter_middleware.rs
@@ -71,7 +71,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let addr = server.local_addr()?;
 
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo").unwrap();
+	module.register_method("say_hello", |_, _, _| "lo").unwrap();
 
 	let handle = server.start(module);
 

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = Server::builder().build("127.0.0.1:0".parse::<SocketAddr>()?).await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
+	module.register_method("say_hello", |_, _, _| "lo")?;
 
 	let addr = server.local_addr()?;
 	let handle = server.start(module);

--- a/examples/examples/http_middleware.rs
+++ b/examples/examples/http_middleware.rs
@@ -115,7 +115,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let addr = server.local_addr()?;
 
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo").unwrap();
+	module.register_method("say_hello", |_, _, _| "lo").unwrap();
 
 	let handle = server.start(module);
 

--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -96,8 +96,8 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let addr = server.local_addr()?;
 
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo").unwrap();
-	module.register_method("system_health", |_, _| serde_json::json!({ "health": true })).unwrap();
+	module.register_method("say_hello", |_, _, _| "lo").unwrap();
+	module.register_method("system_health", |_, _, _| serde_json::json!({ "health": true })).unwrap();
 
 	let handle = server.start(module);
 

--- a/examples/examples/jsonrpsee_as_service.rs
+++ b/examples/examples/jsonrpsee_as_service.rs
@@ -44,7 +44,7 @@ use jsonrpsee::core::async_trait;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::{ResponseFuture, RpcServiceBuilder, RpcServiceT};
-use jsonrpsee::server::{stop_channel, ServerHandle, StopHandle, TowerServiceBuilder};
+use jsonrpsee::server::{stop_channel, Extensions, ServerHandle, StopHandle, TowerServiceBuilder};
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Request};
 use jsonrpsee::ws_client::{HeaderValue, WsClientBuilder};
 use jsonrpsee::{MethodResponse, Methods};
@@ -100,7 +100,7 @@ pub trait Rpc {
 
 #[async_trait]
 impl RpcServer for () {
-	async fn trusted_call(&self) -> Result<String, ErrorObjectOwned> {
+	async fn trusted_call(&self, _ext: &Extensions) -> Result<String, ErrorObjectOwned> {
 		Ok("mysecret".to_string())
 	}
 }

--- a/examples/examples/jsonrpsee_server_low_level_api.rs
+++ b/examples/examples/jsonrpsee_server_low_level_api.rs
@@ -56,7 +56,7 @@ use jsonrpsee::server::{
 };
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Request};
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::{MethodResponse, Methods};
+use jsonrpsee::{Extensions, MethodResponse, Methods};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
@@ -108,7 +108,7 @@ pub trait Rpc {
 
 #[async_trait]
 impl RpcServer for () {
-	async fn say_hello(&self) -> Result<String, ErrorObjectOwned> {
+	async fn say_hello(&self, _ext: &Extensions) -> Result<String, ErrorObjectOwned> {
 		Ok("lo".to_string())
 	}
 }

--- a/examples/examples/proc_macro.rs
+++ b/examples/examples/proc_macro.rs
@@ -31,6 +31,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{PendingSubscriptionSink, Server, SubscriptionMessage};
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::Extensions;
 
 type ExampleHash = [u8; 32];
 type ExampleStorageKey = Vec<u8>;
@@ -62,6 +63,7 @@ pub struct RpcServerImpl;
 impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 	async fn storage_keys(
 		&self,
+		_ext: &Extensions,
 		storage_key: ExampleStorageKey,
 		_hash: Option<ExampleHash>,
 	) -> Result<Vec<ExampleStorageKey>, ErrorObjectOwned> {
@@ -71,6 +73,7 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 	async fn subscribe_storage(
 		&self,
 		pending: PendingSubscriptionSink,
+		_ext: &Extensions,
 		_keys: Option<Vec<ExampleStorageKey>>,
 	) -> SubscriptionResult {
 		let sink = pending.accept().await?;
@@ -80,7 +83,7 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 		Ok(())
 	}
 
-	fn s(&self, pending: PendingSubscriptionSink, _keys: Option<Vec<ExampleStorageKey>>) {
+	fn s(&self, pending: PendingSubscriptionSink, _ext: &Extensions, _keys: Option<Vec<ExampleStorageKey>>) {
 		tokio::spawn(async move {
 			let sink = pending.accept().await.unwrap();
 			let msg = SubscriptionMessage::from_json(&vec![[0; 32]]).unwrap();

--- a/examples/examples/proc_macro_bounds.rs
+++ b/examples/examples/proc_macro_bounds.rs
@@ -31,6 +31,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::Extensions;
 
 type ExampleHash = [u8; 32];
 
@@ -61,7 +62,7 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer<ExampleHash> for RpcServerImpl {
-	fn method(&self) -> Result<<ExampleHash as Config>::Hash, ErrorObjectOwned> {
+	fn method(&self, _ext: &Extensions) -> Result<<ExampleHash as Config>::Hash, ErrorObjectOwned> {
 		Ok([0u8; 32])
 	}
 }

--- a/examples/examples/response_payload_notify_on_response.rs
+++ b/examples/examples/response_payload_notify_on_response.rs
@@ -30,7 +30,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::Server;
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::{rpc_params, ResponsePayload};
+use jsonrpsee::{rpc_params, Extensions, ResponsePayload};
 
 #[rpc(client, server, namespace = "state")]
 pub trait Rpc {
@@ -42,7 +42,7 @@ pub trait Rpc {
 pub struct RpcServerImpl;
 
 impl RpcServer for RpcServerImpl {
-	fn storage_keys(&self) -> ResponsePayload<'static, String> {
+	fn storage_keys(&self, _ext: &Extensions) -> ResponsePayload<'static, String> {
 		let (rp, rp_future) = ResponsePayload::success("ehheeheh".to_string()).notify_on_completion();
 
 		tokio::spawn(async move {

--- a/examples/examples/rpc_middleware.rs
+++ b/examples/examples/rpc_middleware.rs
@@ -157,8 +157,8 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		.layer_fn(move |service| GlobalCalls { service, count: global_cnt.clone() });
 	let server = Server::builder().set_rpc_middleware(rpc_middleware).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
-	module.register_method("thready", |params, _| {
+	module.register_method("say_hello", |_, _, _| "lo")?;
+	module.register_method("thready", |params, _, _| {
 		let thread_count: usize = params.one().unwrap();
 		for _ in 0..thread_count {
 			std::thread::spawn(|| std::thread::sleep(std::time::Duration::from_secs(1)));

--- a/examples/examples/rpc_middleware_modify_request.rs
+++ b/examples/examples/rpc_middleware_modify_request.rs
@@ -81,8 +81,8 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let rpc_middleware = RpcServiceBuilder::new().layer_fn(ModifyRequestIf);
 	let server = Server::builder().set_rpc_middleware(rpc_middleware).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
-	module.register_method("say_goodbye", |_, _| "goodbye")?;
+	module.register_method("say_hello", |_, _, _| "lo")?;
+	module.register_method("say_goodbye", |_, _, _| "goodbye")?;
 	let addr = server.local_addr()?;
 
 	let handle = server.start(module);

--- a/examples/examples/rpc_middleware_rate_limiting.rs
+++ b/examples/examples/rpc_middleware_rate_limiting.rs
@@ -169,8 +169,8 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 
 	let server = Server::builder().set_rpc_middleware(rpc_middleware).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
-	module.register_method("say_goodbye", |_, _| "goodbye")?;
+	module.register_method("say_hello", |_, _, _| "lo")?;
+	module.register_method("say_goodbye", |_, _, _| "goodbye")?;
 	let addr = server.local_addr()?;
 
 	let handle = server.start(module);

--- a/examples/examples/server_with_connection_details.rs
+++ b/examples/examples/server_with_connection_details.rs
@@ -25,60 +25,66 @@
 // DEALINGS IN THE SOFTWARE.
 
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
 
-use jsonrpsee::core::{async_trait, client::Subscription};
+use futures::future::{self, Either};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use jsonrpsee::core::async_trait;
+use jsonrpsee::core::SubscriptionResult;
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{PendingSubscriptionSink, Server, SubscriptionMessage};
-use jsonrpsee::types::ErrorObjectOwned;
+use jsonrpsee::server::middleware::rpc::RpcServiceT;
+use jsonrpsee::server::{stop_channel, PendingSubscriptionSink, RpcServiceBuilder, SubscriptionMessage};
+use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::ConnectionDetails;
+use jsonrpsee::Extensions;
+use tokio::net::TcpListener;
+use tower::Service;
+
+#[derive(Debug, Clone)]
+struct ConnectionDetails<S> {
+	inner: S,
+	connection_id: u32,
+}
+
+impl<'a, S> RpcServiceT<'a> for ConnectionDetails<S>
+where
+	S: RpcServiceT<'a>,
+{
+	type Future = S::Future;
+
+	fn call(&self, mut request: jsonrpsee::types::Request<'a>) -> Self::Future {
+		request.extensions_mut().insert(self.connection_id);
+		self.inner.call(request)
+	}
+}
 
 #[rpc(server, client)]
 pub trait Rpc {
-	/// Raw method with connection ID.
-	#[method(name = "connectionIdMethod", raw_method)]
-	async fn raw_method(&self, first_param: usize, second_param: u16) -> Result<usize, ErrorObjectOwned>;
+	/// method with connection ID.
+	#[method(name = "connectionIdMethod")]
+	async fn method(&self, first_param: usize, second_param: u16) -> Result<u32, ErrorObjectOwned>;
 
-	/// Normal method call example.
-	#[method(name = "normalMethod")]
-	fn normal_method(&self, first_param: usize, second_param: u16) -> Result<usize, ErrorObjectOwned>;
-
-	/// Subscriptions expose the connection ID on the subscription sink.
-	#[subscription(name = "subscribeSync" => "sync", item = usize)]
-	fn sub(&self, first_param: usize);
+	#[subscription(name = "subscribeConnectionId", item = u32)]
+	async fn sub(&self) -> SubscriptionResult;
 }
 
 pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn raw_method(
-		&self,
-		connection_details: ConnectionDetails,
-		_first_param: usize,
-		_second_param: u16,
-	) -> Result<usize, ErrorObjectOwned> {
-		// Return the connection ID from which this method was called.
-		Ok(connection_details.id())
+	async fn method(&self, ext: &Extensions, _first_param: usize, _second_param: u16) -> Result<u32, ErrorObjectOwned> {
+		ext.get::<u32>().cloned().ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))
 	}
 
-	fn normal_method(&self, _first_param: usize, _second_param: u16) -> Result<usize, ErrorObjectOwned> {
-		// The normal method does not have access to the connection ID.
-		Ok(usize::MAX)
-	}
-
-	fn sub(&self, pending: PendingSubscriptionSink, _first_param: usize) {
-		tokio::spawn(async move {
-			// The connection ID can be obtained before or after accepting the subscription
-			let pending_connection_id = pending.connection_id();
-			let sink = pending.accept().await.unwrap();
-			let sink_connection_id = sink.connection_id();
-
-			assert_eq!(pending_connection_id, sink_connection_id);
-
-			let msg = SubscriptionMessage::from_json(&sink_connection_id).unwrap();
-			sink.send(msg).await.unwrap();
-		});
+	async fn sub(&self, pending: PendingSubscriptionSink, ext: &Extensions) -> SubscriptionResult {
+		let sink = pending.accept().await?;
+		let conn_id = ext
+			.get::<u32>()
+			.cloned()
+			.ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))?;
+		sink.send(SubscriptionMessage::from_json(&conn_id).unwrap()).await?;
+		Ok(())
 	}
 }
 
@@ -93,34 +99,101 @@ async fn main() -> anyhow::Result<()> {
 	let url = format!("ws://{}", server_addr);
 
 	let client = WsClientBuilder::default().build(&url).await?;
-	let connection_id_first = client.raw_method(1, 2).await.unwrap();
+	let connection_id_first = client.method(1, 2).await.unwrap();
 
 	// Second call from the same connection ID.
-	assert_eq!(client.raw_method(1, 2).await.unwrap(), connection_id_first);
+	assert_eq!(client.method(1, 2).await.unwrap(), connection_id_first);
 
 	// Second client will increment the connection ID.
-	let client_second = WsClientBuilder::default().build(&url).await?;
-	let connection_id_second = client_second.raw_method(1, 2).await.unwrap();
+	let client2 = WsClientBuilder::default().build(&url).await?;
+	let connection_id_second = client2.method(1, 2).await.unwrap();
 	assert_ne!(connection_id_first, connection_id_second);
 
-	let mut sub: Subscription<usize> = RpcClient::sub(&client, 0).await.unwrap();
+	let mut sub = client.sub().await.unwrap();
 	assert_eq!(connection_id_first, sub.next().await.transpose().unwrap().unwrap());
 
-	let mut sub: Subscription<usize> = RpcClient::sub(&client_second, 0).await.unwrap();
+	let mut sub = client2.sub().await.unwrap();
 	assert_eq!(connection_id_second, sub.next().await.transpose().unwrap().unwrap());
 
 	Ok(())
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let server = Server::builder().build("127.0.0.1:0").await?;
+	let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+	let addr = listener.local_addr()?;
 
-	let addr = server.local_addr()?;
-	let handle = server.start(RpcServerImpl.into_rpc());
+	let (stop_hdl, server_hdl) = stop_channel();
 
-	// In this example we don't care about doing shutdown so let's it run forever.
-	// You may use the `ServerHandle` to shut it down or manage it yourself.
-	tokio::spawn(handle.stopped());
+	tokio::spawn(async move {
+		let conn_id = Arc::new(AtomicU32::new(0));
+		// Create and finalize a server configuration from a TowerServiceBuilder
+		// given an RpcModule and the stop handle.
+		let svc_builder = jsonrpsee::server::Server::builder().to_service_builder();
+		let methods = RpcServerImpl.into_rpc();
+
+		loop {
+			let stream = tokio::select! {
+				res = listener.accept() => {
+					match res {
+						Ok((stream, _remote_addr)) => stream,
+						Err(e) => {
+							tracing::error!("failed to accept v4 connection: {:?}", e);
+							continue;
+						}
+					}
+				}
+				_ = stop_hdl.clone().shutdown() => break,
+			};
+
+			let methods2 = methods.clone();
+			let stop_hdl2 = stop_hdl.clone();
+			let svc_builder2 = svc_builder.clone();
+			let conn_id2 = conn_id.clone();
+			let svc = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+				let connection_id = conn_id2.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+				let rpc_middleware = RpcServiceBuilder::default()
+					.layer_fn(move |service| ConnectionDetails { inner: service, connection_id });
+
+				// Start a new service with our own connection ID.
+				let mut tower_service = svc_builder2
+					.clone()
+					.set_rpc_middleware(rpc_middleware)
+					.connection_id(connection_id as u32)
+					.build(methods2.clone(), stop_hdl2.clone());
+
+				async move { tower_service.call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e)) }
+			});
+
+			let stop_hdl2 = stop_hdl.clone();
+			// Spawn a new task to serve each respective (Hyper) connection.
+			tokio::spawn(async move {
+				let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+				let conn = builder.serve_connection_with_upgrades(TokioIo::new(stream), svc);
+				let stopped = stop_hdl2.shutdown();
+
+				// Pin the future so that it can be polled.
+				tokio::pin!(stopped, conn);
+
+				let res = match future::select(conn, stopped).await {
+					// Return the connection if not stopped.
+					Either::Left((conn, _)) => conn,
+					// If the server is stopped, we should gracefully shutdown
+					// the connection and poll it until it finishes.
+					Either::Right((_, mut conn)) => {
+						conn.as_mut().graceful_shutdown();
+						conn.await
+					}
+				};
+
+				// Log any errors that might have occurred.
+				if let Err(err) = res {
+					tracing::error!(err=?err, "HTTP connection failed");
+				}
+			});
+		}
+	});
+
+	tokio::spawn(server_hdl.stopped());
 
 	Ok(addr)
 }

--- a/examples/examples/tokio_console.rs
+++ b/examples/examples/tokio_console.rs
@@ -51,9 +51,9 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = Server::builder().build("127.0.0.1:9944").await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
-	module.register_method("memory_call", |_, _| "A".repeat(1024 * 1024))?;
-	module.register_async_method("sleep", |_, _| async {
+	module.register_method("say_hello", |_, _, _| "lo")?;
+	module.register_method("memory_call", |_, _, _| "A".repeat(1024 * 1024))?;
+	module.register_async_method("sleep", |_, _, _| async {
 		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 		"lo"
 	})?;

--- a/examples/examples/ws.rs
+++ b/examples/examples/ws.rs
@@ -53,7 +53,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let rpc_middleware = RpcServiceBuilder::new().rpc_logger(1024);
 	let server = Server::builder().set_rpc_middleware(rpc_middleware).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
+	module.register_method("say_hello", |_, _, _| "lo")?;
 	let addr = server.local_addr()?;
 
 	let handle = server.start(module);

--- a/examples/examples/ws_dual_stack.rs
+++ b/examples/examples/ws_dual_stack.rs
@@ -67,7 +67,7 @@ async fn run_server() -> anyhow::Result<(ServerHandle, Addrs)> {
 	let v6_addr = SocketAddr::new("::1".parse().unwrap(), port);
 
 	let mut module = RpcModule::new(());
-	module.register_method("say_hello", |_, _| "lo")?;
+	module.register_method("say_hello", |_, _, _| "lo")?;
 
 	// Bind to both IPv4 and IPv6 addresses.
 	let listener_v4 = TcpListener::bind(&v4_addr).await?;

--- a/examples/examples/ws_pubsub_broadcast.rs
+++ b/examples/examples/ws_pubsub_broadcast.rs
@@ -74,7 +74,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	std::thread::spawn(move || produce_items(tx));
 
 	module
-		.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", |_, pending, tx| async move {
+		.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", |_, pending, tx, _| async move {
 			let rx = tx.subscribe();
 			let stream = BroadcastStream::new(rx);
 			pipe_from_stream_with_bounded_buffer(pending, stream).await?;

--- a/examples/examples/ws_pubsub_with_params.rs
+++ b/examples/examples/ws_pubsub_with_params.rs
@@ -66,26 +66,31 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let server = Server::builder().set_message_buffer_capacity(10).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module
-		.register_subscription("sub_one_param", "sub_one_param", "unsub_one_param", |params, pending, _| async move {
-			// we are doing this verbose way to get a customized reject error on the subscription.
-			let idx = match params.one::<usize>() {
-				Ok(p) => p,
-				Err(e) => {
-					let _ = pending.reject(e).await;
-					return Ok(());
-				}
-			};
+		.register_subscription(
+			"sub_one_param",
+			"sub_one_param",
+			"unsub_one_param",
+			|params, pending, _, _| async move {
+				// we are doing this verbose way to get a customized reject error on the subscription.
+				let idx = match params.one::<usize>() {
+					Ok(p) => p,
+					Err(e) => {
+						let _ = pending.reject(e).await;
+						return Ok(());
+					}
+				};
 
-			let item = LETTERS.chars().nth(idx);
+				let item = LETTERS.chars().nth(idx);
 
-			let interval = interval(Duration::from_millis(200));
-			let stream = IntervalStream::new(interval).map(move |_| item);
+				let interval = interval(Duration::from_millis(200));
+				let stream = IntervalStream::new(interval).map(move |_| item);
 
-			pipe_from_stream_and_drop(pending, stream).await.map_err(Into::into)
-		})
+				pipe_from_stream_and_drop(pending, stream).await.map_err(Into::into)
+			},
+		)
 		.unwrap();
 	module
-		.register_subscription("sub_params_two", "params_two", "unsub_params_two", |params, pending, _| async move {
+		.register_subscription("sub_params_two", "params_two", "unsub_params_two", |params, pending, _, _| async move {
 			let (one, two) = params.parse::<(usize, usize)>()?;
 
 			let item = &LETTERS[one..two];

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -227,7 +227,7 @@ pub(crate) mod visitor;
 ///
 /// // RPC is put into a separate module to clearly show names of generated entities.
 /// mod rpc_impl {
-///     use jsonrpsee::{proc_macros::rpc};
+///     use jsonrpsee::{proc_macros::rpc, Extensions};
 ///     use jsonrpsee::server::{PendingSubscriptionSink, SubscriptionMessage, IntoSubscriptionCloseResponse, SubscriptionCloseResponse};
 ///     use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
 ///
@@ -309,15 +309,15 @@ pub(crate) mod visitor;
 ///     // Note that the trait name we use is `MyRpcServer`, not `MyRpc`!
 ///     #[async_trait]
 ///     impl MyRpcServer for RpcServerImpl {
-///         async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
+///         async fn async_method(&self, _ext: &Extensions, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 ///             Ok(42)
 ///         }
 ///
-///         fn sync_method(&self) -> RpcResult<u16> {
+///         fn sync_method(&self, _ext: &Extensions) -> RpcResult<u16> {
 ///             Ok(10)
 ///         }
 ///
-///         fn blocking_method(&self) -> RpcResult<u16> {
+///         fn blocking_method(&self, _ext: &Extensions) -> RpcResult<u16> {
 ///             // This will block current thread for 1 second, which is fine since we marked
 ///             // this method as `blocking` above.
 ///             std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -326,14 +326,14 @@ pub(crate) mod visitor;
 ///
 ///         // The stream API can be used to pipe items from the underlying stream
 ///         // as subscription responses.
-///         async fn sub_override_notif_method(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
+///         async fn sub_override_notif_method(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
 ///             let mut sink = pending.accept().await?;
 ///             sink.send("Response_A".into()).await?;
 ///             Ok(())
 ///         }
 ///
 ///         // Send out two values on the subscription.
-///         async fn sub(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
+///         async fn sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
 ///             let sink = pending.accept().await?;
 ///
 ///             let msg1 = SubscriptionMessage::from("Response_A");
@@ -348,7 +348,7 @@ pub(crate) mod visitor;
 ///         // If one doesn't want sent out a close message when a subscription terminates or treat
 ///         // errors as subscription error notifications then it's possible to implement
 ///         // `IntoSubscriptionCloseResponse` for customized behavior.
-///         async fn sub_custom_close_msg(&self, pending: PendingSubscriptionSink) -> CloseResponse {
+///         async fn sub_custom_close_msg(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> CloseResponse {
 ///             let Ok(sink) = pending.accept().await else {
 ///                 return CloseResponse::None;
 ///             };

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -6,7 +6,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::params::ArrayParams;
 use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{ServerBuilder, SubscriptionMessage};
+use jsonrpsee::server::{Extensions, ServerBuilder, SubscriptionMessage};
 use jsonrpsee::ws_client::*;
 use jsonrpsee::{rpc_params, PendingSubscriptionSink};
 
@@ -50,33 +50,33 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
+	async fn async_method(&self, _ext: &Extensions, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)
 	}
 
-	async fn optional_params(&self, a: core::option::Option<u8>, _b: String) -> RpcResult<bool> {
+	async fn optional_params(&self, _ext: &Extensions, a: core::option::Option<u8>, _b: String) -> RpcResult<bool> {
 		let res = if a.is_some() { true } else { false };
 		Ok(res)
 	}
 
-	async fn optional_param(&self, a: Option<u8>) -> RpcResult<bool> {
+	async fn optional_param(&self, _ext: &Extensions, a: Option<u8>) -> RpcResult<bool> {
 		let res = if a.is_some() { true } else { false };
 		Ok(res)
 	}
 
-	async fn array_params(&self, items: Vec<u64>) -> RpcResult<u64> {
+	async fn array_params(&self, _ext: &Extensions, items: Vec<u64>) -> RpcResult<u64> {
 		Ok(items.len() as u64)
 	}
 
-	async fn rename_params(&self, r#type: u16, half_type: bool) -> RpcResult<u16> {
+	async fn rename_params(&self, _ext: &Extensions, r#type: u16, half_type: bool) -> RpcResult<u16> {
 		Ok(half_type.then(|| r#type / 2).unwrap_or(r#type))
 	}
 
-	fn sync_method(&self) -> RpcResult<u16> {
+	fn sync_method(&self, _ext: &Extensions) -> RpcResult<u16> {
 		Ok(10u16)
 	}
 
-	async fn sub(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
+	async fn sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 
 		sink.send("Response_A".into()).await?;
@@ -85,7 +85,12 @@ impl RpcServer for RpcServerImpl {
 		Ok(())
 	}
 
-	async fn sub_with_params(&self, pending: PendingSubscriptionSink, val: u32) -> SubscriptionResult {
+	async fn sub_with_params(
+		&self,
+		pending: PendingSubscriptionSink,
+		_ext: &Extensions,
+		val: u32,
+	) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 		let msg = SubscriptionMessage::from_json(&val)?;
 
@@ -95,7 +100,11 @@ impl RpcServer for RpcServerImpl {
 		Ok(())
 	}
 
-	async fn sub_with_override_notif_method(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
+	async fn sub_with_override_notif_method(
+		&self,
+		pending: PendingSubscriptionSink,
+		_ext: &Extensions,
+	) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 
 		let msg = SubscriptionMessage::from_json(&1)?;

--- a/proc-macros/tests/ui/correct/custom_ret_types.rs
+++ b/proc-macros/tests/ui/correct/custom_ret_types.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, ClientError, Serialize};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{IntoResponse, ResponsePayload, ServerBuilder};
+use jsonrpsee::server::{Extensions, IntoResponse, ResponsePayload, ServerBuilder};
 use jsonrpsee::ws_client::*;
 
 // Serialize impl is not used as the responses are sent out as error.
@@ -59,27 +59,27 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method1(&self) -> CustomError {
+	async fn async_method1(&self, _ext: &Extensions) -> CustomError {
 		CustomError::One
 	}
 
-	async fn async_method2(&self, x: u32) -> CustomError {
+	async fn async_method2(&self, _ext: &Extensions, x: u32) -> CustomError {
 		CustomError::Two { custom_data: x }
 	}
 
-	fn method1(&self) -> CustomError {
+	fn method1(&self, _ext: &Extensions) -> CustomError {
 		CustomError::One
 	}
 
-	fn method2(&self, x: u32) -> CustomError {
+	fn method2(&self, _ext: &Extensions, x: u32) -> CustomError {
 		CustomError::Two { custom_data: x }
 	}
 
-	fn blocking_method1(&self) -> CustomError {
+	fn blocking_method1(&self, _ext: &Extensions) -> CustomError {
 		CustomError::One
 	}
 
-	fn blocking_method2(&self, x: u32) -> CustomError {
+	fn blocking_method2(&self, _ext: &Extensions, x: u32) -> CustomError {
 		CustomError::Two { custom_data: x }
 	}
 }

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{PendingSubscriptionSink, ServerBuilder};
+use jsonrpsee::server::{Extensions, PendingSubscriptionSink, ServerBuilder};
 
 #[rpc(server)]
 pub trait Rpc {
@@ -20,15 +20,15 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
+	async fn async_method(&self, _ext: &Extensions, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)
 	}
 
-	fn sync_method(&self) -> RpcResult<u16> {
+	fn sync_method(&self, _ext: &Extensions) -> RpcResult<u16> {
 		Ok(10u16)
 	}
 
-	async fn sub(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
+	async fn sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 
 		sink.send("Response_A".into()).await?;

--- a/proc-macros/tests/ui/correct/param_kind.rs
+++ b/proc-macros/tests/ui/correct/param_kind.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::server::{Extensions, ServerBuilder};
 use jsonrpsee::ws_client::*;
 
 #[rpc(client, server, namespace = "foo")]
@@ -21,19 +21,19 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
+	async fn method_with_array_param(&self, _ext: &Extensions, param_a: u8, param_b: String) -> RpcResult<u16> {
 		assert_eq!(param_a, 0);
 		assert_eq!(&param_b, "a");
 		Ok(42u16)
 	}
 
-	async fn method_with_map_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
+	async fn method_with_map_param(&self, _ext: &Extensions, param_a: u8, param_b: String) -> RpcResult<u16> {
 		assert_eq!(param_a, 0);
 		assert_eq!(&param_b, "a");
 		Ok(42u16)
 	}
 
-	async fn method_with_default_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
+	async fn method_with_default_param(&self, _ext: &Extensions, param_a: u8, param_b: String) -> RpcResult<u16> {
 		assert_eq!(param_a, 0);
 		assert_eq!(&param_b, "a");
 		Ok(42u16)

--- a/proc-macros/tests/ui/correct/rpc_bounds.rs
+++ b/proc-macros/tests/ui/correct/rpc_bounds.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::server::{Extensions, ServerBuilder};
 use jsonrpsee::ws_client::*;
 
 pub trait Config {
@@ -105,7 +105,7 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 pub struct ServerOnlyImpl;
 #[async_trait]
 impl MyRpcSServer<ExampleHash> for ServerOnlyImpl {
-	fn method(&self) -> RpcResult<<ExampleHash as Config>::Hash> {
+	fn method(&self, _ext: &Extensions) -> RpcResult<<ExampleHash as Config>::Hash> {
 		Ok([0u8; 32])
 	}
 }
@@ -114,7 +114,7 @@ impl MyRpcSServer<ExampleHash> for ServerOnlyImpl {
 pub struct ServerClientServerImpl;
 #[async_trait]
 impl MyRpcSCServer<ExampleHash> for ServerClientServerImpl {
-	fn method(&self) -> RpcResult<<ExampleHash as Config>::Hash> {
+	fn method(&self, _ext: &Extensions) -> RpcResult<<ExampleHash as Config>::Hash> {
 		Ok([0u8; 32])
 	}
 }

--- a/proc-macros/tests/ui/correct/server_with_raw_methods.rs
+++ b/proc-macros/tests/ui/correct/server_with_raw_methods.rs
@@ -4,7 +4,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc, types::ErrorObjectOwned};
 
 #[rpc(server)]
 pub trait Rpc {
-	#[method(name = "foo", raw_method)]
+	#[method(name = "foo")]
 	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
 
 	#[method(name = "bar")]

--- a/proc-macros/tests/ui/incorrect/method/method_blocking_raw_incompatible.rs
+++ b/proc-macros/tests/ui/incorrect/method/method_blocking_raw_incompatible.rs
@@ -1,9 +1,0 @@
-use jsonrpsee::proc_macros::rpc;
-
-#[rpc(server)]
-pub trait BlockingMethodCannotBeRaw {
-	#[method(name = "a", blocking, raw_method)]
-	fn a(&self, param: Vec<u8>);
-}
-
-fn main() {}

--- a/proc-macros/tests/ui/incorrect/method/method_blocking_raw_incompatible.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_blocking_raw_incompatible.stderr
@@ -1,6 +1,0 @@
-error: Methods cannot be blocking when used with `raw_method`; remove `blocking` attribute or `raw_method` attribute
- --> tests/ui/incorrect/method/method_blocking_raw_incompatible.rs:5:2
-  |
-5 | /     #[method(name = "a", blocking, raw_method)]
-6 | |     fn a(&self, param: Vec<u8>);
-  | |________________________________^

--- a/proc-macros/tests/ui/incorrect/method/method_sync_raw_incompatible.rs
+++ b/proc-macros/tests/ui/incorrect/method/method_sync_raw_incompatible.rs
@@ -1,9 +1,0 @@
-use jsonrpsee::proc_macros::rpc;
-
-#[rpc(server)]
-pub trait SyncMethodCannotBeRaw {
-	#[method(name = "a", raw_method)]
-	fn a(&self, param: Vec<u8>) -> RpcResult<u16>;
-}
-
-fn main() {}

--- a/proc-macros/tests/ui/incorrect/method/method_sync_raw_incompatible.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_sync_raw_incompatible.stderr
@@ -1,6 +1,0 @@
-error: Methods must be asynchronous when used with `raw_method`; use `async fn` instead of `fn`
- --> tests/ui/incorrect/method/method_sync_raw_incompatible.rs:5:2
-  |
-5 | /     #[method(name = "a", raw_method)]
-6 | |     fn a(&self, param: Vec<u8>) -> RpcResult<u16>;
-  | |__________________________________________________^

--- a/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
@@ -1,4 +1,4 @@
-error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `param_kind`, `raw_method`
+error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `param_kind`
  --> tests/ui/incorrect/method/method_unexpected_field.rs:6:25
   |
 6 |     #[method(name = "foo", magic = false)]

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::server::{Extensions, ServerBuilder};
 use jsonrpsee::ws_client::*;
 
 #[rpc(client, server)]
@@ -31,15 +31,15 @@ pub struct DeprecatedServerImpl;
 
 #[async_trait]
 impl DeprecatedServer for DeprecatedServerImpl {
-	async fn async_method(&self) -> RpcResult<u8> {
+	async fn async_method(&self, _ext: &Extensions) -> RpcResult<u8> {
 		Ok(16u8)
 	}
 
-	async fn async_method_unused(&self) -> RpcResult<u8> {
+	async fn async_method_unused(&self, _ext: &Extensions) -> RpcResult<u8> {
 		Ok(32u8)
 	}
 
-	fn sync_method(&self) -> RpcResult<u8> {
+	fn sync_method(&self, _ext: &Extensions) -> RpcResult<u8> {
 		Ok(64u8)
 	}
 }

--- a/server/src/middleware/rpc/layer/rpc_service.rs
+++ b/server/src/middleware/rpc/layer/rpc_service.rs
@@ -77,13 +77,13 @@ impl<'a> RpcServiceT<'a> for RpcService {
 		let conn_id = self.conn_id;
 		let max_response_body_size = self.max_response_body_size;
 
-		let params = req.params();
-		let name = req.method_name();
-		let id = req.id().clone();
+		let Request { id, method, params, extensions, .. } = req;
+		let params = jsonrpsee_types::Params::new(params.as_ref().map(|p| serde_json::value::RawValue::get(p)));
 
-		match self.methods.method_with_name(name) {
+		match self.methods.method_with_name(&method) {
 			None => {
-				let rp = MethodResponse::error(id, ErrorObject::from(ErrorCode::MethodNotFound));
+				let mut rp = MethodResponse::error(id, ErrorObject::from(ErrorCode::MethodNotFound));
+				*rp.extensions_mut() = extensions;
 				ResponseFuture::ready(rp)
 			}
 			Some((_name, method)) => match method {
@@ -91,7 +91,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 					let params = params.into_owned();
 					let id = id.into_owned();
 
-					let fut = (callback)(id, params, conn_id, max_response_body_size);
+					let fut = (callback)(id, params, conn_id, max_response_body_size, extensions);
 					ResponseFuture::future(fut)
 				}
 				MethodCallback::AsyncWithDetails(callback) => {
@@ -99,11 +99,12 @@ impl<'a> RpcServiceT<'a> for RpcService {
 					let id = id.into_owned();
 
 					// Note: Add the `Request::extensions` to the connection details when available here.
-					let fut = (callback)(id, params, ConnectionDetails::_new(conn_id), max_response_body_size);
+					let fut =
+						(callback)(id, params, ConnectionDetails::_new(conn_id), max_response_body_size, extensions);
 					ResponseFuture::future(fut)
 				}
 				MethodCallback::Sync(callback) => {
-					let rp = (callback)(id, params, max_response_body_size);
+					let rp = (callback)(id, params, max_response_body_size, extensions);
 					ResponseFuture::ready(rp)
 				}
 				MethodCallback::Subscription(callback) => {
@@ -123,7 +124,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 						let conn_state =
 							SubscriptionState { conn_id, id_provider: &*id_provider.clone(), subscription_permit: p };
 
-						let fut = callback(id.clone(), params, sink, conn_state);
+						let fut = callback(id.clone(), params, sink, conn_state, extensions);
 						ResponseFuture::future(fut)
 					} else {
 						let max = bounded_subscriptions.max();
@@ -140,7 +141,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 						return ResponseFuture::ready(rp);
 					};
 
-					let rp = callback(id, params, conn_id, max_response_body_size);
+					let rp = callback(id, params, conn_id, max_response_body_size, extensions);
 					ResponseFuture::ready(rp)
 				}
 			},

--- a/server/src/middleware/rpc/layer/rpc_service.rs
+++ b/server/src/middleware/rpc/layer/rpc_service.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use crate::middleware::rpc::RpcServiceT;
 use futures_util::future::BoxFuture;
 use jsonrpsee_core::server::{
-	BoundedSubscriptions, ConnectionDetails, MethodCallback, MethodResponse, MethodSink, Methods, SubscriptionState,
+	BoundedSubscriptions, MethodCallback, MethodResponse, MethodSink, Methods, SubscriptionState,
 };
 use jsonrpsee_core::traits::IdProvider;
 use jsonrpsee_types::error::{reject_too_many_subscriptions, ErrorCode};
@@ -92,15 +92,6 @@ impl<'a> RpcServiceT<'a> for RpcService {
 					let id = id.into_owned();
 
 					let fut = (callback)(id, params, conn_id, max_response_body_size, extensions);
-					ResponseFuture::future(fut)
-				}
-				MethodCallback::AsyncWithDetails(callback) => {
-					let params = params.into_owned();
-					let id = id.into_owned();
-
-					// Note: Add the `Request::extensions` to the connection details when available here.
-					let fut =
-						(callback)(id, params, ConnectionDetails::_new(conn_id), max_response_body_size, extensions);
 					ResponseFuture::future(fut)
 				}
 				MethodCallback::Sync(callback) => {

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -42,27 +42,27 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 	let ctx = TestContext;
 	let mut module = RpcModule::new(ctx);
 	module
-		.register_method("say_hello", |_, _| {
+		.register_method("say_hello", |_, _, _| {
 			tracing::debug!("server respond to hello");
 			"hello"
 		})
 		.unwrap();
 	module
-		.register_method::<Result<u64, ErrorObjectOwned>, _>("add", |params, _| {
+		.register_method::<Result<u64, ErrorObjectOwned>, _>("add", |params, _, _| {
 			let params: Vec<u64> = params.parse()?;
 			let sum: u64 = params.into_iter().sum();
 			Ok(sum)
 		})
 		.unwrap();
 	module
-		.register_method::<Result<String, ErrorObjectOwned>, _>("multiparam", |params, _| {
+		.register_method::<Result<String, ErrorObjectOwned>, _>("multiparam", |params, _, _| {
 			let params: (String, String, Vec<u8>) = params.parse()?;
 			let r = format!("string1={}, string2={}, vec={}", params.0.len(), params.1.len(), params.2.len());
 			Ok(r)
 		})
 		.unwrap();
 	module
-		.register_async_method("say_hello_async", |_, _| {
+		.register_async_method("say_hello_async", |_, _, _| {
 			async move {
 				tracing::debug!("server respond to hello");
 				// Call some async function inside.
@@ -72,16 +72,16 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 		})
 		.unwrap();
 	module
-		.register_async_method::<Result<u64, ErrorObjectOwned>, _, _>("add_async", |params, _| async move {
+		.register_async_method::<Result<u64, ErrorObjectOwned>, _, _>("add_async", |params, _, _| async move {
 			let params: Vec<u64> = params.parse()?;
 			let sum: u64 = params.into_iter().sum();
 			Ok(sum)
 		})
 		.unwrap();
-	module.register_method("invalid_params", |_params, _| Err::<(), _>(invalid_params())).unwrap();
-	module.register_method("call_fail", |_params, _| Err::<(), _>(MyAppError)).unwrap();
+	module.register_method("invalid_params", |_params, _, _| Err::<(), _>(invalid_params())).unwrap();
+	module.register_method("call_fail", |_params, _, _| Err::<(), _>(MyAppError)).unwrap();
 	module
-		.register_method::<Result<&str, ErrorObjectOwned>, _>("sleep_for", |params, _| {
+		.register_method::<Result<&str, ErrorObjectOwned>, _>("sleep_for", |params, _, _| {
 			let sleep: Vec<u64> = params.parse()?;
 			std::thread::sleep(std::time::Duration::from_millis(sleep[0]));
 			Ok("Yawn!")
@@ -92,7 +92,7 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 			"subscribe_hello",
 			"subscribe_hello",
 			"unsubscribe_hello",
-			|_, pending, _| async move {
+			|_, pending, _, _| async move {
 				let sink = pending.accept().await?;
 
 				loop {
@@ -103,22 +103,22 @@ pub(crate) async fn server_with_handles() -> (SocketAddr, ServerHandle) {
 		)
 		.unwrap();
 
-	module.register_method("notif", |_, _| "").unwrap();
+	module.register_method("notif", |_, _, _| "").unwrap();
 	module
-		.register_method("should_err", |_, ctx| {
+		.register_method("should_err", |_, ctx, _| {
 			ctx.err()?;
 			RpcResult::Ok("err")
 		})
 		.unwrap();
 
 	module
-		.register_method("should_ok", |_, ctx| {
+		.register_method("should_ok", |_, ctx, _| {
 			ctx.ok()?;
 			RpcResult::Ok("ok")
 		})
 		.unwrap();
 	module
-		.register_async_method("should_ok_async", |_p, ctx| async move {
+		.register_async_method("should_ok_async", |_p, ctx, _| async move {
 			ctx.ok()?;
 			Ok::<_, MyAppError>("ok")
 		})
@@ -138,21 +138,21 @@ pub(crate) async fn server_with_context() -> SocketAddr {
 	let mut rpc_module = RpcModule::new(ctx);
 
 	rpc_module
-		.register_method("should_err", |_p, ctx| {
+		.register_method("should_err", |_p, ctx, _| {
 			ctx.err()?;
 			RpcResult::Ok("err")
 		})
 		.unwrap();
 
 	rpc_module
-		.register_method("should_ok", |_p, ctx| {
+		.register_method("should_ok", |_p, ctx, _| {
 			ctx.ok()?;
 			RpcResult::Ok("ok")
 		})
 		.unwrap();
 
 	rpc_module
-		.register_async_method("should_ok_async", |_p, ctx| async move {
+		.register_async_method("should_ok_async", |_p, ctx, _| async move {
 			ctx.ok()?;
 			// Call some async function inside.
 			Result::<_, MyAppError>::Ok(futures_util::future::ready("ok!").await)
@@ -160,7 +160,7 @@ pub(crate) async fn server_with_context() -> SocketAddr {
 		.unwrap();
 
 	rpc_module
-		.register_async_method("err_async", |_p, ctx| async move {
+		.register_async_method("err_async", |_p, ctx, _| async move {
 			ctx.ok()?;
 			// Async work that returns an error
 			futures_util::future::err::<(), _>(MyAppError).await

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -47,38 +47,38 @@ async fn server() -> (SocketAddr, ServerHandle) {
 	let ctx = TestContext;
 	let mut module = RpcModule::new(ctx);
 	let addr = server.local_addr().unwrap();
-	module.register_method("say_hello", |_, _| "lo").unwrap();
-	module.register_async_method("say_hello_async", |_, _| async move { RpcResult::Ok("lo") }).unwrap();
+	module.register_method("say_hello", |_, _, _| "lo").unwrap();
+	module.register_async_method("say_hello_async", |_, _, _| async move { RpcResult::Ok("lo") }).unwrap();
 	module
-		.register_method("add", |params, _| {
+		.register_method("add", |params, _, _| {
 			let params: Vec<u64> = params.parse()?;
 			let sum: u64 = params.into_iter().sum();
 			RpcResult::Ok(sum)
 		})
 		.unwrap();
 	module
-		.register_method::<Result<String, ErrorObjectOwned>, _>("multiparam", |params, _| {
+		.register_method::<Result<String, ErrorObjectOwned>, _>("multiparam", |params, _, _| {
 			let params: (String, String, Vec<u8>) = params.parse()?;
 			let r = format!("string1={}, string2={}, vec={}", params.0.len(), params.1.len(), params.2.len());
 			Ok(r)
 		})
 		.unwrap();
-	module.register_method("notif", |_, _| "").unwrap();
+	module.register_method("notif", |_, _, _| "").unwrap();
 	module
-		.register_method("should_err", |_, ctx| {
+		.register_method("should_err", |_, ctx, _| {
 			ctx.err()?;
 			Ok::<_, MyAppError>("err")
 		})
 		.unwrap();
 
 	module
-		.register_method("should_ok", |_, ctx| {
+		.register_method("should_ok", |_, ctx, _| {
 			ctx.ok()?;
 			Ok::<_, MyAppError>("ok")
 		})
 		.unwrap();
 	module
-		.register_async_method("should_ok_async", |_p, ctx| async move {
+		.register_async_method("should_ok_async", |_p, ctx, _| async move {
 			ctx.ok()?;
 			Ok::<_, MyAppError>("ok")
 		})
@@ -435,12 +435,12 @@ async fn can_register_modules() {
 	let mut mod2 = RpcModule::new(cx2);
 
 	assert_eq!(mod1.method_names().count(), 0);
-	mod1.register_method("bla", |_, cx| format!("Gave me {cx}")).unwrap();
-	mod1.register_method("bla2", |_, cx| format!("Gave me {cx}")).unwrap();
-	mod2.register_method("yada", |_, cx| format!("Gave me {cx:?}")).unwrap();
+	mod1.register_method("bla", |_, cx, _| format!("Gave me {cx}")).unwrap();
+	mod1.register_method("bla2", |_, cx, _| format!("Gave me {cx}")).unwrap();
+	mod2.register_method("yada", |_, cx, _| format!("Gave me {cx:?}")).unwrap();
 
 	// Won't register, name clashes
-	mod2.register_method("bla", |_, cx| format!("Gave me {cx:?}")).unwrap();
+	mod2.register_method("bla", |_, cx, _| format!("Gave me {cx:?}")).unwrap();
 
 	assert_eq!(mod1.method_names().count(), 2);
 
@@ -457,7 +457,7 @@ async fn can_set_the_max_request_body_size() {
 	// Rejects all requests larger than 100 bytes
 	let server = ServerBuilder::default().max_request_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| "a".repeat(100)).unwrap();
+	module.register_method("anything", |_p, _cx, _| "a".repeat(100)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
 	let handle = server.start(module);
@@ -482,7 +482,7 @@ async fn can_set_the_max_response_size() {
 	// Set the max response size to 100 bytes
 	let server = ServerBuilder::default().max_response_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| "a".repeat(101)).unwrap();
+	module.register_method("anything", |_p, _cx, _| "a".repeat(101)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
 	let handle = server.start(module);
@@ -502,7 +502,7 @@ async fn can_set_the_max_response_size_to_batch() {
 	// Set the max response size to 100 bytes
 	let server = ServerBuilder::default().max_response_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| "a".repeat(51)).unwrap();
+	module.register_method("anything", |_p, _cx, _| "a".repeat(51)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
 	let handle = server.start(module);
@@ -523,7 +523,7 @@ async fn disabled_batches() {
 	let server =
 		ServerBuilder::default().set_batch_request_config(BatchRequestConfig::Disabled).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
+	module.register_method("should_ok", |_, _ctx, _| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
 	let handle = server.start(module);
@@ -547,7 +547,7 @@ async fn batch_limit_works() {
 	let server =
 		ServerBuilder::default().set_batch_request_config(BatchRequestConfig::Limit(1)).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
+	module.register_method("should_ok", |_, _ctx, _| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 	let uri = to_http_uri(addr);
 	let handle = server.start(module);

--- a/server/src/tests/shared.rs
+++ b/server/src/tests/shared.rs
@@ -46,7 +46,7 @@ async fn http_only_works() {
 		ServerBuilder::default().http_only().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut module = RpcModule::new(());
 	module
-		.register_method("say_hello", |_, _| {
+		.register_method("say_hello", |_, _, _| {
 			tracing::debug!("server respond to hello");
 			"hello"
 		})
@@ -71,7 +71,7 @@ async fn ws_only_works() {
 	let server = ServerBuilder::default().ws_only().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut module = RpcModule::new(());
 	module
-		.register_method("say_hello", |_, _| {
+		.register_method("say_hello", |_, _, _| {
 			tracing::debug!("server respond to hello");
 			"hello"
 		})

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -49,7 +49,7 @@ async fn can_set_the_max_request_body_size() {
 	// Rejects all requests larger than 100 bytes
 	let server = ServerBuilder::default().max_request_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| "a".repeat(100)).unwrap();
+	module.register_method("anything", |_p, _cx, _| "a".repeat(100)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let handle = server.start(module);
 
@@ -77,7 +77,7 @@ async fn can_set_the_max_response_body_size() {
 	// Set the max response body size to 100 bytes
 	let server = ServerBuilder::default().max_response_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| "a".repeat(101)).unwrap();
+	module.register_method("anything", |_, _, _| "a".repeat(101)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let server_handle = server.start(module);
 
@@ -100,7 +100,7 @@ async fn can_set_the_max_response_size_to_batch() {
 	// Set the max response body size to 100 bytes
 	let server = ServerBuilder::default().max_response_body_size(100).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| "a".repeat(51)).unwrap();
+	module.register_method("anything", |_p, _cx, _| "a".repeat(51)).unwrap();
 	let addr = server.local_addr().unwrap();
 	let server_handle = server.start(module);
 
@@ -123,7 +123,7 @@ async fn can_set_max_connections() {
 	// Server that accepts max 2 connections
 	let server = ServerBuilder::default().max_connections(2).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
-	module.register_method("anything", |_p, _cx| ()).unwrap();
+	module.register_method("anything", |_, _, _| ()).unwrap();
 	let addr = server.local_addr().unwrap();
 
 	let server_handle = server.start(module);
@@ -417,18 +417,21 @@ async fn unknown_field_is_ok() {
 #[tokio::test]
 async fn register_methods_works() {
 	let mut module = RpcModule::new(());
-	assert!(module.register_method("say_hello", |_, _| "lo").is_ok());
-	assert!(module.register_method("say_hello", |_, _| "lo").is_err());
+	assert!(module.register_method("say_hello", |_, _, _| "lo").is_ok());
+	assert!(module.register_method("say_hello", |_, _, _| "lo").is_err());
 	assert!(module
-		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, _, _| async { Ok(()) })
+		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, _, _, _| async { Ok(()) })
 		.is_ok());
 	assert!(module
-		.register_subscription("subscribe_hello_again", "subscribe_hello_again", "unsubscribe_hello", |_, _, _| async {
-			Ok(())
-		})
+		.register_subscription(
+			"subscribe_hello_again",
+			"subscribe_hello_again",
+			"unsubscribe_hello",
+			|_, _, _, _| async { Ok(()) }
+		)
 		.is_err());
 	assert!(
-		module.register_method("subscribe_hello_again", |_, _| "lo").is_ok(),
+		module.register_method("subscribe_hello_again", |_, _, _| "lo").is_ok(),
 		"Failed register_subscription should not have side-effects"
 	);
 }
@@ -437,8 +440,9 @@ async fn register_methods_works() {
 async fn register_same_subscribe_unsubscribe_is_err() {
 	let mut module = RpcModule::new(());
 	assert!(matches!(
-		module
-			.register_subscription("subscribe_hello", "subscribe_hello", "subscribe_hello", |_, _, _| async { Ok(()) }),
+		module.register_subscription("subscribe_hello", "subscribe_hello", "subscribe_hello", |_, _, _, _| async {
+			Ok(())
+		}),
 		Err(RegisterMethodError::SubscriptionNameConflict(_))
 	));
 }
@@ -500,12 +504,12 @@ async fn can_register_modules() {
 
 	assert_eq!(mod1.method_names().count(), 0);
 	assert_eq!(mod2.method_names().count(), 0);
-	mod1.register_method("bla", |_, cx| format!("Gave me {cx}")).unwrap();
-	mod1.register_method("bla2", |_, cx| format!("Gave me {cx}")).unwrap();
-	mod2.register_method("yada", |_, cx| format!("Gave me {cx:?}")).unwrap();
+	mod1.register_method("bla", |_, cx, _| format!("Gave me {cx}")).unwrap();
+	mod1.register_method("bla2", |_, cx, _| format!("Gave me {cx}")).unwrap();
+	mod2.register_method("yada", |_, cx, _| format!("Gave me {cx:?}")).unwrap();
 
 	// Won't register, name clashes
-	mod2.register_method("bla", |_, cx| format!("Gave me {cx:?}")).unwrap();
+	mod2.register_method("bla", |_, cx, _| format!("Gave me {cx:?}")).unwrap();
 
 	assert_eq!(mod1.method_names().count(), 2);
 	let err = mod1.merge(mod2).unwrap_err();
@@ -565,7 +569,7 @@ async fn custom_subscription_id_works() {
 	let addr = server.local_addr().unwrap();
 	let mut module = RpcModule::new(());
 	module
-		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, sink, _| async {
+		.register_subscription("subscribe_hello", "subscribe_hello", "unsubscribe_hello", |_, sink, _, _| async {
 			let sink = sink.accept().await.unwrap();
 
 			assert!(matches!(sink.subscription_id(), SubscriptionId::Str(id) if id == "0xdeadbeef"));
@@ -598,7 +602,7 @@ async fn disabled_batches() {
 		.unwrap();
 
 	let mut module = RpcModule::new(());
-	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
+	module.register_method("should_ok", |_, _ctx, _| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 
 	let server_handle = server.start(module);
@@ -628,7 +632,7 @@ async fn batch_limit_works() {
 		.unwrap();
 
 	let mut module = RpcModule::new(());
-	module.register_method("should_ok", |_, _ctx| "ok").unwrap();
+	module.register_method("should_ok", |_, _ctx, _| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
 
 	let server_handle = server.start(module);
@@ -732,7 +736,7 @@ async fn ws_server_backpressure_works() {
 			"subscribe_with_backpressure_aggregation",
 			"n",
 			"unsubscribe_with_backpressure_aggregation",
-			move |_, pending, mut backpressure_tx| async move {
+			move |_, pending, mut backpressure_tx, _| async move {
 				let sink = pending.accept().await?;
 				let n = SubscriptionMessage::from_json(&1)?;
 				let bp = SubscriptionMessage::from_json(&2)?;
@@ -915,7 +919,7 @@ async fn server_with_infinite_call(
 	let mut module = RpcModule::new(tx);
 
 	module
-		.register_async_method("infinite_call", |_, mut ctx| async move {
+		.register_async_method("infinite_call", |_, mut ctx, _| async move {
 			let tx = std::sync::Arc::make_mut(&mut ctx);
 			tx.send(()).unwrap();
 			futures_util::future::pending::<()>().await;

--- a/tests/proc-macro-core/src/lib.rs
+++ b/tests/proc-macro-core/src/lib.rs
@@ -3,7 +3,7 @@
 use jsonrpsee::core::{async_trait, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
-use jsonrpsee::{ConnectionDetails, PendingSubscriptionSink, SubscriptionMessage};
+use jsonrpsee::{Extensions, PendingSubscriptionSink, SubscriptionMessage};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -38,36 +38,35 @@ pub trait Api {
 
 	#[method(name = "blocking", blocking)]
 	fn blocking_method(&self, a: String) -> Result<u16, ErrorObjectOwned>;
-
-	#[method(name = "raw", raw_method)]
-	async fn raw(&self, a: String) -> Result<u16, ErrorObjectOwned>;
 }
 
 #[async_trait]
 impl ApiServer for () {
-	fn sync_call(&self, _: String) -> Result<String, ErrorObjectOwned> {
+	fn sync_call(&self, _ext: &Extensions, _: String) -> Result<String, ErrorObjectOwned> {
 		Ok("sync_call".to_string())
 	}
 
-	async fn async_call(&self, _: String) -> Result<String, ErrorObjectOwned> {
+	async fn async_call(&self, _ext: &Extensions, _: String) -> Result<String, ErrorObjectOwned> {
 		Ok("async_call".to_string())
 	}
 
-	async fn sub(&self, pending: PendingSubscriptionSink, _: PubSubKind, _: PubSubParams) -> SubscriptionResult {
+	async fn sub(
+		&self,
+		pending: PendingSubscriptionSink,
+		_ext: &Extensions,
+		_: PubSubKind,
+		_: PubSubParams,
+	) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 		sink.send(SubscriptionMessage::from("msg")).await?;
 		Ok(())
 	}
 
-	fn sync_sub(&self, _: PendingSubscriptionSink, _: String) -> SubscriptionResult {
+	fn sync_sub(&self, _: PendingSubscriptionSink, _ext: &Extensions, _: String) -> SubscriptionResult {
 		Ok(())
 	}
 
-	fn blocking_method(&self, _: String) -> Result<u16, ErrorObjectOwned> {
-		Ok(42)
-	}
-
-	async fn raw(&self, _: ConnectionDetails, _: String) -> Result<u16, ErrorObjectOwned> {
+	fn blocking_method(&self, _ext: &Extensions, _: String) -> Result<u16, ErrorObjectOwned> {
 		Ok(42)
 	}
 }

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -166,7 +166,7 @@ pub async fn server() -> SocketAddr {
 
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _, _| "hello").unwrap();
-	module.register_method("raw_method", |_, _, ext| *ext.get::<u32>().unwrap()).unwrap();
+	module.register_method("get_connection_id", |_, _, ext| *ext.get::<u32>().unwrap()).unwrap();
 
 	module
 		.register_async_method("slow_hello", |_, _, _| async {

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -166,7 +166,7 @@ pub async fn server() -> SocketAddr {
 
 	let mut module = RpcModule::new(());
 	module.register_method("say_hello", |_, _, _| "hello").unwrap();
-	module.register_method("raw_method", |_, _, ext| ext.get::<u32>().unwrap().clone()).unwrap();
+	module.register_method("raw_method", |_, _, ext| *ext.get::<u32>().unwrap()).unwrap();
 
 	module
 		.register_async_method("slow_hello", |_, _, _| async {

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -206,7 +206,7 @@ async fn ws_method_call_works_over_proxy_stream() {
 }
 
 #[tokio::test]
-async fn raw_methods_with_different_ws_clients() {
+async fn extensions_with_different_ws_clients() {
 	init_logger();
 
 	let server_addr = server().await;

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -214,13 +214,13 @@ async fn extensions_with_different_ws_clients() {
 	let client = WsClientBuilder::default().build(&server_url).await.unwrap();
 
 	// Connection ID does not change for the same client.
-	let connection_id: usize = client.request("raw_method", rpc_params![]).await.unwrap();
-	let identical_connection_id: usize = client.request("raw_method", rpc_params![]).await.unwrap();
+	let connection_id: usize = client.request("get_connection_id", rpc_params![]).await.unwrap();
+	let identical_connection_id: usize = client.request("get_connection_id", rpc_params![]).await.unwrap();
 	assert_eq!(connection_id, identical_connection_id);
 
 	// Connection ID is different for different clients.
 	let second_client = WsClientBuilder::default().build(&server_url).await.unwrap();
-	let second_connection_id: usize = second_client.request("raw_method", rpc_params![]).await.unwrap();
+	let second_connection_id: usize = second_client.request("get_connection_id", rpc_params![]).await.unwrap();
 	assert_ne!(connection_id, second_connection_id);
 }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -19,3 +19,4 @@ beef = { version = "0.5.1", features = ["impl_serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
+http = "0.2"

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -54,7 +54,7 @@ pub struct Request<'a> {
 	pub params: Option<StdCow<'a, RawValue>>,
 	/// The request's extensions.
 	#[serde(skip)]
-	extensions: Extensions,
+	pub extensions: Extensions,
 }
 
 impl<'a> Request<'a> {

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -34,11 +34,12 @@ use crate::{
 	Params,
 };
 use beef::Cow;
+use http::Extensions;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
 /// JSON-RPC request object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Request<'a> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
@@ -51,12 +52,15 @@ pub struct Request<'a> {
 	/// Parameter values of the request.
 	#[serde(borrow)]
 	pub params: Option<StdCow<'a, RawValue>>,
+	/// The request's extensions.
+	#[serde(skip)]
+	extensions: Extensions,
 }
 
 impl<'a> Request<'a> {
 	/// Create a new [`Request`].
 	pub fn new(method: Cow<'a, str>, params: Option<&'a RawValue>, id: Id<'a>) -> Self {
-		Self { jsonrpc: TwoPointZero, id, method, params: params.map(StdCow::Borrowed) }
+		Self { jsonrpc: TwoPointZero, id, method, params: params.map(StdCow::Borrowed), extensions: Extensions::new() }
 	}
 
 	/// Get the ID of the request.
@@ -72,6 +76,16 @@ impl<'a> Request<'a> {
 	/// Get the params of the request.
 	pub fn params(&self) -> Params {
 		Params::new(self.params.as_ref().map(|p| RawValue::get(p)))
+	}
+
+	/// Returns a reference to the associated extensions.
+	pub fn extensions(&self) -> &Extensions {
+		&self.extensions
+	}
+
+	/// Returns a reference to the associated extensions.
+	pub fn extensions_mut(&mut self) -> &mut Extensions {
+		&mut self.extensions
 	}
 }
 


### PR DESCRIPTION
Fixes #1305 

In summary this PR adds `http::Extensions` to Request and Responses this may be used to share state between middlewares and similar.

Most of the changes are chore but I had to add this to all RPC handlers and the proc macro API.
Thus, the most important things to review is the changes to Request and MethodResponse.
