### PR TITLE
refactor(client): remove MaxSlots limit

### DIFF
--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -403,7 +403,7 @@ impl ClientBuilder {
 			to_back: to_back.clone(),
 			request_timeout: self.request_timeout,
 			error: ErrorFromBack::new(to_back, disconnect_reason),
-			id_manager: RequestIdManager::new(self.max_concurrent_requests, self.id_kind),
+			id_manager: RequestIdManager::new(self.id_kind),
 			max_log_length: self.max_log_length,
 			on_exit: Some(client_dropped_tx),
 		}

--- a/core/src/client/error.rs
+++ b/core/src/client/error.rs
@@ -54,9 +54,6 @@ pub enum Error {
 	/// Request timeout
 	#[error("Request timeout")]
 	RequestTimeout,
-	/// Max number of request slots exceeded.
-	#[error("Max concurrent requests exceeded")]
-	MaxSlotsExceeded,
 	/// Custom error.
 	#[error("Custom error: {0}")]
 	Custom(String),


### PR DESCRIPTION
Close #1374 

The rationale behind this is that the "ws-client/async-client" already has a bounded channel which provides backpressure and it doesn't make sense to use slot limit to throw an error if it's exceeded.

For the http client it's another story where it's handled by the hyper threadpool and we have no channel that provides backpressure.

However, it's better that users themselves decide how many concurrent calls that they want...