### PR TITLE
feat: add macro attr `with_extensions`

### DIFF
--- a/examples/examples/jsonrpsee_as_service.rs
+++ b/examples/examples/jsonrpsee_as_service.rs
@@ -44,7 +44,7 @@ use jsonrpsee::core::async_trait;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::{ResponseFuture, RpcServiceBuilder, RpcServiceT};
-use jsonrpsee::server::{stop_channel, Extensions, ServerHandle, StopHandle, TowerServiceBuilder};
+use jsonrpsee::server::{stop_channel, ServerHandle, StopHandle, TowerServiceBuilder};
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Request};
 use jsonrpsee::ws_client::{HeaderValue, WsClientBuilder};
 use jsonrpsee::{MethodResponse, Methods};
@@ -100,7 +100,7 @@ pub trait Rpc {
 
 #[async_trait]
 impl RpcServer for () {
-	async fn trusted_call(&self, _ext: &Extensions) -> Result<String, ErrorObjectOwned> {
+	async fn trusted_call(&self) -> Result<String, ErrorObjectOwned> {
 		Ok("mysecret".to_string())
 	}
 }

--- a/examples/examples/jsonrpsee_server_low_level_api.rs
+++ b/examples/examples/jsonrpsee_server_low_level_api.rs
@@ -56,7 +56,7 @@ use jsonrpsee::server::{
 };
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Request};
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::{Extensions, MethodResponse, Methods};
+use jsonrpsee::{MethodResponse, Methods};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
@@ -108,7 +108,7 @@ pub trait Rpc {
 
 #[async_trait]
 impl RpcServer for () {
-	async fn say_hello(&self, _ext: &Extensions) -> Result<String, ErrorObjectOwned> {
+	async fn say_hello(&self) -> Result<String, ErrorObjectOwned> {
 		Ok("lo".to_string())
 	}
 }

--- a/examples/examples/proc_macro.rs
+++ b/examples/examples/proc_macro.rs
@@ -31,7 +31,6 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{PendingSubscriptionSink, Server, SubscriptionMessage};
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::Extensions;
 
 type ExampleHash = [u8; 32];
 type ExampleStorageKey = Vec<u8>;
@@ -63,7 +62,6 @@ pub struct RpcServerImpl;
 impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 	async fn storage_keys(
 		&self,
-		_ext: &Extensions,
 		storage_key: ExampleStorageKey,
 		_hash: Option<ExampleHash>,
 	) -> Result<Vec<ExampleStorageKey>, ErrorObjectOwned> {
@@ -73,7 +71,6 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 	async fn subscribe_storage(
 		&self,
 		pending: PendingSubscriptionSink,
-		_ext: &Extensions,
 		_keys: Option<Vec<ExampleStorageKey>>,
 	) -> SubscriptionResult {
 		let sink = pending.accept().await?;
@@ -83,7 +80,7 @@ impl RpcServer<ExampleHash, ExampleStorageKey> for RpcServerImpl {
 		Ok(())
 	}
 
-	fn s(&self, pending: PendingSubscriptionSink, _ext: &Extensions, _keys: Option<Vec<ExampleStorageKey>>) {
+	fn s(&self, pending: PendingSubscriptionSink, _keys: Option<Vec<ExampleStorageKey>>) {
 		tokio::spawn(async move {
 			let sink = pending.accept().await.unwrap();
 			let msg = SubscriptionMessage::from_json(&vec![[0; 32]]).unwrap();

--- a/examples/examples/proc_macro_bounds.rs
+++ b/examples/examples/proc_macro_bounds.rs
@@ -31,8 +31,6 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::Extensions;
-
 type ExampleHash = [u8; 32];
 
 pub trait Config {
@@ -62,7 +60,7 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer<ExampleHash> for RpcServerImpl {
-	fn method(&self, _ext: &Extensions) -> Result<<ExampleHash as Config>::Hash, ErrorObjectOwned> {
+	fn method(&self) -> Result<<ExampleHash as Config>::Hash, ErrorObjectOwned> {
 		Ok([0u8; 32])
 	}
 }

--- a/examples/examples/response_payload_notify_on_response.rs
+++ b/examples/examples/response_payload_notify_on_response.rs
@@ -30,7 +30,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::Server;
 use jsonrpsee::ws_client::WsClientBuilder;
-use jsonrpsee::{rpc_params, Extensions, ResponsePayload};
+use jsonrpsee::{rpc_params, ResponsePayload};
 
 #[rpc(client, server, namespace = "state")]
 pub trait Rpc {
@@ -42,7 +42,7 @@ pub trait Rpc {
 pub struct RpcServerImpl;
 
 impl RpcServer for RpcServerImpl {
-	fn storage_keys(&self, _ext: &Extensions) -> ResponsePayload<'static, String> {
+	fn storage_keys(&self) -> ResponsePayload<'static, String> {
 		let (rp, rp_future) = ResponsePayload::success("ehheeheh".to_string()).notify_on_completion();
 
 		tokio::spawn(async move {

--- a/examples/examples/server_with_connection_details.rs
+++ b/examples/examples/server_with_connection_details.rs
@@ -62,10 +62,10 @@ where
 #[rpc(server, client)]
 pub trait Rpc {
 	/// method with connection ID.
-	#[method(name = "connectionIdMethod")]
+	#[method(name = "connectionIdMethod", with_extensions)]
 	async fn method(&self, first_param: usize, second_param: u16) -> Result<u32, ErrorObjectOwned>;
 
-	#[subscription(name = "subscribeConnectionId", item = u32)]
+	#[subscription(name = "subscribeConnectionId", item = u32, with_extensions)]
 	async fn sub(&self) -> SubscriptionResult;
 }
 

--- a/examples/examples/server_with_connection_details.rs
+++ b/examples/examples/server_with_connection_details.rs
@@ -39,9 +39,9 @@ use jsonrpsee::Extensions;
 pub trait Rpc {
 	/// method with connection ID.
 	#[method(name = "connectionIdMethod", with_extensions)]
-	async fn method(&self, first_param: usize, second_param: u16) -> Result<u32, ErrorObjectOwned>;
+	async fn method(&self) -> Result<usize, ErrorObjectOwned>;
 
-	#[subscription(name = "subscribeConnectionId", item = u32, with_extensions)]
+	#[subscription(name = "subscribeConnectionId", item = usize, with_extensions)]
 	async fn sub(&self) -> SubscriptionResult;
 }
 

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -25,9 +25,12 @@ heck = "0.5.0"
 
 [dev-dependencies]
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "client-core", "http-client", "ws-client", "macros"] }
-trybuild = "1.0"
-tokio = { version = "1.16", features = ["rt", "macros"] }
+hyper = "1.3"
+hyper-util = { version = "0.1.3", features = ["client", "client-legacy"]}
 futures-channel = { version = "0.3.14", default-features = false }
 futures-util = { version = "0.3.14", default-features = false }
 serde_json = "1"
 serde = "1"
+trybuild = "1.0"
+tokio = { version = "1.16", features = ["rt", "macros"] }
+tower = "0.4"

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -309,15 +309,15 @@ pub(crate) mod visitor;
 ///     // Note that the trait name we use is `MyRpcServer`, not `MyRpc`!
 ///     #[async_trait]
 ///     impl MyRpcServer for RpcServerImpl {
-///         async fn async_method(&self, _ext: &Extensions, _param_a: u8, _param_b: String) -> RpcResult<u16> {
+///         async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 ///             Ok(42)
 ///         }
 ///
-///         fn sync_method(&self, _ext: &Extensions) -> RpcResult<u16> {
+///         fn sync_method(&self) -> RpcResult<u16> {
 ///             Ok(10)
 ///         }
 ///
-///         fn blocking_method(&self, _ext: &Extensions) -> RpcResult<u16> {
+///         fn blocking_method(&self) -> RpcResult<u16> {
 ///             // This will block current thread for 1 second, which is fine since we marked
 ///             // this method as `blocking` above.
 ///             std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -326,14 +326,14 @@ pub(crate) mod visitor;
 ///
 ///         // The stream API can be used to pipe items from the underlying stream
 ///         // as subscription responses.
-///         async fn sub_override_notif_method(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
+///         async fn sub_override_notif_method(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
 ///             let mut sink = pending.accept().await?;
 ///             sink.send("Response_A".into()).await?;
 ///             Ok(())
 ///         }
 ///
 ///         // Send out two values on the subscription.
-///         async fn sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
+///         async fn sub(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
 ///             let sink = pending.accept().await?;
 ///
 ///             let msg1 = SubscriptionMessage::from("Response_A");
@@ -348,7 +348,7 @@ pub(crate) mod visitor;
 ///         // If one doesn't want sent out a close message when a subscription terminates or treat
 ///         // errors as subscription error notifications then it's possible to implement
 ///         // `IntoSubscriptionCloseResponse` for customized behavior.
-///         async fn sub_custom_close_msg(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> CloseResponse {
+///         async fn sub_custom_close_msg(&self, pending: PendingSubscriptionSink) -> CloseResponse {
 ///             let Ok(sink) = pending.accept().await else {
 ///                 return CloseResponse::None;
 ///             };

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -66,10 +66,12 @@ impl RpcDescription {
 			let docs = &method.docs;
 			let mut method_sig = method.signature.clone();
 
-			let ext_ty = self.jrps_server_item(quote! { Extensions });
-			// Add `Extension` as the second parameter to the signature.
-			let ext: syn::FnArg = syn::parse_quote!(ext: &#ext_ty);
-			method_sig.sig.inputs.insert(1, ext);
+			if method.with_extensions {
+				let ext_ty = self.jrps_server_item(quote! { Extensions });
+				// Add `Extension` as the second parameter to the signature.
+				let ext: syn::FnArg = syn::parse_quote!(ext: &#ext_ty);
+				method_sig.sig.inputs.insert(1, ext);
+			}
 
 			quote! {
 				#docs
@@ -86,10 +88,12 @@ impl RpcDescription {
 			let mut sub_sig = sub.signature.clone();
 			sub_sig.sig.inputs.insert(1, subscription_sink);
 
-			let ext_ty = self.jrps_server_item(quote! { Extensions });
-			// Add `Extension` as the third parameter to the signature.
-			let ext: syn::FnArg = syn::parse_quote!(ext: &#ext_ty);
-			sub_sig.sig.inputs.insert(2, ext);
+			if sub.with_extensions {
+				let ext_ty = self.jrps_server_item(quote! { Extensions });
+				// Add `Extension` as the third parameter to the signature.
+				let ext: syn::FnArg = syn::parse_quote!(ext: &#ext_ty);
+				sub_sig.sig.inputs.insert(2, ext);
+			}
 
 			quote! {
 				#docs
@@ -148,22 +152,40 @@ impl RpcDescription {
 				check_name(&rpc_method_name, rust_method_name.span());
 
 				if method.signature.sig.asyncness.is_some() {
-					handle_register_result(quote! {
-						rpc.register_async_method(#rpc_method_name, |params, context, ext| async move {
-							#parsing
-							#into_response::into_response(context.as_ref().#rust_method_name(&ext, #params_seq).await)
+					if method.with_extensions {
+						handle_register_result(quote! {
+							rpc.register_async_method(#rpc_method_name, |params, context, ext| async move {
+								#parsing
+								#into_response::into_response(context.as_ref().#rust_method_name(&ext, #params_seq).await)
+							})
 						})
-					})
+					} else {
+						handle_register_result(quote! {
+							rpc.register_async_method(#rpc_method_name, |params, context, _| async move {
+								#parsing
+								#into_response::into_response(context.as_ref().#rust_method_name(#params_seq).await)
+							})
+						})
+					}
 				} else {
 					let register_kind =
 						if method.blocking { quote!(register_blocking_method) } else { quote!(register_method) };
 
-					handle_register_result(quote! {
-						rpc.#register_kind(#rpc_method_name, |params, context, ext| {
-							#parsing
-							#into_response::into_response(context.#rust_method_name(&ext, #params_seq))
+					if method.with_extensions {
+						handle_register_result(quote! {
+							rpc.#register_kind(#rpc_method_name, |params, context, ext| {
+								#parsing
+								#into_response::into_response(context.#rust_method_name(&ext, #params_seq))
+							})
 						})
-					})
+					} else {
+						handle_register_result(quote! {
+							rpc.#register_kind(#rpc_method_name, |params, context, _| {
+								#parsing
+								#into_response::into_response(context.#rust_method_name(#params_seq))
+							})
+						})
+					}
 				}
 			})
 			.collect::<Vec<_>>();
@@ -200,20 +222,39 @@ impl RpcDescription {
 				};
 
 				if sub.signature.sig.asyncness.is_some() {
-					handle_register_result(quote! {
-						rpc.register_subscription(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, ext| async move {
-							#parsing
-							#into_sub_response::into_response(context.as_ref().#rust_method_name(pending, &ext, #params_seq).await)
+					if sub.with_extensions {
+						handle_register_result(quote! {
+							rpc.register_subscription(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, ext| async move {
+								#parsing
+								#into_sub_response::into_response(context.as_ref().#rust_method_name(pending, &ext, #params_seq).await)
+							})
 						})
-					})
+					} else {
+						handle_register_result(quote! {
+							rpc.register_subscription(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, _| async move {
+								#parsing
+								#into_sub_response::into_response(context.as_ref().#rust_method_name(pending, #params_seq).await)
+							})
+						})
+					}
 				} else {
-					handle_register_result(quote! {
-						rpc.register_subscription_raw(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, ext| {
-							#parsing
-							let _ = context.as_ref().#rust_method_name(pending, &ext, #params_seq);
-							#sub_err::None
+					if sub.with_extensions {
+						handle_register_result(quote! {
+							rpc.register_subscription_raw(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, ext| {
+								#parsing
+								let _ = context.as_ref().#rust_method_name(pending, &ext, #params_seq);
+								#sub_err::None
+							})
 						})
-					})
+					} else {
+						handle_register_result(quote! {
+							rpc.register_subscription_raw(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, _| {
+								#parsing
+								let _ = context.as_ref().#rust_method_name(pending, #params_seq);
+								#sub_err::None
+							})
+						})
+					}
 				}
 			})
 			.collect::<Vec<_>>();

--- a/proc-macros/src/render_server.rs
+++ b/proc-macros/src/render_server.rs
@@ -237,16 +237,15 @@ impl RpcDescription {
 							})
 						})
 					}
-				} else {
-					if sub.with_extensions {
-						handle_register_result(quote! {
+				} else if sub.with_extensions {
+					handle_register_result(quote! {
 							rpc.register_subscription_raw(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, ext| {
 								#parsing
 								let _ = context.as_ref().#rust_method_name(pending, &ext, #params_seq);
 								#sub_err::None
 							})
 						})
-					} else {
+				} else {
 						handle_register_result(quote! {
 							rpc.register_subscription_raw(#rpc_sub_name, #rpc_notif_name, #rpc_unsub_name, |params, mut pending, context, _| {
 								#parsing
@@ -255,7 +254,6 @@ impl RpcDescription {
 							})
 						})
 					}
-				}
 			})
 			.collect::<Vec<_>>();
 

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -6,9 +6,10 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::params::ArrayParams;
 use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{Extensions, ServerBuilder, SubscriptionMessage};
+use jsonrpsee::server::SubscriptionMessage;
+use jsonrpsee::types::ErrorObject;
 use jsonrpsee::ws_client::*;
-use jsonrpsee::{rpc_params, PendingSubscriptionSink};
+use jsonrpsee::{rpc_params, Extensions, PendingSubscriptionSink};
 
 #[rpc(client, server, namespace = "foo")]
 pub trait Rpc {
@@ -31,11 +32,20 @@ pub trait Rpc {
 		#[argument(rename = "halfType")] ignored_name: bool,
 	) -> RpcResult<u16>;
 
+	#[method(name = "async_conn_id", with_extensions)]
+	async fn conn_id(&self) -> RpcResult<u32>;
+
 	#[method(name = "bar")]
 	fn sync_method(&self) -> RpcResult<u16>;
 
+	#[method(name = "sync_conn_id", with_extensions)]
+	fn sync_conn_id(&self) -> RpcResult<u32>;
+
 	#[subscription(name = "subscribe", item = String)]
 	async fn sub(&self) -> SubscriptionResult;
+
+	#[subscription(name = "subscribe_conn_id", item = u32, with_extensions)]
+	async fn sub_with_conn_id(&self) -> SubscriptionResult;
 
 	#[subscription(name = "echo", unsubscribe = "unsubscribeEcho", aliases = ["ECHO"], item = u32, unsubscribe_aliases = ["NotInterested", "listenNoMore"])]
 	async fn sub_with_params(&self, val: u32) -> SubscriptionResult;
@@ -50,33 +60,41 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method(&self, _ext: &Extensions, _param_a: u8, _param_b: String) -> RpcResult<u16> {
+	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)
 	}
 
-	async fn optional_params(&self, _ext: &Extensions, a: core::option::Option<u8>, _b: String) -> RpcResult<bool> {
+	async fn optional_params(&self, a: core::option::Option<u8>, _b: String) -> RpcResult<bool> {
 		let res = if a.is_some() { true } else { false };
 		Ok(res)
 	}
 
-	async fn optional_param(&self, _ext: &Extensions, a: Option<u8>) -> RpcResult<bool> {
+	async fn optional_param(&self, a: Option<u8>) -> RpcResult<bool> {
 		let res = if a.is_some() { true } else { false };
 		Ok(res)
 	}
 
-	async fn array_params(&self, _ext: &Extensions, items: Vec<u64>) -> RpcResult<u64> {
+	async fn array_params(&self, items: Vec<u64>) -> RpcResult<u64> {
 		Ok(items.len() as u64)
 	}
 
-	async fn rename_params(&self, _ext: &Extensions, r#type: u16, half_type: bool) -> RpcResult<u16> {
+	async fn rename_params(&self, r#type: u16, half_type: bool) -> RpcResult<u16> {
 		Ok(half_type.then(|| r#type / 2).unwrap_or(r#type))
 	}
 
-	fn sync_method(&self, _ext: &Extensions) -> RpcResult<u16> {
+	async fn conn_id(&self, ext: &jsonrpsee::Extensions) -> RpcResult<u32> {
+		ext.get::<u32>().cloned().ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))
+	}
+
+	fn sync_conn_id(&self, ext: &jsonrpsee::Extensions) -> RpcResult<u32> {
+		ext.get::<u32>().cloned().ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))
+	}
+
+	fn sync_method(&self) -> RpcResult<u16> {
 		Ok(10u16)
 	}
 
-	async fn sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
+	async fn sub(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 
 		sink.send("Response_A".into()).await?;
@@ -85,12 +103,7 @@ impl RpcServer for RpcServerImpl {
 		Ok(())
 	}
 
-	async fn sub_with_params(
-		&self,
-		pending: PendingSubscriptionSink,
-		_ext: &Extensions,
-		val: u32,
-	) -> SubscriptionResult {
+	async fn sub_with_params(&self, pending: PendingSubscriptionSink, val: u32) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 		let msg = SubscriptionMessage::from_json(&val)?;
 
@@ -100,11 +113,7 @@ impl RpcServer for RpcServerImpl {
 		Ok(())
 	}
 
-	async fn sub_with_override_notif_method(
-		&self,
-		pending: PendingSubscriptionSink,
-		_ext: &Extensions,
-	) -> SubscriptionResult {
+	async fn sub_with_override_notif_method(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 
 		let msg = SubscriptionMessage::from_json(&1)?;
@@ -112,14 +121,102 @@ impl RpcServer for RpcServerImpl {
 
 		Ok(())
 	}
+
+	async fn sub_with_conn_id(&self, pending: PendingSubscriptionSink, ext: &Extensions) -> SubscriptionResult {
+		let sink = pending.accept().await?;
+		let conn_id = ext
+			.get::<u32>()
+			.cloned()
+			.ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))?;
+		sink.send(SubscriptionMessage::from_json(&conn_id).unwrap()).await?;
+		Ok(())
+	}
 }
 
 pub async fn server() -> SocketAddr {
-	let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
-	let addr = server.local_addr().unwrap();
-	let server_handle = server.start(RpcServerImpl.into_rpc());
+	use hyper_util::rt::{TokioExecutor, TokioIo};
+	use jsonrpsee::server::middleware::rpc::RpcServiceT;
+	use jsonrpsee::server::{stop_channel, RpcServiceBuilder};
+	use std::convert::Infallible;
+	use std::sync::{atomic::AtomicU32, Arc};
+	use tower::Service;
 
-	tokio::spawn(server_handle.stopped());
+	#[derive(Debug, Clone)]
+	struct ConnectionDetails<S> {
+		inner: S,
+		connection_id: u32,
+	}
+
+	impl<'a, S> RpcServiceT<'a> for ConnectionDetails<S>
+	where
+		S: RpcServiceT<'a>,
+	{
+		type Future = S::Future;
+
+		fn call(&self, mut request: jsonrpsee::types::Request<'a>) -> Self::Future {
+			request.extensions_mut().insert(self.connection_id);
+			self.inner.call(request)
+		}
+	}
+
+	let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await.unwrap();
+	let addr = listener.local_addr().unwrap();
+
+	let (stop_hdl, server_hdl) = stop_channel();
+
+	tokio::spawn(async move {
+		let conn_id = Arc::new(AtomicU32::new(0));
+		let svc_builder = jsonrpsee::server::Server::builder().to_service_builder();
+		let methods = RpcServerImpl.into_rpc();
+
+		loop {
+			let stream = tokio::select! {
+				res = listener.accept() => {
+					match res {
+						Ok((stream, _remote_addr)) => stream,
+						Err(e) => {
+							eprintln!("failed to accept ipv4 connection: {:?}", e);
+							continue;
+						}
+					}
+				}
+				_ = stop_hdl.clone().shutdown() => break,
+			};
+
+			let methods2 = methods.clone();
+			let stop_hdl2 = stop_hdl.clone();
+			let svc_builder2 = svc_builder.clone();
+			let conn_id2 = conn_id.clone();
+			let svc = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+				let connection_id = conn_id2.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+				let rpc_middleware = RpcServiceBuilder::default()
+					.layer_fn(move |service| ConnectionDetails { inner: service, connection_id });
+
+				// Start a new service with our own connection ID.
+				let mut tower_service = svc_builder2
+					.clone()
+					.set_rpc_middleware(rpc_middleware)
+					.connection_id(connection_id)
+					.build(methods2.clone(), stop_hdl2.clone());
+
+				async move {
+					let rp = tower_service.call(req).await.unwrap();
+					Ok::<_, Infallible>(rp)
+				}
+			});
+
+			tokio::spawn(async move {
+				let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+				let conn = builder.serve_connection_with_upgrades(TokioIo::new(stream), svc);
+
+				if let Err(err) = conn.await {
+					eprintln!("HTTP connection failed: {:?}", err);
+				}
+			});
+		}
+	});
+
+	tokio::spawn(server_hdl.stopped());
 
 	addr
 }
@@ -163,4 +260,10 @@ async fn main() {
 	let mut sub = client.sub_with_override_notif_method().await.unwrap();
 	let recv = sub.next().await.transpose().unwrap();
 	assert_eq!(recv, Some(1));
+
+	assert!(client.conn_id().await.is_ok());
+	assert!(client.sync_conn_id().await.is_ok());
+
+	let mut sub = client.sub_with_conn_id().await.unwrap();
+	assert!(matches!(sub.next().await, Some(Ok(_))));
 }

--- a/proc-macros/tests/ui/correct/custom_ret_types.rs
+++ b/proc-macros/tests/ui/correct/custom_ret_types.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, ClientError, Serialize};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{Extensions, IntoResponse, ResponsePayload, ServerBuilder};
+use jsonrpsee::server::{IntoResponse, ResponsePayload, ServerBuilder};
 use jsonrpsee::ws_client::*;
 
 // Serialize impl is not used as the responses are sent out as error.
@@ -59,27 +59,27 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method1(&self, _ext: &Extensions) -> CustomError {
+	async fn async_method1(&self) -> CustomError {
 		CustomError::One
 	}
 
-	async fn async_method2(&self, _ext: &Extensions, x: u32) -> CustomError {
+	async fn async_method2(&self, x: u32) -> CustomError {
 		CustomError::Two { custom_data: x }
 	}
 
-	fn method1(&self, _ext: &Extensions) -> CustomError {
+	fn method1(&self) -> CustomError {
 		CustomError::One
 	}
 
-	fn method2(&self, _ext: &Extensions, x: u32) -> CustomError {
+	fn method2(&self, x: u32) -> CustomError {
 		CustomError::Two { custom_data: x }
 	}
 
-	fn blocking_method1(&self, _ext: &Extensions) -> CustomError {
+	fn blocking_method1(&self) -> CustomError {
 		CustomError::One
 	}
 
-	fn blocking_method2(&self, _ext: &Extensions, x: u32) -> CustomError {
+	fn blocking_method2(&self, x: u32) -> CustomError {
 		CustomError::Two { custom_data: x }
 	}
 }

--- a/proc-macros/tests/ui/correct/only_server.rs
+++ b/proc-macros/tests/ui/correct/only_server.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{Extensions, PendingSubscriptionSink, ServerBuilder};
+use jsonrpsee::server::{PendingSubscriptionSink, ServerBuilder};
 
 #[rpc(server)]
 pub trait Rpc {
@@ -20,15 +20,15 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn async_method(&self, _ext: &Extensions, _param_a: u8, _param_b: String) -> RpcResult<u16> {
+	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
 		Ok(42u16)
 	}
 
-	fn sync_method(&self, _ext: &Extensions) -> RpcResult<u16> {
+	fn sync_method(&self) -> RpcResult<u16> {
 		Ok(10u16)
 	}
 
-	async fn sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
+	async fn sub(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 
 		sink.send("Response_A".into()).await?;

--- a/proc-macros/tests/ui/correct/param_kind.rs
+++ b/proc-macros/tests/ui/correct/param_kind.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{Extensions, ServerBuilder};
+use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::*;
 
 #[rpc(client, server, namespace = "foo")]
@@ -21,19 +21,19 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn method_with_array_param(&self, _ext: &Extensions, param_a: u8, param_b: String) -> RpcResult<u16> {
+	async fn method_with_array_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
 		assert_eq!(param_a, 0);
 		assert_eq!(&param_b, "a");
 		Ok(42u16)
 	}
 
-	async fn method_with_map_param(&self, _ext: &Extensions, param_a: u8, param_b: String) -> RpcResult<u16> {
+	async fn method_with_map_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
 		assert_eq!(param_a, 0);
 		assert_eq!(&param_b, "a");
 		Ok(42u16)
 	}
 
-	async fn method_with_default_param(&self, _ext: &Extensions, param_a: u8, param_b: String) -> RpcResult<u16> {
+	async fn method_with_default_param(&self, param_a: u8, param_b: String) -> RpcResult<u16> {
 		assert_eq!(param_a, 0);
 		assert_eq!(&param_b, "a");
 		Ok(42u16)

--- a/proc-macros/tests/ui/correct/rpc_bounds.rs
+++ b/proc-macros/tests/ui/correct/rpc_bounds.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{Extensions, ServerBuilder};
+use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::*;
 
 pub trait Config {
@@ -105,7 +105,7 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 pub struct ServerOnlyImpl;
 #[async_trait]
 impl MyRpcSServer<ExampleHash> for ServerOnlyImpl {
-	fn method(&self, _ext: &Extensions) -> RpcResult<<ExampleHash as Config>::Hash> {
+	fn method(&self) -> RpcResult<<ExampleHash as Config>::Hash> {
 		Ok([0u8; 32])
 	}
 }
@@ -114,7 +114,7 @@ impl MyRpcSServer<ExampleHash> for ServerOnlyImpl {
 pub struct ServerClientServerImpl;
 #[async_trait]
 impl MyRpcSCServer<ExampleHash> for ServerClientServerImpl {
-	fn method(&self, _ext: &Extensions) -> RpcResult<<ExampleHash as Config>::Hash> {
+	fn method(&self) -> RpcResult<<ExampleHash as Config>::Hash> {
 		Ok([0u8; 32])
 	}
 }

--- a/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_unexpected_field.stderr
@@ -1,4 +1,4 @@
-error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `param_kind`
+error: Unknown argument `magic`, expected one of: `aliases`, `blocking`, `name`, `param_kind`, `with_extensions`
  --> tests/ui/incorrect/method/method_unexpected_field.rs:6:25
   |
 6 |     #[method(name = "foo", magic = false)]

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::{Extensions, ServerBuilder};
+use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::ws_client::*;
 
 #[rpc(client, server)]
@@ -31,15 +31,15 @@ pub struct DeprecatedServerImpl;
 
 #[async_trait]
 impl DeprecatedServer for DeprecatedServerImpl {
-	async fn async_method(&self, _ext: &Extensions) -> RpcResult<u8> {
+	async fn async_method(&self) -> RpcResult<u8> {
 		Ok(16u8)
 	}
 
-	async fn async_method_unused(&self, _ext: &Extensions) -> RpcResult<u8> {
+	async fn async_method_unused(&self) -> RpcResult<u8> {
 		Ok(32u8)
 	}
 
-	fn sync_method(&self, _ext: &Extensions) -> RpcResult<u8> {
+	fn sync_method(&self) -> RpcResult<u8> {
 		Ok(64u8)
 	}
 }

--- a/proc-macros/tests/ui/incorrect/sub/sub_unsupported_field.stderr
+++ b/proc-macros/tests/ui/incorrect/sub/sub_unsupported_field.stderr
@@ -1,4 +1,4 @@
-error: Unknown argument `magic`, expected one of: `aliases`, `item`, `name`, `param_kind`, `unsubscribe`, `unsubscribe_aliases`
+error: Unknown argument `magic`, expected one of: `aliases`, `item`, `name`, `param_kind`, `unsubscribe`, `unsubscribe_aliases`, `with_extensions`
  --> tests/ui/incorrect/sub/sub_unsupported_field.rs:6:65
   |
 6 |     #[subscription(name = "sub", unsubscribe = "unsub", item = u8, magic = true)]

--- a/tests/proc-macro-core/src/lib.rs
+++ b/tests/proc-macro-core/src/lib.rs
@@ -3,7 +3,7 @@
 use jsonrpsee::core::{async_trait, SubscriptionResult};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
-use jsonrpsee::{Extensions, PendingSubscriptionSink, SubscriptionMessage};
+use jsonrpsee::{PendingSubscriptionSink, SubscriptionMessage};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -42,31 +42,25 @@ pub trait Api {
 
 #[async_trait]
 impl ApiServer for () {
-	fn sync_call(&self, _ext: &Extensions, _: String) -> Result<String, ErrorObjectOwned> {
+	fn sync_call(&self, _: String) -> Result<String, ErrorObjectOwned> {
 		Ok("sync_call".to_string())
 	}
 
-	async fn async_call(&self, _ext: &Extensions, _: String) -> Result<String, ErrorObjectOwned> {
+	async fn async_call(&self, _: String) -> Result<String, ErrorObjectOwned> {
 		Ok("async_call".to_string())
 	}
 
-	async fn sub(
-		&self,
-		pending: PendingSubscriptionSink,
-		_ext: &Extensions,
-		_: PubSubKind,
-		_: PubSubParams,
-	) -> SubscriptionResult {
+	async fn sub(&self, pending: PendingSubscriptionSink, _: PubSubKind, _: PubSubParams) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 		sink.send(SubscriptionMessage::from("msg")).await?;
 		Ok(())
 	}
 
-	fn sync_sub(&self, _: PendingSubscriptionSink, _ext: &Extensions, _: String) -> SubscriptionResult {
+	fn sync_sub(&self, _: PendingSubscriptionSink, _: String) -> SubscriptionResult {
 		Ok(())
 	}
 
-	fn blocking_method(&self, _ext: &Extensions, _: String) -> Result<u16, ErrorObjectOwned> {
+	fn blocking_method(&self, _: String) -> Result<u16, ErrorObjectOwned> {
 		Ok(42)
 	}
 }

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -49,7 +49,6 @@ mod rpc_impl {
 	use jsonrpsee::core::{async_trait, SubscriptionResult};
 	use jsonrpsee::proc_macros::rpc;
 	use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
-	use jsonrpsee::Extensions;
 
 	pub struct CustomSubscriptionRet;
 
@@ -155,20 +154,15 @@ mod rpc_impl {
 
 	#[async_trait]
 	impl RpcServer for RpcServerImpl {
-		async fn async_method(
-			&self,
-			_ext: &Extensions,
-			_param_a: u8,
-			_param_b: String,
-		) -> Result<u16, ErrorObjectOwned> {
+		async fn async_method(&self, _param_a: u8, _param_b: String) -> Result<u16, ErrorObjectOwned> {
 			Ok(42)
 		}
 
-		fn sync_method(&self, _ext: &Extensions) -> Result<u16, ErrorObjectOwned> {
+		fn sync_method(&self) -> Result<u16, ErrorObjectOwned> {
 			Ok(10)
 		}
 
-		async fn sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) -> SubscriptionResult {
+		async fn sub(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
 			let sink = pending.accept().await?;
 			sink.send("Response_A".into()).await?;
 			sink.send("Response_B".into()).await?;
@@ -176,12 +170,7 @@ mod rpc_impl {
 			Ok(())
 		}
 
-		async fn sub_with_params(
-			&self,
-			pending: PendingSubscriptionSink,
-			_ext: &Extensions,
-			val: u32,
-		) -> SubscriptionResult {
+		async fn sub_with_params(&self, pending: PendingSubscriptionSink, val: u32) -> SubscriptionResult {
 			let sink = pending.accept().await?;
 			let msg = SubscriptionMessage::from_json(&val)?;
 			sink.send(msg.clone()).await?;
@@ -190,28 +179,23 @@ mod rpc_impl {
 			Ok(())
 		}
 
-		async fn sub_not_result(&self, pending: PendingSubscriptionSink, _ext: &Extensions) {
+		async fn sub_not_result(&self, pending: PendingSubscriptionSink) {
 			let sink = pending.accept().await.unwrap();
 			sink.send("lo".into()).await.unwrap();
 		}
 
-		async fn sub_custom_ret(
-			&self,
-			_pending: PendingSubscriptionSink,
-			_ext: &Extensions,
-			_x: usize,
-		) -> CustomSubscriptionRet {
+		async fn sub_custom_ret(&self, _pending: PendingSubscriptionSink, _x: usize) -> CustomSubscriptionRet {
 			CustomSubscriptionRet
 		}
 
-		fn sync_sub(&self, pending: PendingSubscriptionSink, _ext: &Extensions) {
+		fn sync_sub(&self, pending: PendingSubscriptionSink) {
 			tokio::spawn(async move {
 				let sink = pending.accept().await.unwrap();
 				sink.send("hello".into()).await.unwrap();
 			});
 		}
 
-		async fn sub_unit_type(&self, _pending: PendingSubscriptionSink, _ext: &Extensions, _x: usize) {}
+		async fn sub_unit_type(&self, _pending: PendingSubscriptionSink, _x: usize) {}
 	}
 }
 

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -175,24 +175,19 @@ async fn calling_method_without_server_using_proc_macro() {
 
 	#[async_trait]
 	impl CoolServer for CoolServerImpl {
-		fn rebel_without_cause(&self, _ext: &Extensions) -> RpcResult<bool> {
+		fn rebel_without_cause(&self) -> RpcResult<bool> {
 			Ok(false)
 		}
 
-		fn rebel(&self, _ext: &Extensions, gun: Gun, map: HashMap<u8, u8>) -> RpcResult<String> {
+		fn rebel(&self, gun: Gun, map: HashMap<u8, u8>) -> RpcResult<String> {
 			Ok(format!("{} {:?}", map.values().len(), gun))
 		}
 
-		async fn can_have_any_name(
-			&self,
-			_ext: &Extensions,
-			beverage: Beverage,
-			some_bytes: Vec<u8>,
-		) -> RpcResult<String> {
+		async fn can_have_any_name(&self, beverage: Beverage, some_bytes: Vec<u8>) -> RpcResult<String> {
 			Ok(format!("drink: {:?}, phases: {:?}", beverage, some_bytes))
 		}
 
-		async fn can_have_options(&self, _ext: &Extensions, x: usize) -> RpcResult<Option<String>> {
+		async fn can_have_options(&self, x: usize) -> RpcResult<Option<String>> {
 			match x {
 				0 => Ok(Some("one".to_string())),
 				1 => Ok(None),


### PR DESCRIPTION
Follow-up on #1306 

Let's add on option to use `Extensions` in the API or not because it may be annoying to just mark it as used and would be nice not to break the previous API for existing users.

```rust
#[rpc(client, server)]
pub trait Rpc {
        // legacy
	#[method(name = "foo"])
	async fn async_method(&self, param_a: u8, param_b: String) -> u16>;

        // with extensions
	#[method(name = "with_ext", with_extensions)]
	async fn f(&self) -> bool;
}

impl RpcServer for () {
	async fn async_method(&self, param_a: u8, param_b: String) -> u16 {
            12
        }

	// NOTE: ext is injected here in the API
        async fn f(&self, ext: &Extensions: b: String) -> {
             ext.get::<u32>().is_ok()
        }
}
```