### PR TITLE
fix(proc-macros): re-export tokio for params parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 	"test-utils",
 	"tests",
 	"tests/wasm-tests",
+	"tests/proc-macro-core",
 	"types",
 ]
 resolver = "2"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -76,6 +76,7 @@ pub mod __reexports {
 	pub use serde;
 	pub use serde_json;
 
+	// Needed for the params parsing in the proc macro API.
 	cfg_client_or_server! {
 		pub use tokio;
 	}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -75,6 +75,10 @@ pub mod __reexports {
 	pub use async_trait::async_trait;
 	pub use serde;
 	pub use serde_json;
+
+	cfg_client_or_server! {
+		pub use tokio;
+	}
 }
 
 pub use beef::Cow;

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -20,6 +20,15 @@ macro_rules! cfg_server {
 	};
 }
 
+macro_rules! cfg_client_or_server {
+	($($item:item)*) => {
+		$(
+			#[cfg(any(feature = "client", feature = "server"))]
+			$item
+		)*
+	}
+}
+
 macro_rules! cfg_http_helpers {
  ($($item:item)*) => {
 		cfg_feature!("http-helpers", $($item)*);

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -316,7 +316,7 @@ impl RpcDescription {
 		let tracing = self.jrps_server_item(quote! { tracing });
 		let sub_err = self.jrps_server_item(quote! { SubscriptionCloseResponse });
 		let response_payload = self.jrps_server_item(quote! { ResponsePayload });
-		let tokio = self.jrps_server_item(quote! { tokio });
+		let tokio = self.jrps_server_item(quote! { core::__reexports::tokio });
 
 		// Code to decode sequence of parameters from a JSON array.
 		let decode_array = {

--- a/tests/proc-macro-core/Cargo.toml
+++ b/tests/proc-macro-core/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 
 [dependencies]
 jsonrpsee = { path = "../../jsonrpsee", features = ["server-core", "client-core", "macros"] }
+serde = "1.0"

--- a/tests/proc-macro-core/Cargo.toml
+++ b/tests/proc-macro-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpsee-proc-macro-core"
-description = "Test crate to make sure that jsonrpsee core compiles"
+description = "Test crate for the proc-macro API to make sure that it compiles with the core features"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/tests/proc-macro-core/Cargo.toml
+++ b/tests/proc-macro-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "jsonrpsee-proc-macro-core"
+description = "Test crate to make sure that jsonrpsee core compiles"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+jsonrpsee = { path = "../../jsonrpsee", features = ["server-core", "client-core", "macros"] }

--- a/tests/proc-macro-core/src/lib.rs
+++ b/tests/proc-macro-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! Test module for the proc-macro API to make sure that is compiles with core features.
+//! Test module for the proc-macro API to make sure that it compiles with core features.
 
 use jsonrpsee::core::{async_trait, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;

--- a/tests/proc-macro-core/src/lib.rs
+++ b/tests/proc-macro-core/src/lib.rs
@@ -1,0 +1,56 @@
+//! Test module for the proc-macro API to make sure that is compiles with core features.
+
+use jsonrpsee::core::{async_trait, SubscriptionResult};
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::types::ErrorObjectOwned;
+use jsonrpsee::{ConnectionDetails, PendingSubscriptionSink, SubscriptionMessage};
+
+#[rpc(client, server)]
+pub trait Api {
+	#[method(name = "sync_call")]
+	fn sync_call(&self, _x: String) -> Result<String, ErrorObjectOwned>;
+
+	#[method(name = "async_call")]
+	async fn async_call(&self, _x: String) -> Result<String, ErrorObjectOwned>;
+
+	#[subscription(name = "subscribe", item = String)]
+	async fn sub(&self, _x: String) -> SubscriptionResult;
+
+	#[subscription(name = "subscribeSync", item = String)]
+	fn sync_sub(&self, _x: String) -> SubscriptionResult;
+
+	#[method(name = "blocking", blocking)]
+	fn blocking_method(&self, _x: String) -> Result<u16, ErrorObjectOwned>;
+
+	#[method(name = "raw", raw_method)]
+	async fn raw(&self, _x: String) -> Result<u16, ErrorObjectOwned>;
+}
+
+#[async_trait]
+impl ApiServer for () {
+	fn sync_call(&self, _x: String) -> Result<String, ErrorObjectOwned> {
+		Ok("sync_call".to_string())
+	}
+
+	async fn async_call(&self, _x: String) -> Result<String, ErrorObjectOwned> {
+		Ok("async_call".to_string())
+	}
+
+	async fn sub(&self, pending: PendingSubscriptionSink, _x: String) -> SubscriptionResult {
+		let sink = pending.accept().await?;
+		sink.send(SubscriptionMessage::from("msg")).await?;
+		Ok(())
+	}
+
+	fn sync_sub(&self, _sink: PendingSubscriptionSink, _x: String) -> SubscriptionResult {
+		Ok(())
+	}
+
+	fn blocking_method(&self, _x: String) -> Result<u16, ErrorObjectOwned> {
+		Ok(42)
+	}
+
+	async fn raw(&self, _conn: ConnectionDetails, _x: String) -> Result<u16, ErrorObjectOwned> {
+		Ok(42)
+	}
+}

--- a/tests/proc-macro-core/src/lib.rs
+++ b/tests/proc-macro-core/src/lib.rs
@@ -4,7 +4,6 @@ use jsonrpsee::core::{async_trait, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::{ConnectionDetails, PendingSubscriptionSink, SubscriptionMessage};
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -26,31 +25,31 @@ pub struct PubSubItem {
 #[rpc(client, server)]
 pub trait Api {
 	#[method(name = "sync_call")]
-	fn sync_call(&self, _x: String) -> Result<String, ErrorObjectOwned>;
+	fn sync_call(&self, a: String) -> Result<String, ErrorObjectOwned>;
 
 	#[method(name = "async_call")]
-	async fn async_call(&self, _x: String) -> Result<String, ErrorObjectOwned>;
+	async fn async_call(&self, a: String) -> Result<String, ErrorObjectOwned>;
 
 	#[subscription(name = "subscribe", item = PubSubItem)]
-	async fn sub(&self, kind: PubSubKind, _x: PubSubParams) -> SubscriptionResult;
+	async fn sub(&self, kind: PubSubKind, p: PubSubParams) -> SubscriptionResult;
 
 	#[subscription(name = "subscribeSync", item = String)]
-	fn sync_sub(&self, _x: String) -> SubscriptionResult;
+	fn sync_sub(&self, a: String) -> SubscriptionResult;
 
 	#[method(name = "blocking", blocking)]
-	fn blocking_method(&self, _x: String) -> Result<u16, ErrorObjectOwned>;
+	fn blocking_method(&self, a: String) -> Result<u16, ErrorObjectOwned>;
 
 	#[method(name = "raw", raw_method)]
-	async fn raw(&self, _x: String) -> Result<u16, ErrorObjectOwned>;
+	async fn raw(&self, a: String) -> Result<u16, ErrorObjectOwned>;
 }
 
 #[async_trait]
 impl ApiServer for () {
-	fn sync_call(&self, _x: String) -> Result<String, ErrorObjectOwned> {
+	fn sync_call(&self, _: String) -> Result<String, ErrorObjectOwned> {
 		Ok("sync_call".to_string())
 	}
 
-	async fn async_call(&self, _x: String) -> Result<String, ErrorObjectOwned> {
+	async fn async_call(&self, _: String) -> Result<String, ErrorObjectOwned> {
 		Ok("async_call".to_string())
 	}
 
@@ -60,15 +59,15 @@ impl ApiServer for () {
 		Ok(())
 	}
 
-	fn sync_sub(&self, _sink: PendingSubscriptionSink, _x: String) -> SubscriptionResult {
+	fn sync_sub(&self, _: PendingSubscriptionSink, _: String) -> SubscriptionResult {
 		Ok(())
 	}
 
-	fn blocking_method(&self, _x: String) -> Result<u16, ErrorObjectOwned> {
+	fn blocking_method(&self, _: String) -> Result<u16, ErrorObjectOwned> {
 		Ok(42)
 	}
 
-	async fn raw(&self, _conn: ConnectionDetails, _x: String) -> Result<u16, ErrorObjectOwned> {
+	async fn raw(&self, _: ConnectionDetails, _: String) -> Result<u16, ErrorObjectOwned> {
 		Ok(42)
 	}
 }

--- a/tests/proc-macro-core/src/lib.rs
+++ b/tests/proc-macro-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! Test module for the proc-macro API to make sure that it compiles with core features.
+//! Test module for the proc-macro API to make sure that it compiles with the core features.
 
 use jsonrpsee::core::{async_trait, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;


### PR DESCRIPTION
Follow-up on #1360 and I forgot that we use tokio in param parsing.

I also added a test crate to ensure that it compiles

