### PR TITLE
fix(proc-macros): make feature `server-core` compile

### DIFF
--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -78,8 +78,11 @@ cfg_client_transport! {
 
 cfg_server! {
 	pub use jsonrpsee_server as server;
-	pub use jsonrpsee_core::server::*;
 	pub use tokio;
+}
+
+cfg_server_core! {
+	pub use jsonrpsee_core::server::*;
 }
 
 cfg_proc_macros! {

--- a/jsonrpsee/src/macros.rs
+++ b/jsonrpsee/src/macros.rs
@@ -56,6 +56,12 @@ macro_rules! cfg_server {
 	}
 }
 
+macro_rules! cfg_server_core {
+	($($item:item)*) => {
+		cfg_feature!("server-core", $($item)*);
+	}
+}
+
 macro_rules! cfg_proc_macros {
 	($($item:item)*) => {
 		cfg_feature!("jsonrpsee-proc-macros", $($item)*);


### PR DESCRIPTION
Similar to #1359 and kudos to @koushiro for detecting this but I prefer not re-export tokio