### PR TITLE
fix(proc-macros): some types are missing when using proc-macros but only the `server-core` feature is enabled

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,7 +49,6 @@ cfg_http_helpers! {
 cfg_server! {
 	pub mod id_providers;
 	pub mod server;
-
 }
 
 cfg_client! {
@@ -75,6 +74,11 @@ pub mod __reexports {
 	pub use async_trait::async_trait;
 	pub use serde;
 	pub use serde_json;
+	pub use tracing;
+
+	cfg_client_or_server! {
+		pub use tokio;
+	}
 }
 
 pub use beef::Cow;

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -26,6 +26,15 @@ macro_rules! cfg_http_helpers {
 	};
 }
 
+macro_rules! cfg_client_or_server {
+	($($item:item)*) => {
+		$(
+			#[cfg(any(feature = "client", feature = "server"))]
+			$item
+		)*
+	}
+}
+
 macro_rules! cfg_async_client {
 	($($item:item)*) => {
 		$(

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -64,7 +64,7 @@ impl RpcDescription {
 			let mut method_sig = method.signature.clone();
 
 			if method.raw_method {
-				let context_ty = self.jrps_server_item(quote! { ConnectionDetails });
+				let context_ty = self.jrps_server_item(quote! { core::server::ConnectionDetails });
 				// Add `ConnectionDetails` as the second parameter to the signature.
 				let context: syn::FnArg = syn::parse_quote!(connection_details: #context_ty);
 				method_sig.sig.inputs.insert(1, context);
@@ -78,7 +78,7 @@ impl RpcDescription {
 
 		let subscriptions = self.subscriptions.iter().map(|sub| {
 			let docs = &sub.docs;
-			let subscription_sink_ty = self.jrps_server_item(quote! { PendingSubscriptionSink });
+			let subscription_sink_ty = self.jrps_server_item(quote! { core::server::PendingSubscriptionSink });
 			// Add `SubscriptionSink` as the second input parameter to the signature.
 			let subscription_sink: syn::FnArg = syn::parse_quote!(subscription_sink: #subscription_sink_ty);
 			let mut sub_sig = sub.signature.clone();
@@ -97,7 +97,7 @@ impl RpcDescription {
 	}
 
 	fn render_into_rpc(&self) -> Result<TokenStream2, syn::Error> {
-		let rpc_module = self.jrps_server_item(quote! { RpcModule });
+		let rpc_module = self.jrps_server_item(quote! { core::server::RpcModule });
 
 		let mut registered = HashSet::new();
 		let mut errors = Vec::new();
@@ -136,7 +136,7 @@ impl RpcDescription {
 				// called..
 				let (parsing, params_seq) = self.render_params_decoding(&method.params, None);
 
-				let into_response = self.jrps_server_item(quote! { IntoResponse });
+				let into_response = self.jrps_server_item(quote! { core::server::IntoResponse });
 
 				check_name(&rpc_method_name, rust_method_name.span());
 
@@ -187,8 +187,8 @@ impl RpcDescription {
 				// `params_seq` is the comma-delimited sequence of parameters.
 				let pending = proc_macro2::Ident::new("pending", rust_method_name.span());
 				let (parsing, params_seq) = self.render_params_decoding(&sub.params, Some(pending));
-				let sub_err = self.jrps_server_item(quote! { SubscriptionCloseResponse });
-				let into_sub_response = self.jrps_server_item(quote! { IntoSubscriptionCloseResponse });
+				let sub_err = self.jrps_server_item(quote! { core::server::SubscriptionCloseResponse });
+				let into_sub_response = self.jrps_server_item(quote! { core::server::IntoSubscriptionCloseResponse });
 
 				check_name(&rpc_sub_name, rust_method_name.span());
 				check_name(&rpc_unsub_name, rust_method_name.span());
@@ -313,10 +313,10 @@ impl RpcDescription {
 
 		let params_fields_seq = params.iter().map(|(name, _)| name);
 		let params_fields = quote! { #(#params_fields_seq),* };
-		let tracing = self.jrps_server_item(quote! { tracing });
-		let sub_err = self.jrps_server_item(quote! { SubscriptionCloseResponse });
-		let response_payload = self.jrps_server_item(quote! { ResponsePayload });
-		let tokio = self.jrps_server_item(quote! { tokio });
+		let tracing = self.jrps_server_item(quote! { core::__reexports::tracing });
+		let sub_err = self.jrps_server_item(quote! { core::server::SubscriptionCloseResponse });
+		let response_payload = self.jrps_server_item(quote! { core::server::ResponsePayload });
+		let tokio = self.jrps_server_item(quote! { core::__reexports::tokio });
 
 		// Code to decode sequence of parameters from a JSON array.
 		let decode_array = {


### PR DESCRIPTION
`Cargo.toml`:

```toml
jsonrpsee = { version = "0.22.4", features = ["client-core", "server-core", "macros"] }
```

Error:

```
error[E0433]: failed to resolve: could not find `RpcModule` in `jsonrpsee`
  --> client/rpc/api/src/debug.rs:25:1
   |
25 | #[rpc(client, server, namespace = "debug")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `RpcModule` in `jsonrpsee`
   |
   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
error[E0433]: failed to resolve: could not find `ResponsePayload` in `jsonrpsee`
  --> client/rpc/api/src/debug.rs:25:1
   |
25 | #[rpc(client, server, namespace = "debug")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `ResponsePayload` in `jsonrpsee`
```