### PR TITLE
refactor(subscription): delegate handling to user and do not close when lagging.

### DIFF
--- a/client/wasm-client/src/lib.rs
+++ b/client/wasm-client/src/lib.rs
@@ -62,7 +62,6 @@ use jsonrpsee_core::client::{ClientBuilder, Error, IdKind};
 pub struct WasmClientBuilder {
 	id_kind: IdKind,
 	max_concurrent_requests: usize,
-	max_buffer_capacity_per_subscription: usize,
 	max_log_length: u32,
 	request_timeout: Duration,
 }
@@ -73,7 +72,6 @@ impl Default for WasmClientBuilder {
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
 			max_concurrent_requests: 256,
-			max_buffer_capacity_per_subscription: 1024,
 			request_timeout: Duration::from_secs(60),
 		}
 	}
@@ -97,12 +95,6 @@ impl WasmClientBuilder {
 		self
 	}
 
-	/// See documentation [`ClientBuilder::max_buffer_capacity_per_subscription`] (default is 1024).
-	pub fn max_buffer_capacity_per_subscription(mut self, max: usize) -> Self {
-		self.max_buffer_capacity_per_subscription = max;
-		self
-	}
-
 	/// See documentation for [`ClientBuilder::id_format`] (default is Number).
 	pub fn id_format(mut self, kind: IdKind) -> Self {
 		self.id_kind = kind;
@@ -119,20 +111,13 @@ impl WasmClientBuilder {
 
 	/// Build the client with specified URL to connect to.
 	pub async fn build(self, url: impl AsRef<str>) -> Result<Client, Error> {
-		let Self {
-			max_log_length,
-			id_kind,
-			request_timeout,
-			max_concurrent_requests,
-			max_buffer_capacity_per_subscription,
-		} = self;
+		let Self { max_log_length, id_kind, request_timeout, max_concurrent_requests } = self;
 		let (sender, receiver) = web::connect(url).await.map_err(|e| Error::Transport(e.into()))?;
 
 		let builder = ClientBuilder::default()
 			.set_max_logging_length(max_log_length)
 			.request_timeout(request_timeout)
 			.id_format(id_kind)
-			.max_buffer_capacity_per_subscription(max_buffer_capacity_per_subscription)
 			.max_concurrent_requests(max_concurrent_requests);
 
 		Ok(builder.build_with_wasm(sender, receiver))

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -86,7 +86,6 @@ pub struct WsClientBuilder {
 	ping_config: Option<PingConfig>,
 	headers: http::HeaderMap,
 	max_concurrent_requests: usize,
-	max_buffer_capacity_per_subscription: usize,
 	max_redirections: usize,
 	id_kind: IdKind,
 	max_log_length: u32,
@@ -104,7 +103,6 @@ impl Default for WsClientBuilder {
 			ping_config: None,
 			headers: HeaderMap::new(),
 			max_concurrent_requests: 256,
-			max_buffer_capacity_per_subscription: 1024,
 			max_redirections: 5,
 			id_kind: IdKind::Number,
 			max_log_length: 4096,
@@ -197,12 +195,6 @@ impl WsClientBuilder {
 		self
 	}
 
-	/// See documentation [`ClientBuilder::max_buffer_capacity_per_subscription`] (default is 1024).
-	pub fn max_buffer_capacity_per_subscription(mut self, max: usize) -> Self {
-		self.max_buffer_capacity_per_subscription = max;
-		self
-	}
-
 	/// See documentation [`WsTransportClientBuilder::max_redirections`] (default is 5).
 	pub fn max_redirections(mut self, redirect: usize) -> Self {
 		self.max_redirections = redirect;
@@ -240,18 +232,10 @@ impl WsClientBuilder {
 		R: TransportReceiverT + Send,
 	{
 		let Self {
-			max_concurrent_requests,
-			request_timeout,
-			ping_config,
-			max_buffer_capacity_per_subscription,
-			id_kind,
-			max_log_length,
-			tcp_no_delay,
-			..
+			max_concurrent_requests, request_timeout, ping_config, id_kind, max_log_length, tcp_no_delay, ..
 		} = self;
 
 		let mut client = ClientBuilder::default()
-			.max_buffer_capacity_per_subscription(max_buffer_capacity_per_subscription)
 			.request_timeout(request_timeout)
 			.max_concurrent_requests(max_concurrent_requests)
 			.id_format(id_kind)

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -202,13 +202,7 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 	.unwrap();
 
 	let uri = to_ws_uri_string(server.local_addr());
-	let client = WsClientBuilder::default()
-		.max_buffer_capacity_per_subscription(4)
-		.build(&uri)
-		.with_default_timeout()
-		.await
-		.unwrap()
-		.unwrap();
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
 	let mut nh: Subscription<String> =
 		client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
 

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -728,7 +728,11 @@ async fn handle_backend_messages<R: TransportReceiverT>(
 				}
 				// Incoming Notification
 				else if let Ok(notif) = serde_json::from_slice::<Notification<_>>(raw) {
-					process_notification(&mut manager.lock(), notif);
+					let fut = process_notification(&mut manager.lock(), notif);
+
+					if let Err(method) = fut.await {
+						return Ok(Some(FrontToBack::UnregisterNotification(method)));
+					}
 				} else {
 					return Err(unparse_error(raw));
 				}

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -45,6 +45,14 @@ use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 use tower_http::cors::CorsLayer;
 
+pub struct CustomError;
+
+impl From<CustomError> for ErrorObjectOwned {
+	fn from(_: CustomError) -> Self {
+		ErrorObject::owned(-32001, "err", None::<()>)
+	}
+}
+
 pub async fn server_with_subscription_and_handle() -> (SocketAddr, ServerHandle) {
 	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
 
@@ -150,14 +158,6 @@ pub async fn server() -> SocketAddr {
 			"hello"
 		})
 		.unwrap();
-
-	struct CustomError;
-
-	impl From<CustomError> for ErrorObjectOwned {
-		fn from(_: CustomError) -> Self {
-			ErrorObject::owned(-32001, "err", None::<()>)
-		}
-	}
 
 	module.register_async_method::<Result<(), CustomError>, _, _>("err", |_, _| async { Err(CustomError) }).unwrap();
 


### PR DESCRIPTION
This PR changes that subscription is not closed if couldn't keep up with the server. 

Instead entire connection is "backpressured" and until the subscription is polled by the user no other messages are processed until doing.

The benefit is that jsonrpsee doesn't have to provide that logic and is less opinionated. Then it's easy to extend to proper behavior, and the internal buffer for subscription is removed or replaced with a capacity of 1.

The downside is that if something is polled in the wrong order it may "stall the connection", thus if one has to several subscriptions and poll them in the wrong order the connection will never make progress.

Example to drop the oldest message.

```rust
let sub: Subscription<i32> =
    client1.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await?;

// drop oldest messages from subscription:
let sub = drop_oldest(sub, buffer_size);

fn drop_oldest<T>(mut sub: Stream<T>, buffer_size: usize) -> impl Stream<T> {
    let buf = Vec::with_capacity(usize);
    let (tx, rx) = async_broadcast::channel(); 
    tokio::spawn(async move {
        // poll sub, sending msgs to our chan which throws stuff away
        while let Some(msg) = sub.next().await { tx.send(msg) }
    })
    rx
}
```