### PR TITLE
chore: Release 0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [v0.22.2] - 2024-03-05
 
-This is a small patch release that exposes the connection details to server methods without breaking changes.
+This is a small patch release that exposes the connection details in server method implementations without breaking changes.
 Currently, users can only retrieve the connection ID from these details.
 We plan to extend this functionality in jsonrpsee v1.0, although this will necessitate a breaking change.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We plan to extend this functionality in jsonrpsee v1.0, although this will neces
 - server: Register raw method with connection ID ([#1297](https://github.com/paritytech/jsonrpsee/pull/1297))
 
 ### [Changed]
-- Update Syn 1.0 -> 2.0  ([#1304](https://github.com/paritytech/jsonrpsee/pull/1304))
+- Update Syn 1.0 -> 2.0 ([#1304](https://github.com/paritytech/jsonrpsee/pull/1304))
 
 ## [v0.22.1] - 2024-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is a small patch release that exposes the connection details in server meth
 We plan to extend this functionality in jsonrpsee v1.0, although this will necessitate a breaking change.
 
 ### [Added]
-- server: Register raw method with connection ID  ([#1297](https://github.com/paritytech/jsonrpsee/pull/1297))
+- server: Register raw method with connection ID ([#1297](https://github.com/paritytech/jsonrpsee/pull/1297))
 
 ### [Changed]
 - Update Syn 1.0 -> 2.0  ([#1304](https://github.com/paritytech/jsonrpsee/pull/1304))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog].
 ## [v0.22.2] - 2024-03-05
 
 This is a small patch release that exposes the connection details in server method implementations without breaking changes.
-Currently, users can only retrieve the connection ID from these details.
 We plan to extend this functionality in jsonrpsee v1.0, although this will necessitate a breaking change.
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.22.2] - 2024-03-05
+
+This is a small patch release that exposes the connection details to server methods without breaking changes.
+Currently, users can only retrieve the connection ID from these details.
+We plan to extend this functionality in jsonrpsee v1.0, although this will necessitate a breaking change.
+
+### [Added]
+- server: Register raw method with connection ID  ([#1297](https://github.com/paritytech/jsonrpsee/pull/1297))
+
+### [Changed]
+- Update Syn 1.0 -> 2.0  ([#1304](https://github.com/paritytech/jsonrpsee/pull/1304))
+
 ## [v0.22.1] - 2024-02-19
 
 This is a small patch release that internally changes `AtomicU64` to `AtomicUsize`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 rust-version = "1.64.0"
 license = "MIT"
@@ -30,11 +30,11 @@ keywords = ["jsonrpc", "json", "http", "websocket", "WASM"]
 readme = "README.md"
 
 [workspace.dependencies]
-jsonrpsee-types = { path = "types", version = "0.22.1" }
-jsonrpsee-core = { path = "core", version = "0.22.1" }
-jsonrpsee-server = { path = "server", version = "0.22.1" }
-jsonrpsee-ws-client = { path = "client/ws-client", version = "0.22.1" }
-jsonrpsee-http-client = { path = "client/http-client", version = "0.22.1" }
-jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.22.1" }
-jsonrpsee-client-transport = { path = "client/transport", version = "0.22.1" }
-jsonrpsee-proc-macros = { path = "proc-macros", version = "0.22.1" }
+jsonrpsee-types = { path = "types", version = "0.22.2" }
+jsonrpsee-core = { path = "core", version = "0.22.2" }
+jsonrpsee-server = { path = "server", version = "0.22.2" }
+jsonrpsee-ws-client = { path = "client/ws-client", version = "0.22.2" }
+jsonrpsee-http-client = { path = "client/http-client", version = "0.22.2" }
+jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.22.2" }
+jsonrpsee-client-transport = { path = "client/transport", version = "0.22.2" }
+jsonrpsee-proc-macros = { path = "proc-macros", version = "0.22.2" }


### PR DESCRIPTION
## [v0.22.2] - 2024-03-05

This is a small patch release that exposes the connection details to server methods without breaking changes.
Currently, users can only retrieve the connection ID from these details.
We plan to extend this functionality in jsonrpsee v1.0, although this will necessitate a breaking change.

### [Added]
- server: Register raw method with connection ID  ([#1297](https://github.com/paritytech/jsonrpsee/pull/1297))

### [Changed]
- Update Syn 1.0 -> 2.0  ([#1304](https://github.com/paritytech/jsonrpsee/pull/1304))
