### PR TITLE
refactor: use rustls-platform-verifier cert store

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -39,7 +39,6 @@ tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros"] }
 [features]
 default = ["tls"]
 
-# Internal feature to indicate whether TLS is enabled.
 # Does nothing on its own.
 tls = ["hyper-rustls", "rustls", "rustls-platform-verifier"]
 

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -17,8 +17,7 @@ publish = true
 async-trait = "0.1"
 hyper = { version = "1.3", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27.1", optional = true, default-features = false, features = ["http1", "http2", "tls12", "logging", "rustls-platform-verifier", "ring"] }
-rustls-platform-verifier = { version = "0.3", optional = true }
-hyper-util = { version = "0.1.1", features = ["client", "client-legacy"] }
+hyper-util = { version = "0.1.1", features = ["client", "client-legacy", "tokio", "http1", "http2"] }
 http-body = "1"
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["client", "http-helpers"] }
@@ -41,7 +40,7 @@ default = ["tls"]
 
 # Internal feature to indicate whether TLS is enabled.
 # Does nothing on its own.
-tls = ["hyper-rustls", "rustls", "rustls-platform-verifier"]
+tls = ["hyper-rustls", "rustls"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 [dependencies]
 async-trait = "0.1"
 hyper = { version = "1.3", features = ["client", "http1", "http2"] }
-hyper-rustls = { version = "0.27.1", default-features = false, features = ["http1", "http2", "tls12", "logging", "ring", "rustls-platform-verifier"], optional = true }
+hyper-rustls = { version = "0.27.1", default-features = false, features = ["http1", "http2", "tls12", "logging", "ring"], optional = true }
 hyper-util = { version = "0.1.1", features = ["client", "client-legacy", "tokio", "http1", "http2"] }
 http-body = "1"
 jsonrpsee-types = { workspace = true }

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -39,7 +39,6 @@ tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros"] }
 [features]
 default = ["tls"]
 
-# Does nothing on its own.
 tls = ["hyper-rustls", "rustls", "rustls-platform-verifier"]
 
 [package.metadata.docs.rs]

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -16,12 +16,13 @@ publish = true
 [dependencies]
 async-trait = "0.1"
 hyper = { version = "1.3", features = ["client", "http1", "http2"] }
-hyper-rustls = { version = "0.27.1", optional = true, default-features = false, features = ["http1", "http2", "tls12", "logging", "rustls-platform-verifier", "ring"] }
+hyper-rustls = { version = "0.27.1", default-features = false, features = ["http1", "http2", "tls12", "logging", "ring", "rustls-platform-verifier"], optional = true }
 hyper-util = { version = "0.1.1", features = ["client", "client-legacy", "tokio", "http1", "http2"] }
 http-body = "1"
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["client", "http-helpers"] }
-rustls = { version = "0.23.7", default-features = false, optional = true }
+rustls = { version = "0.23.7", default-features = false, optional = true, features = ["logging", "std", "tls12", "ring"] }
+rustls-platform-verifier = { version = "0.3", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
@@ -40,7 +41,7 @@ default = ["tls"]
 
 # Internal feature to indicate whether TLS is enabled.
 # Does nothing on its own.
-tls = ["hyper-rustls", "rustls"]
+tls = ["hyper-rustls", "rustls", "rustls-platform-verifier"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -16,11 +16,13 @@ publish = true
 [dependencies]
 async-trait = "0.1"
 hyper = { version = "1.3", features = ["client", "http1", "http2"] }
-hyper-rustls = { version = "0.27.1", optional = true, default-features = false, features = ["http1", "http2", "tls12", "logging"] }
+hyper-rustls = { version = "0.27.1", optional = true, default-features = false, features = ["http1", "http2", "tls12", "logging", "rustls-platform-verifier", "ring"] }
+rustls-platform-verifier = { version = "0.3", optional = true }
 hyper-util = { version = "0.1.1", features = ["client", "client-legacy"] }
 http-body = "1"
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["client", "http-helpers"] }
+rustls = { version = "0.23.7", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
@@ -35,13 +37,11 @@ jsonrpsee-test-utils = { path = "../../test-utils" }
 tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros"] }
 
 [features]
-default = ["native-tls"]
-native-tls = ["hyper-rustls/native-tokio", "hyper-rustls/ring", "__tls"]
-webpki-tls = ["hyper-rustls/webpki-tokio", "hyper-rustls/ring", "__tls"]
+default = ["tls"]
 
 # Internal feature to indicate whether TLS is enabled.
 # Does nothing on its own.
-__tls = ["hyper-rustls"]
+tls = ["hyper-rustls", "rustls", "rustls-platform-verifier"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -48,7 +48,7 @@ use tower::{Layer, Service};
 use tracing::instrument;
 
 #[cfg(feature = "tls")]
-use crate::{CertificateStore, TlsConfig};
+use crate::{CertificateStore, CustomCertStore};
 
 /// HTTP client builder.
 ///
@@ -113,19 +113,6 @@ impl<L> HttpClientBuilder<L> {
 		self
 	}
 
-	/// Force to use rustls-platform-verifier as certification store.
-	/// If you want to use a custom certificate store, use [`HttpClientBuilder::with_tls_config`] instead.
-	/// This is enabled with the default settings and features.
-	///
-	/// # Optional
-	///
-	/// This requires the optional `tls` feature.
-	#[cfg(feature = "tls")]
-	pub fn with_rustls_platform_verifier(mut self) -> Self {
-		self.certificate_store = CertificateStore::Native;
-		self
-	}
-
 	/// Force to use a custom certificate store.
 	///
 	/// # Optional
@@ -135,7 +122,7 @@ impl<L> HttpClientBuilder<L> {
 	/// # Example
 	///
 	/// ```no_run
-	/// use jsonrpsee_http_client::HttpClientBuilder;
+	/// use jsonrpsee_http_client::{HttpClientBuilder, CustomCertStore};
 	/// use rustls::{
 	///     client::danger::{self, HandshakeSignatureValid, ServerCertVerified},
 	///     pki_types::{CertificateDer, ServerName, UnixTime},
@@ -180,16 +167,16 @@ impl<L> HttpClientBuilder<L> {
 	///     }
 	/// }
 	///
-	/// let tls_cfg = rustls::ClientConfig::builder()
+	/// let tls_cfg = CustomCertStore::builder()
 	///    .dangerous()
 	///    .with_custom_certificate_verifier(std::sync::Arc::new(NoCertificateVerification))
 	///    .with_no_client_auth();
 	///
 	/// // client builder with disabled certificate verification.
-	/// let client_builder = HttpClientBuilder::new().with_tls_config(tls_cfg);
+	/// let client_builder = HttpClientBuilder::new().with_custom_cert_store(tls_cfg);
 	/// ```
 	#[cfg(feature = "tls")]
-	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {
+	pub fn with_custom_cert_store(mut self, cfg: CustomCertStore) -> Self {
 		self.certificate_store = CertificateStore::Custom(cfg);
 		self
 	}

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -113,9 +113,8 @@ impl<L> HttpClientBuilder<L> {
 		self
 	}
 
-	/// Force to use rustls-platform-verifier to select which certificate store to use.
-	///
-	///
+	/// Force to use rustls-platform-verifier as certification store.
+	/// If you want to use a custom certificate store, use [`HttpClientBuilder::with_tls_config`] instead.
 	/// This is enabled with the default settings and features.
 	///
 	/// # Optional
@@ -136,49 +135,49 @@ impl<L> HttpClientBuilder<L> {
 	/// # Example
 	///
 	/// ```no_run
-	/// use jsonrpsee_ws_client::WsClientBuilder;
+	/// use jsonrpsee_http_client::HttpClientBuilder;
 	/// use rustls::{
-	///	    client::danger::{self, HandshakeSignatureValid, ServerCertVerified},
-	///	    pki_types::{CertificateDer, ServerName, UnixTime},
-	///	    Error,
+	///     client::danger::{self, HandshakeSignatureValid, ServerCertVerified},
+	///     pki_types::{CertificateDer, ServerName, UnixTime},
+	///     Error,
 	/// };
 	///
 	/// #[derive(Debug)]
 	/// struct NoCertificateVerification;
 	///
 	/// impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
-	///	    fn verify_server_cert(
-	///		    &self,
-	///		    _: &CertificateDer<'_>,
-	///		    _: &[CertificateDer<'_>],
-	///		    _: &ServerName<'_>,
-	///		    _: &[u8],
-	///		    _: UnixTime,
-	///	     ) -> Result<ServerCertVerified, Error> {
-	///		    Ok(ServerCertVerified::assertion())
-	///      }
+	///     fn verify_server_cert(
+	///         &self,
+	///         _: &CertificateDer<'_>,
+	///         _: &[CertificateDer<'_>],
+	///         _: &ServerName<'_>,
+	///         _: &[u8],
+	///         _: UnixTime,
+	///     ) -> Result<ServerCertVerified, Error> {
+	///         Ok(ServerCertVerified::assertion())
+	///     }
 	///
 	///     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
 	///         vec![rustls::SignatureScheme::ECDSA_NISTP256_SHA256]
-	///	     }
+	///     }
 	///
-	///	    fn verify_tls12_signature(
+	///     fn verify_tls12_signature(
 	///         &self,
-	///		    _: &[u8],
-	///		    _: &CertificateDer<'_>,
-	///		    _: &rustls::DigitallySignedStruct,
-	///	    ) -> Result<rustls::client::danger::HandshakeSignatureValid, Error> {
-	///		    Ok(HandshakeSignatureValid::assertion())
-	///	    }
+	///         _: &[u8],
+	///         _: &CertificateDer<'_>,
+	///         _: &rustls::DigitallySignedStruct,
+	///     ) -> Result<rustls::client::danger::HandshakeSignatureValid, Error> {
+	///         Ok(HandshakeSignatureValid::assertion())
+	///     }
 	///
-	///	    fn verify_tls13_signature(
-	///		    &self,
-	///		    _: &[u8],
-	///		    _: &CertificateDer<'_>,
-	///		    _: &rustls::DigitallySignedStruct,
-	///	    ) -> Result<HandshakeSignatureValid, Error> {
-	///		    Ok(HandshakeSignatureValid::assertion())
-	///	    }
+	///     fn verify_tls13_signature(
+	///         &self,
+	///         _: &[u8],
+	///         _: &CertificateDer<'_>,
+	///         _: &rustls::DigitallySignedStruct,
+	///     ) -> Result<HandshakeSignatureValid, Error> {
+	///         Ok(HandshakeSignatureValid::assertion())
+	///     }
 	/// }
 	///
 	/// let tls_cfg = rustls::ClientConfig::builder()
@@ -187,7 +186,7 @@ impl<L> HttpClientBuilder<L> {
 	///    .with_no_client_auth();
 	///
 	/// // client builder with disabled certificate verification.
-	/// let client_builder = WsClientBuilder::default().with_tls_config(tls_cfg);
+	/// let client_builder = HttpClientBuilder::new().with_tls_config(tls_cfg);
 	/// ```
 	#[cfg(feature = "tls")]
 	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {
@@ -268,6 +267,7 @@ where
 			..
 		} = self;
 
+		#[allow(unused_mut)]
 		let mut builder = HttpTransportClientBuilder::new()
 			.max_request_size(max_request_size)
 			.max_response_size(max_response_size)

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -267,22 +267,21 @@ where
 			..
 		} = self;
 
-		#[allow(unused_mut)]
-		let mut builder = HttpTransportClientBuilder::new()
-			.max_request_size(max_request_size)
-			.max_response_size(max_response_size)
-			.set_headers(headers)
-			.set_tcp_no_delay(tcp_no_delay)
-			.set_max_logging_length(max_log_length)
-			.set_service(service_builder);
-
-		#[cfg(feature = "tls")]
-		{
-			builder = builder.set_certification_store(certificate_store);
+		let transport = HttpTransportClientBuilder {
+			max_request_size,
+			max_response_size,
+			headers,
+			max_log_length,
+			tcp_no_delay,
+			service_builder,
+			#[cfg(feature = "tls")]
+			certificate_store,
 		}
+		.build(target)
+		.map_err(|e| Error::Transport(e.into()))?;
 
 		Ok(HttpClient {
-			transport: builder.build(target).map_err(|e| Error::Transport(e.into()))?,
+			transport,
 			id_manager: Arc::new(RequestIdManager::new(max_concurrent_requests, id_kind)),
 			request_timeout,
 		})

--- a/client/http-client/src/lib.rs
+++ b/client/http-client/src/lib.rs
@@ -56,11 +56,11 @@ pub type HttpResponse<T = HttpBody> = jsonrpsee_core::http_helpers::Response<T>;
 
 /// Custom TLS configuration.
 #[cfg(feature = "tls")]
-pub type TlsConfig = rustls::ClientConfig;
+pub type CustomCertStore = rustls::ClientConfig;
 
 #[cfg(feature = "tls")]
 #[derive(Debug)]
 pub(crate) enum CertificateStore {
 	Native,
-	Custom(TlsConfig),
+	Custom(CustomCertStore),
 }

--- a/client/http-client/src/lib.rs
+++ b/client/http-client/src/lib.rs
@@ -53,3 +53,14 @@ pub type HttpBody = jsonrpsee_core::http_helpers::Body;
 pub type HttpRequest<T = HttpBody> = jsonrpsee_core::http_helpers::Request<T>;
 /// HTTP response with default body.
 pub type HttpResponse<T = HttpBody> = jsonrpsee_core::http_helpers::Response<T>;
+
+/// Custom TLS configuration.
+#[cfg(feature = "tls")]
+pub type TlsConfig = rustls::ClientConfig;
+
+#[cfg(feature = "tls")]
+#[derive(Debug)]
+pub(crate) enum CertificateStore {
+	Native,
+	Custom(TlsConfig),
+}

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -28,7 +28,7 @@ use url::Url;
 use crate::{HttpBody, HttpRequest, HttpResponse};
 
 #[cfg(feature = "tls")]
-use crate::{CertificateStore, TlsConfig};
+use crate::{CertificateStore, CustomCertStore};
 
 const CONTENT_TYPE_JSON: &str = "application/json";
 
@@ -127,16 +127,9 @@ impl HttpTransportClientBuilder<Identity> {
 }
 
 impl<L> HttpTransportClientBuilder<L> {
-	/// See docs [`crate::HttpClientBuilder::with_rustls_platform_verifier`] for more information.
-	#[cfg(feature = "tls")]
-	pub fn with_rustls_platform_verifier(mut self) -> Self {
-		self.certificate_store = CertificateStore::Native;
-		self
-	}
-
 	/// See docs [`crate::HttpClientBuilder::with_tls_config`] for more information.
 	#[cfg(feature = "tls")]
-	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {
+	pub fn with_custom_cert_store(mut self, cfg: CustomCertStore) -> Self {
 		self.certificate_store = CertificateStore::Custom(cfg);
 		self
 	}

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -223,7 +223,7 @@ impl<L> HttpTransportClientBuilder<L> {
 
 				let https_conn = match certificate_store {
 					CertificateStore::Native => hyper_rustls::HttpsConnectorBuilder::new()
-						.with_platform_verifier()
+						.with_tls_config(rustls_platform_verifier::tls_config())
 						.https_or_http()
 						.enable_all_versions()
 						.wrap_connector(http_conn),

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -227,6 +227,7 @@ impl<L> HttpTransportClientBuilder<L> {
 						.https_or_http()
 						.enable_all_versions()
 						.wrap_connector(http_conn),
+
 					CertificateStore::Custom(tls_config) => hyper_rustls::HttpsConnectorBuilder::new()
 						.with_tls_config(tls_config)
 						.https_or_http()

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -127,7 +127,7 @@ impl HttpTransportClientBuilder<Identity> {
 }
 
 impl<L> HttpTransportClientBuilder<L> {
-	/// See docs [`crate::HttpClientBuilder::with_tls_config`] for more information.
+	/// See docs [`crate::HttpClientBuilder::with_custom_cert_store`] for more information.
 	#[cfg(feature = "tls")]
 	pub fn with_custom_cert_store(mut self, cfg: CustomCertStore) -> Self {
 		self.certificate_store = CertificateStore::Custom(cfg);

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -28,7 +28,7 @@ use url::Url;
 use crate::{HttpBody, HttpRequest, HttpResponse};
 
 #[cfg(feature = "tls")]
-use crate::CertificateStore;
+use crate::{CertificateStore, TlsConfig};
 
 const CONTENT_TYPE_JSON: &str = "application/json";
 
@@ -87,21 +87,21 @@ where
 pub struct HttpTransportClientBuilder<L> {
 	/// Certificate store.
 	#[cfg(feature = "tls")]
-	certificate_store: CertificateStore,
+	pub(crate) certificate_store: CertificateStore,
 	/// Configurable max request body size
-	max_request_size: u32,
+	pub(crate) max_request_size: u32,
 	/// Configurable max response body size
-	max_response_size: u32,
+	pub(crate) max_response_size: u32,
 	/// Max length for logging for requests and responses
 	///
 	/// Logs bigger than this limit will be truncated.
-	max_log_length: u32,
+	pub(crate) max_log_length: u32,
 	/// Custom headers to pass with every request.
-	headers: HeaderMap,
+	pub(crate) headers: HeaderMap,
 	/// Service builder
-	service_builder: tower::ServiceBuilder<L>,
+	pub(crate) service_builder: tower::ServiceBuilder<L>,
 	/// TCP_NODELAY
-	tcp_no_delay: bool,
+	pub(crate) tcp_no_delay: bool,
 }
 
 impl Default for HttpTransportClientBuilder<Identity> {
@@ -127,10 +127,17 @@ impl HttpTransportClientBuilder<Identity> {
 }
 
 impl<L> HttpTransportClientBuilder<L> {
-	/// Set the certificate store.
+	/// See docs [`crate::HttpClientBuilder::with_rustls_platform_verifier`] for more information.
 	#[cfg(feature = "tls")]
-	pub(crate) fn set_certification_store(mut self, cert_store: CertificateStore) -> Self {
-		self.certificate_store = cert_store;
+	pub fn with_rustls_platform_verifier(mut self) -> Self {
+		self.certificate_store = CertificateStore::Native;
+		self
+	}
+
+	/// See docs [`crate::HttpClientBuilder::with_tls_config`] for more information.
+	#[cfg(feature = "tls")]
+	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {
+		self.certificate_store = CertificateStore::Custom(cfg);
 		self
 	}
 

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -86,6 +86,7 @@ where
 #[derive(Debug)]
 pub struct HttpTransportClientBuilder<L> {
 	/// Certificate store.
+	#[cfg(feature = "tls")]
 	certificate_store: CertificateStore,
 	/// Configurable max request body size
 	max_request_size: u32,
@@ -113,6 +114,7 @@ impl HttpTransportClientBuilder<Identity> {
 	/// Create a new [`HttpTransportClientBuilder`].
 	pub fn new() -> Self {
 		Self {
+			#[cfg(feature = "tls")]
 			certificate_store: CertificateStore::Native,
 			max_request_size: TEN_MB_SIZE_BYTES,
 			max_response_size: TEN_MB_SIZE_BYTES,
@@ -171,6 +173,7 @@ impl<L> HttpTransportClientBuilder<L> {
 	/// Configure a tower service.
 	pub fn set_service<T>(self, service: tower::ServiceBuilder<T>) -> HttpTransportClientBuilder<T> {
 		HttpTransportClientBuilder {
+			#[cfg(feature = "tls")]
 			certificate_store: self.certificate_store,
 			headers: self.headers,
 			max_log_length: self.max_log_length,
@@ -191,6 +194,7 @@ impl<L> HttpTransportClientBuilder<L> {
 		B::Error: Into<BoxError>,
 	{
 		let Self {
+			#[cfg(feature = "tls")]
 			certificate_store,
 			max_request_size,
 			max_response_size,

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -28,10 +28,10 @@ pin-project = { version = "1", optional = true }
 url = { version = "2.4.0", optional = true }
 
 # tls
-rustls-native-certs = { version = "0.7", optional = true }
-webpki-roots = { version = "0.26", optional = true }
 tokio-rustls = { version = "0.26", default-features = false, optional = true, features = ["logging", "tls12", "ring"] }
 rustls-pki-types = { version = "1", optional = true }
+rustls-platform-verifier = { version = "0.3.1", optional = true }
+rustls = { version = "0.23", default-features = false, optional = true }
 
 # ws
 soketto = { version = "0.8", optional = true }
@@ -40,12 +40,7 @@ soketto = { version = "0.8", optional = true }
 gloo-net = { version = "0.5.0", default-features = false, features = ["json", "websocket"], optional = true }
 
 [features]
-native-tls = ["rustls-native-certs", "__tls"]
-webpki-tls = ["webpki-roots", "__tls"]
-
-# Internal feature to indicate whether TLS is enabled.
-# Does nothing on its own.
-__tls = ["tokio-rustls", "rustls-pki-types"]
+tls = ["tokio-rustls", "rustls-pki-types", "rustls-platform-verifier", "rustls"]
 
 ws = [
     "futures-util",

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -80,6 +80,7 @@ pub struct Receiver<T> {
 /// Builder for a WebSocket transport [`Sender`] and [`Receiver`] pair.
 #[derive(Debug)]
 pub struct WsTransportClientBuilder {
+	#[cfg(feature = "tls")]
 	/// What certificate store to use
 	pub certificate_store: CertificateStore,
 	/// Timeout for the connection.
@@ -99,6 +100,7 @@ pub struct WsTransportClientBuilder {
 impl Default for WsTransportClientBuilder {
 	fn default() -> Self {
 		Self {
+			#[cfg(feature = "tls")]
 			certificate_store: CertificateStore::Native,
 			max_request_size: TEN_MB_SIZE_BYTES,
 			max_response_size: TEN_MB_SIZE_BYTES,

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -52,7 +52,7 @@ const LOG_TARGET: &str = "jsonrpsee-client";
 
 /// Custom TLS configuration.
 #[cfg(feature = "tls")]
-pub type TlsConfig = rustls::ClientConfig;
+pub type CustomCertStore = rustls::ClientConfig;
 
 /// Certificate store to use for TLS connections.
 #[cfg(feature = "tls")]
@@ -61,7 +61,7 @@ pub enum CertificateStore {
 	/// Native.
 	Native,
 	/// Custom certificate store.
-	Custom(TlsConfig),
+	Custom(CustomCertStore),
 }
 
 /// Sending end of WebSocket transport.
@@ -113,27 +113,13 @@ impl Default for WsTransportClientBuilder {
 }
 
 impl WsTransportClientBuilder {
-	/// Force to use rustls-platform-verifier to select which certificate store to use.
-	///
-	///
-	/// This is enabled with the default settings and features.
-	///
-	/// # Optional
-	///
-	/// This requires the optional `tls` feature.
-	#[cfg(feature = "tls")]
-	pub fn with_rustls_platform_verifier(mut self) -> Self {
-		self.certificate_store = CertificateStore::Native;
-		self
-	}
-
 	/// Force to use a custom certificate store.
 	///
 	/// # Optional
 	///
 	/// This requires the optional `tls` feature.
 	#[cfg(feature = "tls")]
-	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {
+	pub fn with_custom_cert_store(mut self, cfg: CustomCertStore) -> Self {
 		self.certificate_store = CertificateStore::Custom(cfg);
 		self
 	}

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -31,7 +31,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures_util::io::{BufReader, BufWriter};
-use jsonrpsee_core::client::{CertificateStore, MaybeSend, ReceivedMessage, TransportReceiverT, TransportSenderT};
+use jsonrpsee_core::client::{MaybeSend, ReceivedMessage, TransportReceiverT, TransportSenderT};
 use jsonrpsee_core::TEN_MB_SIZE_BYTES;
 use jsonrpsee_core::{async_trait, Cow};
 use soketto::connection::Error::Utf8;
@@ -49,6 +49,20 @@ pub use tokio::io::{AsyncRead, AsyncWrite};
 pub use url::Url;
 
 const LOG_TARGET: &str = "jsonrpsee-client";
+
+/// Custom TLS configuration.
+#[cfg(feature = "tls")]
+pub type TlsConfig = rustls::ClientConfig;
+
+/// Certificate store to use for TLS connections.
+#[cfg(feature = "tls")]
+#[derive(Debug, Clone)]
+pub enum CertificateStore {
+	/// Native.
+	Native,
+	/// Custom certificate store.
+	Custom(TlsConfig),
+}
 
 /// Sending end of WebSocket transport.
 #[derive(Debug)]
@@ -97,31 +111,28 @@ impl Default for WsTransportClientBuilder {
 }
 
 impl WsTransportClientBuilder {
-	/// Force to use the rustls native certificate store.
+	/// Force to use rustls-platform-verifier to select which certificate store to use.
 	///
-	/// Since multiple certificate stores can be optionally enabled, this option will
-	/// force the `native certificate store` to be used.
+	///
+	/// This is enabled with the default settings and features.
 	///
 	/// # Optional
 	///
-	/// This requires the optional `native-tls` feature.
-	#[cfg(feature = "native-tls")]
-	pub fn use_native_rustls(mut self) -> Self {
+	/// This requires the optional `tls` feature.
+	#[cfg(feature = "tls")]
+	pub fn with_rustls_platform_verifier(mut self) -> Self {
 		self.certificate_store = CertificateStore::Native;
 		self
 	}
 
-	/// Force to use the rustls webpki certificate store.
-	///
-	/// Since multiple certificate stores can be optionally enabled, this option will
-	/// force the `webpki certificate store` to be used.
+	/// Force to use a custom certificate store.
 	///
 	/// # Optional
 	///
-	/// This requires the optional `webpki-tls` feature.
-	#[cfg(feature = "webpki-tls")]
-	pub fn use_webpki_rustls(mut self) -> Self {
-		self.certificate_store = CertificateStore::WebPki;
+	/// This requires the optional `tls` feature.
+	#[cfg(feature = "tls")]
+	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {
+		self.certificate_store = CertificateStore::Custom(cfg);
 		self
 	}
 
@@ -328,7 +339,7 @@ impl WsTransportClientBuilder {
 		let mut err = None;
 
 		// Only build TLS connector if `wss` in URL.
-		#[cfg(feature = "__tls")]
+		#[cfg(feature = "tls")]
 		let mut connector = match target._mode {
 			Mode::Tls => Some(build_tls_config(&self.certificate_store)?),
 			Mode::Plain => None,
@@ -340,7 +351,7 @@ impl WsTransportClientBuilder {
 			// The sockaddrs might get reused if the server replies with a relative URI.
 			let sockaddrs = std::mem::take(&mut target.sockaddrs);
 			for sockaddr in &sockaddrs {
-				#[cfg(feature = "__tls")]
+				#[cfg(feature = "tls")]
 				let tcp_stream = match connect(*sockaddr, self.connection_timeout, &target.host, connector.as_ref(), self.tcp_no_delay)
 					.await
 				{
@@ -352,7 +363,7 @@ impl WsTransportClientBuilder {
 					}
 				};
 
-				#[cfg(not(feature = "__tls"))]
+				#[cfg(not(feature = "tls"))]
 				let tcp_stream = match connect(*sockaddr, self.connection_timeout).await {
 					Ok(stream) => stream,
 					Err(e) => {
@@ -377,7 +388,7 @@ impl WsTransportClientBuilder {
 								})?;
 
 								// Only build TLS connector if `wss` in redirection URL.
-								#[cfg(feature = "__tls")]
+								#[cfg(feature = "tls")]
 								match target._mode {
 									Mode::Tls if connector.is_none() => {
 										connector = Some(build_tls_config(&self.certificate_store)?);
@@ -468,7 +479,7 @@ impl WsTransportClientBuilder {
 	}
 }
 
-#[cfg(feature = "__tls")]
+#[cfg(feature = "tls")]
 async fn connect(
 	sockaddr: SocketAddr,
 	timeout_dur: Duration,
@@ -497,7 +508,7 @@ async fn connect(
 	}
 }
 
-#[cfg(not(feature = "__tls"))]
+#[cfg(not(feature = "tls"))]
 async fn connect(sockaddr: SocketAddr, timeout_dur: Duration) -> Result<EitherStream, WsHandshakeError> {
 	let socket = TcpStream::connect(sockaddr);
 	let timeout = tokio::time::sleep(timeout_dur);
@@ -552,12 +563,12 @@ impl TryFrom<url::Url> for Target {
 	fn try_from(url: Url) -> Result<Self, Self::Error> {
 		let _mode = match url.scheme() {
 			"ws" => Mode::Plain,
-			#[cfg(feature = "__tls")]
+			#[cfg(feature = "tls")]
 			"wss" => Mode::Tls,
 			invalid_scheme => {
-				#[cfg(feature = "__tls")]
+				#[cfg(feature = "tls")]
 				let err = format!("`{invalid_scheme}` not supported, expects 'ws' or 'wss'");
-				#[cfg(not(feature = "__tls"))]
+				#[cfg(not(feature = "tls"))]
 				let err = format!("`{invalid_scheme}` not supported, expects 'ws' ('wss' requires the tls feature)");
 				return Err(WsHandshakeError::Url(err.into()));
 			}
@@ -582,39 +593,12 @@ impl TryFrom<url::Url> for Target {
 }
 
 // NOTE: this is slow and should be used sparingly.
-#[cfg(feature = "__tls")]
+#[cfg(feature = "tls")]
 fn build_tls_config(cert_store: &CertificateStore) -> Result<tokio_rustls::TlsConnector, WsHandshakeError> {
-	use tokio_rustls::rustls;
-
-	let mut roots = rustls::RootCertStore::empty();
-
-	match cert_store {
-		#[cfg(feature = "native-tls")]
-		CertificateStore::Native => {
-			let mut first_error = None;
-			let certs = rustls_native_certs::load_native_certs().map_err(WsHandshakeError::CertificateStore)?;
-			for cert in certs {
-				if let Err(err) = roots.add(cert) {
-					first_error = first_error.or_else(|| Some(io::Error::new(io::ErrorKind::InvalidData, err)));
-				}
-			}
-			if roots.is_empty() {
-				let err = first_error
-					.unwrap_or_else(|| io::Error::new(io::ErrorKind::NotFound, "No valid certificate found"));
-				return Err(WsHandshakeError::CertificateStore(err));
-			}
-		}
-		#[cfg(feature = "webpki-tls")]
-		CertificateStore::WebPki => {
-			roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-		}
-		_ => {
-			let err = io::Error::new(io::ErrorKind::NotFound, "Invalid certificate store");
-			return Err(WsHandshakeError::CertificateStore(err));
-		}
+	let config = match cert_store {
+		CertificateStore::Native => rustls_platform_verifier::tls_config(),
+		CertificateStore::Custom(cfg) => cfg.clone(),
 	};
-
-	let config = rustls::ClientConfig::builder().with_root_certificates(roots).with_no_client_auth();
 
 	Ok(std::sync::Arc::new(config).into())
 }
@@ -640,14 +624,14 @@ mod tests {
 		assert_ws_target(target, "127.0.0.1", "127.0.0.1:9933", Mode::Plain, "/");
 	}
 
-	#[cfg(feature = "__tls")]
+	#[cfg(feature = "tls")]
 	#[test]
 	fn wss_works_with_port() {
 		let target = parse_target("wss://kusama-rpc.polkadot.io:9999").unwrap();
 		assert_ws_target(target, "kusama-rpc.polkadot.io", "kusama-rpc.polkadot.io:9999", Mode::Tls, "/");
 	}
 
-	#[cfg(not(feature = "__tls"))]
+	#[cfg(not(feature = "tls"))]
 	#[test]
 	fn wss_fails_with_tls_feature() {
 		let err = parse_target("wss://kusama-rpc.polkadot.io").unwrap_err();
@@ -686,7 +670,7 @@ mod tests {
 		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/my.htm");
 	}
 
-	#[cfg(feature = "__tls")]
+	#[cfg(feature = "tls")]
 	#[test]
 	fn wss_default_port_is_omitted() {
 		let target = parse_target("wss://127.0.0.1:443").unwrap();

--- a/client/transport/src/ws/stream.rs
+++ b/client/transport/src/ws/stream.rs
@@ -43,7 +43,7 @@ pub enum EitherStream {
 	/// Unencrypted socket stream.
 	Plain(#[pin] TcpStream),
 	/// Encrypted socket stream.
-	#[cfg(feature = "__tls")]
+	#[cfg(feature = "tls")]
 	Tls(#[pin] tokio_rustls::client::TlsStream<TcpStream>),
 }
 
@@ -55,7 +55,7 @@ impl AsyncRead for EitherStream {
 	) -> Poll<Result<(), IoError>> {
 		match self.project() {
 			EitherStreamProj::Plain(stream) => AsyncRead::poll_read(stream, cx, buf),
-			#[cfg(feature = "__tls")]
+			#[cfg(feature = "tls")]
 			EitherStreamProj::Tls(stream) => AsyncRead::poll_read(stream, cx, buf),
 		}
 	}
@@ -65,7 +65,7 @@ impl AsyncWrite for EitherStream {
 	fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize, IoError>> {
 		match self.project() {
 			EitherStreamProj::Plain(stream) => AsyncWrite::poll_write(stream, cx, buf),
-			#[cfg(feature = "__tls")]
+			#[cfg(feature = "tls")]
 			EitherStreamProj::Tls(stream) => AsyncWrite::poll_write(stream, cx, buf),
 		}
 	}
@@ -73,7 +73,7 @@ impl AsyncWrite for EitherStream {
 	fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), IoError>> {
 		match self.project() {
 			EitherStreamProj::Plain(stream) => AsyncWrite::poll_flush(stream, cx),
-			#[cfg(feature = "__tls")]
+			#[cfg(feature = "tls")]
 			EitherStreamProj::Tls(stream) => AsyncWrite::poll_flush(stream, cx),
 		}
 	}
@@ -81,7 +81,7 @@ impl AsyncWrite for EitherStream {
 	fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), IoError>> {
 		match self.project() {
 			EitherStreamProj::Plain(stream) => AsyncWrite::poll_shutdown(stream, cx),
-			#[cfg(feature = "__tls")]
+			#[cfg(feature = "tls")]
 			EitherStreamProj::Tls(stream) => AsyncWrite::poll_shutdown(stream, cx),
 		}
 	}

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -28,9 +28,8 @@ serde_json = "1"
 serde = "1"
 
 [features]
-native-tls = ["jsonrpsee-client-transport/native-tls"]
-webpki-tls = ["jsonrpsee-client-transport/webpki-tls"]
-default = ["native-tls"]
+tls = ["jsonrpsee-client-transport/tls"]
+default = ["tls"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -26,6 +26,7 @@ jsonrpsee-test-utils = { path = "../../test-utils" }
 tokio = { version = "1.16", features = ["macros"] }
 serde_json = "1"
 serde = "1"
+rustls = { version = "0.23.7", default-features = false, features = ["logging", "std", "tls12", "ring"] }
 
 [features]
 tls = ["jsonrpsee-client-transport/tls"]

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -98,6 +98,7 @@ pub struct WsClientBuilder {
 impl Default for WsClientBuilder {
 	fn default() -> Self {
 		Self {
+			#[cfg(feature = "tls")]
 			certificate_store: CertificateStore::Native,
 			max_request_size: TEN_MB_SIZE_BYTES,
 			max_response_size: TEN_MB_SIZE_BYTES,
@@ -329,6 +330,7 @@ impl WsClientBuilder {
 		T: AsyncRead + AsyncWrite + Unpin + MaybeSend + 'static,
 	{
 		let transport_builder = WsTransportClientBuilder {
+			#[cfg(feature = "tls")]
 			certificate_store: self.certificate_store.clone(),
 			connection_timeout: self.connection_timeout,
 			headers: self.headers.clone(),
@@ -354,6 +356,7 @@ impl WsClientBuilder {
 	/// Panics if being called outside of `tokio` runtime context.
 	pub async fn build(self, url: impl AsRef<str>) -> Result<WsClient, Error> {
 		let transport_builder = WsTransportClientBuilder {
+			#[cfg(feature = "tls")]
 			certificate_store: self.certificate_store.clone(),
 			connection_timeout: self.connection_timeout,
 			headers: self.headers.clone(),

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -122,9 +122,8 @@ impl WsClientBuilder {
 		WsClientBuilder::default()
 	}
 
-	/// Force to use rustls-platform-verifier to select which certificate store to use.
-	///
-	///
+	/// Force to use rustls-platform-verifier as certification store.
+	/// If you want to use a custom certificate store, use [`WsClientBuilder::with_tls_config`] instead.
 	/// This is enabled with the default settings and features.
 	///
 	/// # Optional
@@ -147,47 +146,47 @@ impl WsClientBuilder {
 	/// ```no_run
 	/// use jsonrpsee_ws_client::WsClientBuilder;
 	/// use rustls::{
-	///	    client::danger::{self, HandshakeSignatureValid, ServerCertVerified},
-	///	    pki_types::{CertificateDer, ServerName, UnixTime},
-	///	    Error,
+	///     client::danger::{self, HandshakeSignatureValid, ServerCertVerified},
+	///     pki_types::{CertificateDer, ServerName, UnixTime},
+	///     Error,
 	/// };
 	///
 	/// #[derive(Debug)]
 	/// struct NoCertificateVerification;
 	///
 	/// impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
-	///	    fn verify_server_cert(
-	///		    &self,
-	///		    _: &CertificateDer<'_>,
-	///		    _: &[CertificateDer<'_>],
-	///		    _: &ServerName<'_>,
-	///		    _: &[u8],
-	///		    _: UnixTime,
-	///	     ) -> Result<ServerCertVerified, Error> {
-	///		    Ok(ServerCertVerified::assertion())
-	///      }
+	///     fn verify_server_cert(
+	///         &self,
+	///         _: &CertificateDer<'_>,
+	///         _: &[CertificateDer<'_>],
+	///         _: &ServerName<'_>,
+	///         _: &[u8],
+	///         _: UnixTime,
+	///     ) -> Result<ServerCertVerified, Error> {
+	///         Ok(ServerCertVerified::assertion())
+	///     }
 	///
 	///     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
 	///         vec![rustls::SignatureScheme::ECDSA_NISTP256_SHA256]
-	///	     }
+	///     }
 	///
-	///	    fn verify_tls12_signature(
+	///     fn verify_tls12_signature(
 	///         &self,
-	///		    _: &[u8],
-	///		    _: &CertificateDer<'_>,
-	///		    _: &rustls::DigitallySignedStruct,
-	///	    ) -> Result<rustls::client::danger::HandshakeSignatureValid, Error> {
-	///		    Ok(HandshakeSignatureValid::assertion())
-	///	    }
+	///         _: &[u8],
+	///         _: &CertificateDer<'_>,
+	///         _: &rustls::DigitallySignedStruct,
+	///     ) -> Result<rustls::client::danger::HandshakeSignatureValid, Error> {
+	///         Ok(HandshakeSignatureValid::assertion())
+	///     }
 	///
-	///	    fn verify_tls13_signature(
-	///		    &self,
-	///		    _: &[u8],
-	///		    _: &CertificateDer<'_>,
-	///		    _: &rustls::DigitallySignedStruct,
-	///	    ) -> Result<HandshakeSignatureValid, Error> {
-	///		    Ok(HandshakeSignatureValid::assertion())
-	///	    }
+	///     fn verify_tls13_signature(
+	///         &self,
+	///         _: &[u8],
+	///         _: &CertificateDer<'_>,
+	///         _: &rustls::DigitallySignedStruct,
+	///     ) -> Result<HandshakeSignatureValid, Error> {
+	///         Ok(HandshakeSignatureValid::assertion())
+	///     }
 	/// }
 	///
 	/// let tls_cfg = rustls::ClientConfig::builder()
@@ -196,7 +195,7 @@ impl WsClientBuilder {
 	///    .with_no_client_auth();
 	///
 	/// // client builder with disabled certificate verification.
-	/// let client_builder = WsClientBuilder::default().with_tls_config(tls_cfg);
+	/// let client_builder = WsClientBuilder::new().with_tls_config(tls_cfg);
 	/// ```
 	#[cfg(feature = "tls")]
 	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -50,7 +50,10 @@ use std::time::Duration;
 use url::Url;
 
 #[cfg(feature = "tls")]
-use jsonrpsee_client_transport::ws::{CertificateStore, TlsConfig};
+pub use jsonrpsee_client_transport::ws::CustomCertStore;
+
+#[cfg(feature = "tls")]
+use jsonrpsee_client_transport::ws::CertificateStore;
 
 /// Builder for [`WsClient`].
 ///
@@ -122,19 +125,6 @@ impl WsClientBuilder {
 		WsClientBuilder::default()
 	}
 
-	/// Force to use rustls-platform-verifier as certification store.
-	/// If you want to use a custom certificate store, use [`WsClientBuilder::with_tls_config`] instead.
-	/// This is enabled with the default settings and features.
-	///
-	/// # Optional
-	///
-	/// This requires the optional `tls` feature.
-	#[cfg(feature = "tls")]
-	pub fn with_rustls_platform_verifier(mut self) -> Self {
-		self.certificate_store = CertificateStore::Native;
-		self
-	}
-
 	/// Force to use a custom certificate store.
 	///
 	/// # Optional
@@ -144,7 +134,7 @@ impl WsClientBuilder {
 	/// # Example
 	///
 	/// ```no_run
-	/// use jsonrpsee_ws_client::WsClientBuilder;
+	/// use jsonrpsee_ws_client::{WsClientBuilder, CustomCertStore};
 	/// use rustls::{
 	///     client::danger::{self, HandshakeSignatureValid, ServerCertVerified},
 	///     pki_types::{CertificateDer, ServerName, UnixTime},
@@ -189,16 +179,16 @@ impl WsClientBuilder {
 	///     }
 	/// }
 	///
-	/// let tls_cfg = rustls::ClientConfig::builder()
+	/// let tls_cfg = CustomCertStore::builder()
 	///    .dangerous()
 	///    .with_custom_certificate_verifier(std::sync::Arc::new(NoCertificateVerification))
 	///    .with_no_client_auth();
 	///
 	/// // client builder with disabled certificate verification.
-	/// let client_builder = WsClientBuilder::new().with_tls_config(tls_cfg);
+	/// let client_builder = WsClientBuilder::new().with_custom_cert_store(tls_cfg);
 	/// ```
 	#[cfg(feature = "tls")]
-	pub fn with_tls_config(mut self, cfg: TlsConfig) -> Self {
+	pub fn with_custom_cert_store(mut self, cfg: CustomCertStore) -> Self {
 		self.certificate_store = CertificateStore::Custom(cfg);
 		self
 	}

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -522,16 +522,6 @@ impl<T: Clone> RequestIdGuard<T> {
 	}
 }
 
-/// What certificate store to use
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum CertificateStore {
-	/// Use the native system certificate store
-	Native,
-	/// Use WebPKI's certificate store
-	WebPki,
-}
-
 /// JSON-RPC request object id data type.
 #[derive(Debug, Copy, Clone)]
 pub enum IdKind {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 anyhow = "1"
 http-body-util = "0.1"
 futures = "0.3"
-jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-native-tls"] }
+jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-tls"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 tokio = { version = "1.16", features = ["full"] }

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -28,8 +28,7 @@ tracing = { version = "0.1.34", optional = true }
 tokio = { version = "1", optional = true }
 
 [features]
-client-ws-transport-native-tls = ["jsonrpsee-client-transport/ws", "jsonrpsee-client-transport/native-tls"]
-client-ws-transport-webpki-tls = ["jsonrpsee-client-transport/ws", "jsonrpsee-client-transport/webpki-tls"]
+client-ws-transport-tls = ["jsonrpsee-client-transport/ws", "jsonrpsee-client-transport/tls"]
 client-ws-transport-no-tls = ["jsonrpsee-client-transport/ws"]
 client-web-transport = ["jsonrpsee-client-transport/web"]
 async-client = ["jsonrpsee-core/async-client"]
@@ -39,7 +38,7 @@ wasm-client = ["jsonrpsee-wasm-client", "jsonrpsee-types", "jsonrpsee-core/clien
 ws-client = ["jsonrpsee-ws-client", "jsonrpsee-types", "jsonrpsee-core/client"]
 macros = ["jsonrpsee-proc-macros", "jsonrpsee-types", "tracing"]
 
-client = ["http-client", "ws-client", "wasm-client", "client-ws-transport-native-tls", "client-ws-transport-webpki-tls", "client-web-transport", "async-client", "async-wasm-client", "client-core"]
+client = ["http-client", "ws-client", "wasm-client", "client-ws-transport-tls", "client-web-transport", "async-client", "async-wasm-client", "client-core"]
 client-core = ["jsonrpsee-core/client"]
 server = ["jsonrpsee-server", "server-core", "jsonrpsee-types", "tokio"]
 server-core = ["jsonrpsee-core/server"]


### PR DESCRIPTION
Close #1340

This PR replaces the current certificate stores `rust-native-cert` and `webpki` with `rustls-platform-verifier` and additionally it adds an API to use a custom certificate store for special use-cases e.g. such as disabling cert verification or use some custom certificate store on some niche platform.