### PR TITLE
chore: export AlreadyStoppedError

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -40,7 +40,7 @@ pub mod middleware;
 #[cfg(test)]
 mod tests;
 
-pub use future::{stop_channel, ConnectionGuard, ConnectionPermit, ServerHandle, StopHandle};
+pub use future::{stop_channel, AlreadyStoppedError, ConnectionGuard, ConnectionPermit, ServerHandle, StopHandle};
 pub use jsonrpsee_core::error::RegisterMethodError;
 pub use jsonrpsee_core::server::*;
 pub use jsonrpsee_core::{id_providers::*, traits::IdProvider};


### PR DESCRIPTION
part of public API, but can't be imported