### PR TITLE
feat: RpcModule::from_arc

### DIFF
--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -507,12 +507,14 @@ pub struct RpcModule<Context> {
 impl<Context> RpcModule<Context> {
 	/// Create a new module with a given shared `Context`.
 	pub fn new(ctx: Context) -> Self {
-		Self { ctx: Arc::new(ctx), methods: Default::default() }
+		Self::from_arc(Arc::new(ctx))
 	}
 
-	/// Get a reference to the shared `Context`.
-	pub fn context(&self) -> &Arc<Context> {
-		&self.ctx
+	/// Create a new module from an already shared `Context`.
+	///
+	/// This is useful if `Context` needs to be shared outside of an [`RpcModule`].
+	pub fn from_arc(ctx: Arc<Context>) -> Self {
+		Self { ctx, methods: Default::default() }
 	}
 
 	/// Transform a module into an `RpcModule<()>` (unit context).

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -510,6 +510,11 @@ impl<Context> RpcModule<Context> {
 		Self { ctx: Arc::new(ctx), methods: Default::default() }
 	}
 
+	/// Get a reference to the shared `Context`.
+	pub fn context(&self) -> &Arc<Context> {
+		&self.ctx
+	}
+
 	/// Transform a module into an `RpcModule<()>` (unit context).
 	pub fn remove_context(self) -> RpcModule<()> {
 		let mut module = RpcModule::new(());


### PR DESCRIPTION
I want to share state between my `RpcModule` and another service.
Because `RpcModule` only `Deref`s to `Context`, I have to have a _second_ `Arc`, and my handlers have to accept `Arc<Arc<Context>>`.

This would allow me to clone the inner context, obviating the need for the double indirection.

Alternative approaches:
- impl `Deref<Target = Arc<Context>>`. I think this is backwards-compatible.
- `RpcModule::new(_: impl Into<Arc<Context>>)`, which is backwards-compatible.
  I could clone the arc before passing it to the ctor, where it would stay without a new `Arc`