### PR TITLE
feat: inject connection id in extensions

### DIFF
--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -73,7 +73,7 @@ type UnsubscriptionMethod =
 	Arc<dyn Send + Sync + Fn(Id, Params, ConnectionId, MaxResponseSize, Extensions) -> MethodResponse>;
 
 /// Connection ID.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, serde::Deserialize, serde::Serialize)]
 pub struct ConnectionId(pub usize);
 
 impl From<u32> for ConnectionId {

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -302,8 +302,8 @@ impl PendingSubscriptionSink {
 	}
 
 	/// Returns connection identifier, which was used to perform pending subscription request
-	pub fn connection_id(&self) -> ConnectionId {
-		self.uniq_sub.conn_id
+	pub fn connection_id(&self) -> usize {
+		self.uniq_sub.conn_id.0
 	}
 }
 
@@ -336,8 +336,8 @@ impl SubscriptionSink {
 	}
 
 	/// Get the connection ID.
-	pub fn connection_id(&self) -> ConnectionId {
-		self.uniq_sub.conn_id
+	pub fn connection_id(&self) -> usize {
+		self.uniq_sub.conn_id.0
 	}
 
 	/// Send out a response on the subscription and wait until there is capacity.

--- a/examples/examples/server_with_connection_details.rs
+++ b/examples/examples/server_with_connection_details.rs
@@ -25,47 +25,23 @@
 // DEALINGS IN THE SOFTWARE.
 
 use std::net::SocketAddr;
-use std::sync::atomic::AtomicU32;
-use std::sync::Arc;
 
-use futures::future::{self, Either};
-use hyper_util::rt::{TokioExecutor, TokioIo};
 use jsonrpsee::core::async_trait;
 use jsonrpsee::core::SubscriptionResult;
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::server::middleware::rpc::RpcServiceT;
-use jsonrpsee::server::{stop_channel, PendingSubscriptionSink, RpcServiceBuilder, SubscriptionMessage};
+use jsonrpsee::server::{PendingSubscriptionSink, SubscriptionMessage};
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 use jsonrpsee::ws_client::WsClientBuilder;
+use jsonrpsee::ConnectionId;
 use jsonrpsee::Extensions;
-use tokio::net::TcpListener;
-use tower::Service;
-
-#[derive(Debug, Clone)]
-struct ConnectionDetails<S> {
-	inner: S,
-	connection_id: u32,
-}
-
-impl<'a, S> RpcServiceT<'a> for ConnectionDetails<S>
-where
-	S: RpcServiceT<'a>,
-{
-	type Future = S::Future;
-
-	fn call(&self, mut request: jsonrpsee::types::Request<'a>) -> Self::Future {
-		request.extensions_mut().insert(self.connection_id);
-		self.inner.call(request)
-	}
-}
 
 #[rpc(server, client)]
 pub trait Rpc {
 	/// method with connection ID.
 	#[method(name = "connectionIdMethod")]
-	async fn method(&self, first_param: usize, second_param: u16) -> Result<u32, ErrorObjectOwned>;
+	async fn method(&self) -> Result<usize, ErrorObjectOwned>;
 
-	#[subscription(name = "subscribeConnectionId", item = u32)]
+	#[subscription(name = "subscribeConnectionId", item = usize)]
 	async fn sub(&self) -> SubscriptionResult;
 }
 
@@ -73,14 +49,19 @@ pub struct RpcServerImpl;
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-	async fn method(&self, ext: &Extensions, _first_param: usize, _second_param: u16) -> Result<u32, ErrorObjectOwned> {
-		ext.get::<u32>().cloned().ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))
+	async fn method(&self, ext: &Extensions) -> Result<usize, ErrorObjectOwned> {
+		let conn_id = ext
+			.get::<ConnectionId>()
+			.cloned()
+			.ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))?;
+
+		Ok(conn_id.0)
 	}
 
 	async fn sub(&self, pending: PendingSubscriptionSink, ext: &Extensions) -> SubscriptionResult {
 		let sink = pending.accept().await?;
 		let conn_id = ext
-			.get::<u32>()
+			.get::<ConnectionId>()
 			.cloned()
 			.ok_or_else(|| ErrorObject::owned(0, "No connection details found", None::<()>))?;
 		sink.send(SubscriptionMessage::from_json(&conn_id).unwrap()).await?;
@@ -99,14 +80,14 @@ async fn main() -> anyhow::Result<()> {
 	let url = format!("ws://{}", server_addr);
 
 	let client = WsClientBuilder::default().build(&url).await?;
-	let connection_id_first = client.method(1, 2).await.unwrap();
+	let connection_id_first = client.method().await.unwrap();
 
 	// Second call from the same connection ID.
-	assert_eq!(client.method(1, 2).await.unwrap(), connection_id_first);
+	assert_eq!(client.method().await.unwrap(), connection_id_first);
 
 	// Second client will increment the connection ID.
 	let client2 = WsClientBuilder::default().build(&url).await?;
-	let connection_id_second = client2.method(1, 2).await.unwrap();
+	let connection_id_second = client2.method().await.unwrap();
 	assert_ne!(connection_id_first, connection_id_second);
 
 	let mut sub = client.sub().await.unwrap();
@@ -119,81 +100,12 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
-	let addr = listener.local_addr()?;
+	let server = jsonrpsee::server::Server::builder().build("127.0.0.1:0").await?;
+	let addr = server.local_addr()?;
 
-	let (stop_hdl, server_hdl) = stop_channel();
+	let handle = server.start(RpcServerImpl.into_rpc());
 
-	tokio::spawn(async move {
-		let conn_id = Arc::new(AtomicU32::new(0));
-		// Create and finalize a server configuration from a TowerServiceBuilder
-		// given an RpcModule and the stop handle.
-		let svc_builder = jsonrpsee::server::Server::builder().to_service_builder();
-		let methods = RpcServerImpl.into_rpc();
-
-		loop {
-			let stream = tokio::select! {
-				res = listener.accept() => {
-					match res {
-						Ok((stream, _remote_addr)) => stream,
-						Err(e) => {
-							tracing::error!("failed to accept v4 connection: {:?}", e);
-							continue;
-						}
-					}
-				}
-				_ = stop_hdl.clone().shutdown() => break,
-			};
-
-			let methods2 = methods.clone();
-			let stop_hdl2 = stop_hdl.clone();
-			let svc_builder2 = svc_builder.clone();
-			let conn_id2 = conn_id.clone();
-			let svc = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
-				let connection_id = conn_id2.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-				let rpc_middleware = RpcServiceBuilder::default()
-					.layer_fn(move |service| ConnectionDetails { inner: service, connection_id });
-
-				// Start a new service with our own connection ID.
-				let mut tower_service = svc_builder2
-					.clone()
-					.set_rpc_middleware(rpc_middleware)
-					.connection_id(connection_id)
-					.build(methods2.clone(), stop_hdl2.clone());
-
-				async move { tower_service.call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e)) }
-			});
-
-			let stop_hdl2 = stop_hdl.clone();
-			// Spawn a new task to serve each respective (Hyper) connection.
-			tokio::spawn(async move {
-				let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
-				let conn = builder.serve_connection_with_upgrades(TokioIo::new(stream), svc);
-				let stopped = stop_hdl2.shutdown();
-
-				// Pin the future so that it can be polled.
-				tokio::pin!(stopped, conn);
-
-				let res = match future::select(conn, stopped).await {
-					// Return the connection if not stopped.
-					Either::Left((conn, _)) => conn,
-					// If the server is stopped, we should gracefully shutdown
-					// the connection and poll it until it finishes.
-					Either::Right((_, mut conn)) => {
-						conn.as_mut().graceful_shutdown();
-						conn.await
-					}
-				};
-
-				// Log any errors that might have occurred.
-				if let Err(err) = res {
-					tracing::error!(err=?err, "HTTP connection failed");
-				}
-			});
-		}
-	});
-
-	tokio::spawn(server_hdl.stopped());
+	tokio::spawn(handle.stopped());
 
 	Ok(addr)
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1101,7 +1101,7 @@ where
 					let rpc_service = RpcService::new(
 						this.methods.clone(),
 						this.server_cfg.max_response_body_size as usize,
-						this.conn_id as usize,
+						this.conn_id.into(),
 						cfg,
 					);
 
@@ -1160,7 +1160,7 @@ where
 			let rpc_service = self.rpc_middleware.service(RpcService::new(
 				methods,
 				max_response_size as usize,
-				this.conn_id as usize,
+				this.conn_id.into(),
 				RpcServiceCfg::OnlyCalls,
 			));
 

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -51,7 +51,7 @@ where
 	let rpc_service = rpc_service.service(RpcService::new(
 		methods.into(),
 		max_response_body_size as usize,
-		conn.conn_id as usize,
+		conn.conn_id.into(),
 		RpcServiceCfg::OnlyCalls,
 	));
 

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -443,7 +443,7 @@ where
 			let rpc_service = RpcService::new(
 				methods.into(),
 				server_cfg.max_response_body_size as usize,
-				conn.conn_id as usize,
+				conn.conn_id.into(),
 				rpc_service_cfg,
 			);
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/jsonrpsee/pull/1306#discussion_r1613301472

I introduced a wrapper type ConnectionId to avoid collisions in the extensions because those the builtin rustc types may used by users and they might unintentionally overwrite usize for some else....