### PR TITLE
fix(proc macros): don't use `params` as name

### DIFF
--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -243,7 +243,7 @@ impl RpcDescription {
 				}
 
 				quote!({
-					let mut #p #jsonrpsee::core::params::ObjectParams::new();
+					let mut #p = #jsonrpsee::core::params::ObjectParams::new();
 					#(
 						if let Err(err) = #p.insert( #params_insert ) {
 							panic!("Parameter `{}` cannot be serialized: {:?}", stringify!( #params_insert ), err);

--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -226,7 +226,9 @@ impl RpcDescription {
 		}
 
 		if params.iter().any(|(param, _)| param.ident == p) {
-			panic!("Cannot use `{}` as a parameter name", ILLEGAL_PARAM_NAME);
+			panic!(
+				"Cannot use `{}` as a parameter name because it's overlapping with an internal variable in the generated code. Change it something else to make it work", ILLEGAL_PARAM_NAME
+			);
 		}
 
 		match param_kind {

--- a/tests/proc-macro-core/src/lib.rs
+++ b/tests/proc-macro-core/src/lib.rs
@@ -31,7 +31,7 @@ pub trait Api {
 	async fn async_call(&self, a: String) -> Result<String, ErrorObjectOwned>;
 
 	#[subscription(name = "subscribe", item = PubSubItem)]
-	async fn sub(&self, kind: PubSubKind, p: PubSubParams) -> SubscriptionResult;
+	async fn sub(&self, kind: PubSubKind, params: PubSubParams) -> SubscriptionResult;
 
 	#[subscription(name = "subscribeSync", item = String)]
 	fn sync_sub(&self, a: String) -> SubscriptionResult;


### PR DESCRIPTION
Because jsonrpsee's internal proc macro code was using `params` as internal variable name it could conflict and with `params` in the user's API in such case it may try to overwrite the "wrong" variable.

In this PR I have renamed this internal variable to something much weirder which should be quite unlikely that anyone will use and panic if those collide to make it easier to debug.

Close #1362 

