### PR TITLE
client: add `Subscription::close_reason`

### DIFF
--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -29,7 +29,9 @@
 use crate::types::error::{ErrorCode, ErrorObject};
 use crate::WsClientBuilder;
 
-use jsonrpsee_core::client::{BatchResponse, ClientT, Error, IdKind, Subscription, SubscriptionClientT};
+use jsonrpsee_core::client::{
+	BatchResponse, ClientT, Error, IdKind, Subscription, SubscriptionClientT, SubscriptionError,
+};
 use jsonrpsee_core::params::BatchRequestBuilder;
 use jsonrpsee_core::{rpc_params, DeserializeOwned};
 use jsonrpsee_test_utils::helpers::*;
@@ -190,7 +192,7 @@ async fn notification_handler_works() {
 }
 
 #[tokio::test]
-async fn notification_without_polling_doesnt_make_client_unuseable() {
+async fn notification_lagging_works() {
 	init_logger();
 
 	let server = WebSocketTestServer::with_hardcoded_notification(
@@ -212,22 +214,14 @@ async fn notification_without_polling_doesnt_make_client_unuseable() {
 	let mut nh: Subscription<String> =
 		client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
 
-	// don't poll the notification stream for 2 seconds, should be full now.
+	// Don't poll the notification stream for 2 seconds, should be full now.
 	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-	for _ in 0..4 {
-		assert!(nh.next().with_default_timeout().await.unwrap().unwrap().is_ok());
-	}
+	// Lagged
+	assert!(matches!(nh.next().with_default_timeout().await.unwrap(), Some(Err(SubscriptionError::TooSlow))));
+	// Next recv should poll the stream again.
+	assert!(matches!(nh.next().with_default_timeout().await.unwrap(), Some(Ok(_))));
 
-	// NOTE: this is now unuseable and unregistered.
-	assert!(nh.next().with_default_timeout().await.unwrap().is_none());
-
-	// The same subscription should be possible to register again.
-	let mut other_nh: Subscription<String> =
-		client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
-
-	// check that the new subscription works.
-	assert!(other_nh.next().with_default_timeout().await.unwrap().unwrap().is_ok());
 	assert!(client.is_connected());
 }
 

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -192,7 +192,7 @@ async fn notification_handler_works() {
 }
 
 #[tokio::test]
-async fn notification_lagging_works() {
+async fn notification_close_on_lagging() {
 	init_logger();
 
 	let server = WebSocketTestServer::with_hardcoded_notification(
@@ -228,6 +228,12 @@ async fn notification_lagging_works() {
 	// It should be dropped when lagging.
 	assert!(nh.next().with_default_timeout().await.unwrap().is_none());
 
+	// The same subscription should be possible to register again.
+	let mut other_nh: Subscription<String> =
+		client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
+
+	// check that the new subscription works.
+	assert!(other_nh.next().with_default_timeout().await.unwrap().unwrap().is_ok());
 	assert!(client.is_connected());
 }
 

--- a/core/src/client/async_client/helpers.rs
+++ b/core/src/client/async_client/helpers.rs
@@ -111,7 +111,7 @@ pub(crate) fn process_subscription_response(
 			Err(TrySubscriptionSendError::Closed) => Some(sub_id),
 			Err(TrySubscriptionSendError::TooSlow(m)) => {
 				tracing::error!(target: LOG_TARGET, "Subscription {{method={}, sub_id={:?}}} couldn't keep up with server; failed to send {m}", response.method, sub_id);
-				None
+				Some(sub_id)
 			}
 		},
 		None => {
@@ -157,6 +157,7 @@ pub(crate) fn process_notification(manager: &mut RequestManager, notif: Notifica
 			}
 			Err(TrySubscriptionSendError::TooSlow(m)) => {
 				tracing::error!(target: LOG_TARGET, "Notification `{}` couldn't keep up with server; failed to send {m}", notif.method);
+				let _ = manager.remove_notification_handler(&notif.method);
 			}
 		},
 		None => {

--- a/core/src/client/async_client/manager.rs
+++ b/core/src/client/async_client/manager.rs
@@ -37,11 +37,14 @@ use std::{
 	ops::Range,
 };
 
-use crate::{client::BatchEntry, client::Error, error::RegisterMethodError};
+use crate::{
+	client::{BatchEntry, Error, SubscriptionReceiver, SubscriptionSender},
+	error::RegisterMethodError,
+};
 use jsonrpsee_types::{Id, SubscriptionId};
 use rustc_hash::FxHashMap;
 use serde_json::value::Value as JsonValue;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
 #[derive(Debug)]
 enum Kind {
@@ -65,9 +68,8 @@ pub(crate) enum RequestStatus {
 
 type PendingCallOneshot = Option<oneshot::Sender<Result<JsonValue, Error>>>;
 type PendingBatchOneshot = oneshot::Sender<Result<Vec<BatchEntry<'static, JsonValue>>, Error>>;
-type PendingSubscriptionOneshot =
-	oneshot::Sender<Result<(mpsc::Receiver<JsonValue>, mpsc::Sender<JsonValue>, SubscriptionId<'static>), Error>>;
-type SubscriptionSink = mpsc::Sender<JsonValue>;
+type PendingSubscriptionOneshot = oneshot::Sender<Result<(SubscriptionReceiver, SubscriptionId<'static>), Error>>;
+type SubscriptionSink = SubscriptionSender;
 type UnsubscribeMethod = String;
 type RequestId = Id<'static>;
 
@@ -337,10 +339,12 @@ impl RequestManager {
 
 #[cfg(test)]
 mod tests {
+	use crate::client::subscription_channel;
+
 	use super::{Error, RequestManager};
 	use jsonrpsee_types::{Id, SubscriptionId};
 	use serde_json::Value as JsonValue;
-	use tokio::sync::{mpsc, oneshot};
+	use tokio::sync::oneshot;
 
 	#[test]
 	fn insert_remove_pending_request_works() {
@@ -354,7 +358,7 @@ mod tests {
 	#[test]
 	fn insert_remove_subscription_works() {
 		let (pending_sub_tx, _) = oneshot::channel();
-		let (sub_tx, _) = mpsc::channel::<JsonValue>(1);
+		let (sub_tx, _) = subscription_channel(1);
 		let mut manager = RequestManager::new();
 		assert!(manager
 			.insert_pending_subscription(Id::Number(1), Id::Number(2), pending_sub_tx, "unsubscribe_method".into())
@@ -420,7 +424,7 @@ mod tests {
 		let (request_tx1, _) = oneshot::channel();
 		let (request_tx2, _) = oneshot::channel();
 		let (pending_sub_tx, _) = oneshot::channel();
-		let (sub_tx, _) = mpsc::channel::<JsonValue>(1);
+		let (sub_tx, _) = subscription_channel(1);
 
 		let mut manager = RequestManager::new();
 		assert!(manager.insert_pending_call(Id::Number(0), Some(request_tx1)).is_ok());
@@ -448,7 +452,7 @@ mod tests {
 		let (request_tx, _) = oneshot::channel();
 		let (pending_sub_tx1, _) = oneshot::channel();
 		let (pending_sub_tx2, _) = oneshot::channel();
-		let (sub_tx, _) = mpsc::channel::<JsonValue>(1);
+		let (sub_tx, _) = subscription_channel(1);
 
 		let mut manager = RequestManager::new();
 		assert!(manager
@@ -478,8 +482,8 @@ mod tests {
 	fn active_subscriptions_faulty() {
 		let (request_tx, _) = oneshot::channel();
 		let (pending_sub_tx, _) = oneshot::channel();
-		let (sub_tx1, _) = mpsc::channel::<JsonValue>(1);
-		let (sub_tx2, _) = mpsc::channel::<JsonValue>(1);
+		let (sub_tx1, _) = subscription_channel(1);
+		let (sub_tx2, _) = subscription_channel(1);
 
 		let mut manager = RequestManager::new();
 

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -66,7 +66,7 @@ use tracing::instrument;
 
 use self::utils::{InactivityCheck, IntervalStream};
 
-use super::{generate_batch_id_range, FrontToBack, IdKind, RequestIdManager};
+use super::{generate_batch_id_range, subscription_channel, FrontToBack, IdKind, RequestIdManager};
 
 const LOG_TARGET: &str = "jsonrpsee-client";
 
@@ -674,7 +674,7 @@ impl SubscriptionClientT for Client {
 			return Err(self.disconnect_reason().await);
 		}
 
-		let (notifs_rx, rx_lagged, sub_id) = match call_with_timeout(self.request_timeout, send_back_rx).await {
+		let (notifs_rx, sub_id) = match call_with_timeout(self.request_timeout, send_back_rx).await {
 			Ok(Ok(val)) => val,
 			Ok(Err(err)) => return Err(err),
 			Err(_) => return Err(self.disconnect_reason().await),
@@ -682,7 +682,7 @@ impl SubscriptionClientT for Client {
 
 		rx_log_from_json(&Response::new(ResponsePayload::success_borrowed(&sub_id), id_unsub), self.max_log_length);
 
-		Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id), rx_lagged))
+		Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id)))
 	}
 
 	/// Subscribe to a specific method.
@@ -707,13 +707,13 @@ impl SubscriptionClientT for Client {
 
 		let res = call_with_timeout(self.request_timeout, send_back_rx).await;
 
-		let (rx, rx_lagged, method) = match res {
+		let (rx, method) = match res {
 			Ok(Ok(val)) => val,
 			Ok(Err(err)) => return Err(err),
 			Err(_) => return Err(self.disconnect_reason().await),
 		};
 
-		Ok(Subscription::new(self.to_back.clone(), rx, SubscriptionKind::Method(method), rx_lagged))
+		Ok(Subscription::new(self.to_back.clone(), rx, SubscriptionKind::Method(method)))
 	}
 }
 
@@ -746,7 +746,7 @@ fn handle_backend_messages<R: TransportReceiverT>(
 				}
 				// Subscription response.
 				else if let Ok(response) = serde_json::from_slice::<SubscriptionResponse<_>>(raw) {
-					if let Err(Some(sub_id)) = process_subscription_response(&mut manager.lock(), response) {
+					if let Some(sub_id) = process_subscription_response(&mut manager.lock(), response) {
 						return Ok(Some(FrontToBack::SubscriptionClosed(sub_id)));
 					}
 				}
@@ -896,11 +896,10 @@ async fn handle_frontend_messages<S: TransportSenderT>(
 		}
 		// User called `register_notification` on the front-end.
 		FrontToBack::RegisterNotification(reg) => {
-			let (subscribe_tx, subscribe_rx) = mpsc::channel(max_buffer_capacity_per_subscription);
-			let rx_lagged = subscribe_tx.clone();
+			let (subscribe_tx, subscribe_rx) = subscription_channel(max_buffer_capacity_per_subscription);
 
 			if manager.lock().insert_notification_handler(&reg.method, subscribe_tx).is_ok() {
-				let _ = reg.send_back.send(Ok((subscribe_rx, rx_lagged, reg.method)));
+				let _ = reg.send_back.send(Ok((subscribe_rx, reg.method)));
 			} else {
 				let _ = reg.send_back.send(Err(RegisterMethodError::AlreadyRegistered(reg.method).into()));
 			}

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -674,7 +674,7 @@ impl SubscriptionClientT for Client {
 			return Err(self.disconnect_reason().await);
 		}
 
-		let (notifs_rx, sub_id) = match call_with_timeout(self.request_timeout, send_back_rx).await {
+		let (notifs_rx, rx_lagged, sub_id) = match call_with_timeout(self.request_timeout, send_back_rx).await {
 			Ok(Ok(val)) => val,
 			Ok(Err(err)) => return Err(err),
 			Err(_) => return Err(self.disconnect_reason().await),
@@ -682,7 +682,7 @@ impl SubscriptionClientT for Client {
 
 		rx_log_from_json(&Response::new(ResponsePayload::success_borrowed(&sub_id), id_unsub), self.max_log_length);
 
-		Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id)))
+		Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id), rx_lagged))
 	}
 
 	/// Subscribe to a specific method.
@@ -707,13 +707,13 @@ impl SubscriptionClientT for Client {
 
 		let res = call_with_timeout(self.request_timeout, send_back_rx).await;
 
-		let (notifs_rx, method) = match res {
+		let (rx, rx_lagged, method) = match res {
 			Ok(Ok(val)) => val,
 			Ok(Err(err)) => return Err(err),
 			Err(_) => return Err(self.disconnect_reason().await),
 		};
 
-		Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Method(method)))
+		Ok(Subscription::new(self.to_back.clone(), rx, SubscriptionKind::Method(method), rx_lagged))
 	}
 }
 
@@ -897,9 +897,10 @@ async fn handle_frontend_messages<S: TransportSenderT>(
 		// User called `register_notification` on the front-end.
 		FrontToBack::RegisterNotification(reg) => {
 			let (subscribe_tx, subscribe_rx) = mpsc::channel(max_buffer_capacity_per_subscription);
+			let rx_lagged = subscribe_tx.clone();
 
 			if manager.lock().insert_notification_handler(&reg.method, subscribe_tx).is_ok() {
-				let _ = reg.send_back.send(Ok((subscribe_rx, reg.method)));
+				let _ = reg.send_back.send(Ok((subscribe_rx, rx_lagged, reg.method)));
 			} else {
 				let _ = reg.send_back.send(Err(RegisterMethodError::AlreadyRegistered(reg.method).into()));
 			}

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -247,7 +247,7 @@ pub enum SubscriptionError {
 	/// The subscription lagged too far behind i.e, could not keep up with the server.
 	#[error("The subscription was too slow and at least one message was lost")]
 	TooSlow,
-	/// The subscription was closed because the connection was closed.
+	/// The subscription was closed.
 	#[error("The subscription was closed")]
 	Closed,
 	/// The subscription notification parsing failed.

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -314,7 +314,7 @@ impl<Notif> Subscription<Notif> {
 	pub fn close_reason(&self) -> Option<SubscriptionCloseReason> {
 		let lagged = self.rx.lagged.has_lagged();
 
-		// The `is_closed` is only set if the subscription has been polled
+		// `is_closed` is only set if the subscription has been polled
 		// and that is why lagged is checked here as well.
 		if !self.is_closed && !lagged {
 			return None;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [dev-dependencies]
 anyhow = "1"
-async-broadcast = "0.7"
 futures = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-native-tls"] }
 tracing = "0.1.34"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dev-dependencies]
 anyhow = "1"
+async-broadcast = "0.7"
 futures = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-native-tls"] }
 tracing = "0.1.34"

--- a/examples/examples/client_subscription_drop_oldest_item.rs
+++ b/examples/examples/client_subscription_drop_oldest_item.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
 	tokio::time::sleep(Duration::from_secs(1)).await;
 
 	// The subscription starts from zero but you can
-	// noticed that many items have been replaced
+	// notice that many items have been replaced
 	// because the subscription wasn't polled.
 	for _ in 0..10 {
 		let n = sub.next().await.unwrap();

--- a/examples/examples/client_subscription_drop_oldest_item.rs
+++ b/examples/examples/client_subscription_drop_oldest_item.rs
@@ -1,0 +1,118 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use futures::{Stream, StreamExt};
+use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
+use jsonrpsee::core::DeserializeOwned;
+use jsonrpsee::rpc_params;
+use jsonrpsee::server::{RpcModule, Server, SubscriptionMessage};
+use jsonrpsee::ws_client::WsClientBuilder;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	tracing_subscriber::FmtSubscriber::builder()
+		.with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+		.try_init()
+		.expect("setting default subscriber failed");
+
+	let addr = run_server().await?;
+	let url = format!("ws://{}", addr);
+
+	let client = WsClientBuilder::default().build(&url).await?;
+
+	let sub: Subscription<i32> = client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await?;
+
+	// drop oldest messages from subscription:
+	let mut sub = drop_oldest_when_lagging(sub, 10);
+
+	// Simulate that polling takes a long time.
+	tokio::time::sleep(Duration::from_secs(1)).await;
+
+	// The subscription starts from zero but you can
+	// noticed that many items have been replaced
+	// because the subscription wasn't polled.
+	for _ in 0..10 {
+		let n = sub.next().await.unwrap();
+		tracing::info!("sub item: {n}");
+	}
+
+	Ok(())
+}
+
+fn drop_oldest_when_lagging<T: Clone + DeserializeOwned + Send + Sync + 'static>(
+	mut sub: Subscription<T>,
+	buffer_size: usize,
+) -> impl Stream<Item = T> {
+	let (mut tx, rx) = async_broadcast::broadcast(buffer_size);
+
+	tx.set_overflow(true);
+
+	tokio::spawn(async move {
+		// poll sub, sending msgs to our chan which throws stuff away
+		while let Some(n) = sub.next().await {
+			let msg = match n {
+				Ok(msg) => msg,
+				Err(e) => {
+					tracing::error!("Failed to recv subscription message: {e}");
+					continue;
+				}
+			};
+
+			tx.try_broadcast(msg).expect("Infallible in overflowing mode; qed");
+		}
+	});
+	rx
+}
+
+async fn run_server() -> anyhow::Result<SocketAddr> {
+	let server = Server::builder().build("127.0.0.1:0").await?;
+	let mut module = RpcModule::new(());
+	module
+		.register_subscription("subscribe_hello", "s_hello", "unsubscribe_hello", |_, pending, _| async move {
+			let sub = pending.accept().await.unwrap();
+
+			for i in 0..usize::MAX {
+				let msg = SubscriptionMessage::from_json(&i).unwrap();
+				sub.send(msg).await.unwrap();
+				tokio::time::sleep(Duration::from_millis(10)).await;
+			}
+
+			Ok(())
+		})
+		.unwrap();
+	let addr = server.local_addr()?;
+
+	let handle = server.start(module);
+
+	// In this example we don't care about doing shutdown so let's it run forever.
+	// You may use the `ServerHandle` to shut it down or manage it yourself.
+	tokio::spawn(handle.stopped());
+
+	Ok(addr)
+}

--- a/server/src/middleware/http/host_filter.rs
+++ b/server/src/middleware/http/host_filter.rs
@@ -47,7 +47,7 @@ pub struct HostFilterLayer(Option<Arc<WhitelistedHosts>>);
 
 impl HostFilterLayer {
 	/// Enables host filtering and allow only the specified hosts.
-	pub fn new<T: IntoIterator<Item = U>, U: TryInto<Authority>>(allow_only: T) -> Result<Self, AuthorityError>
+	pub fn new<T, U>(allow_only: T) -> Result<Self, AuthorityError>
 	where
 		T: IntoIterator<Item = U>,
 		U: TryInto<Authority, Error = AuthorityError>,

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -121,7 +121,6 @@ async fn ws_unsubscription_works() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn ws_unsubscription_works_over_proxy_stream() {
 	init_logger();
 

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -359,7 +359,7 @@ async fn ws_subscription_several_clients_with_drop() {
 }
 
 #[tokio::test]
-async fn ws_subscription_close_on_lagg() {
+async fn ws_subscription_close_on_lagging() {
 	init_logger();
 
 	let server_addr = server_with_subscription().await;
@@ -383,6 +383,14 @@ async fn ws_subscription_close_on_lagg() {
 	// It should be dropped when lagging.
 	assert!(hello_sub.next().with_default_timeout().await.unwrap().is_none());
 
+	// The client should still be useable => make sure it still works.
+	let _hello_req: JsonValue = client.request("say_hello", rpc_params![]).await.unwrap();
+
+	// The same subscription should be possible to register again.
+	let mut other_sub: Subscription<JsonValue> =
+		client.subscribe("subscribe_hello", rpc_params![], "unsubscribe_hello").await.unwrap();
+
+	assert!(other_sub.next().with_default_timeout().await.unwrap().is_some());
 	assert!(client.is_connected());
 }
 


### PR DESCRIPTION
This PR changes adds a new API to the subscription know how the subscription was closed.

It still drops the subscription if it's lagging but the subscription should easily-extendable to
implement specific handling for lagging, see the example below

### Example of custom subscription logic

```rust
fn drop_oldest_when_lagging<T: Clone + DeserializeOwned + Send + Sync + 'static>(
	mut sub: Subscription<T>,
	buffer_size: usize,
) -> impl Stream<Item = T> {
	let (mut tx, rx) = async_broadcast::broadcast(buffer_size);

	tx.set_overflow(true);

	tokio::spawn(async move {
		// poll sub, sending msgs to our chan which throws stuff away
		while let Some(n) = sub.next().await {
			let msg = match n {
				Ok(msg) => msg,
				Err(e) => {
					tracing::error!("Failed to recv subscription message: {e}");
					continue;
				}
			};

			tx.try_broadcast(msg).expect("Infallible in overflowing mode; qed");
		}
	});
	rx
}
```

Resolves https://github.com/paritytech/jsonrpsee/issues/1291