### PR TITLE
fix(client): support batched notifications

### DIFF
--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -192,6 +192,26 @@ async fn notification_handler_works() {
 }
 
 #[tokio::test]
+async fn batched_notification_handler_works() {
+	let server = WebSocketTestServer::with_hardcoded_notification(
+		"127.0.0.1:0".parse().unwrap(),
+		server_batched_notification("test", "batched server originated notification works".into()),
+	)
+	.with_default_timeout()
+	.await
+	.unwrap();
+
+	let uri = to_ws_uri_string(server.local_addr());
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	{
+		let mut nh: Subscription<String> =
+			client.subscribe_to_method("test").with_default_timeout().await.unwrap().unwrap();
+		let response: String = nh.next().with_default_timeout().await.unwrap().unwrap().unwrap();
+		assert_eq!("batched server originated notification works".to_owned(), response);
+	}
+}
+
+#[tokio::test]
 async fn notification_close_on_lagging() {
 	init_logger();
 

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -186,6 +186,11 @@ pub fn server_notification(method: &str, params: Value) -> String {
 	format!(r#"{{"jsonrpc":"2.0","method":"{}", "params":{} }}"#, method, serde_json::to_string(&params).unwrap())
 }
 
+/// Batched server originated notification
+pub fn server_batched_notification(method: &str, params: Value) -> String {
+	format!(r#"[{{"jsonrpc":"2.0","method":"{}", "params":{} }}]"#, method, serde_json::to_string(&params).unwrap())
+}
+
 pub async fn http_request(body: Body, uri: Uri) -> Result<HttpResponse, String> {
 	let client = hyper::Client::new();
 	http_post(client, body, uri).await


### PR DESCRIPTION
As per the examples in the [jsonrpc specification](https://www.jsonrpc.org/specification#examples), it is valid to include only notifications in a batch. 

rpc call Batch (all notifications):
```
--> [
        {"jsonrpc": "2.0", "method": "notify_sum", "params": [1,2,4]},
        {"jsonrpc": "2.0", "method": "notify_hello", "params": [7]}
    ]
<-- //Nothing is returned for all notification batches
```

This change adds support for handling this use case.

I ran into this while trying to leverage this library for a proof of conept I was working on a little while back,. My particular use case was using the client crate of this library to communicate with an existing service. I realized I never upstreamed this change and figured it might be useful to others.

I didn't see any contribution guidelines for this project, so please let me know if I'm missing any information. If you're not accepting external contributions I understand and can close this out. Thanks for your time.