### PR TITLE
client: set `authorization header` from the URL

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -15,6 +15,7 @@ publish = true
 
 [dependencies]
 async-trait = "0.1"
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 hyper = { version = "1.3", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27.1", default-features = false, features = ["http1", "http2", "tls12", "logging", "ring"], optional = true }
 hyper-util = { version = "0.1.1", features = ["client", "client-legacy", "tokio", "http1", "http2"] }

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -260,19 +260,16 @@ impl<L> HttpTransportClientBuilder<L> {
 			}
 		}
 
-		match url.password() {
-			Some(pwd) if !url.username().is_empty() => {
-				if !cached_headers.contains_key(hyper::header::AUTHORIZATION) {
-					let digest = base64::engine::general_purpose::STANDARD.encode(format!("{}:{pwd}", url.username()));
-					cached_headers.append(
-						hyper::header::AUTHORIZATION,
-						HeaderValue::from_str(&format!("Basic {digest}"))
-							.map_err(|_| Error::Url("Header value `authorization basic user:pwd` invalid".into()))?,
-					);
-				}
+		if let Some(pwd) = url.password() {
+			if !cached_headers.contains_key(hyper::header::AUTHORIZATION) {
+				let digest = base64::engine::general_purpose::STANDARD.encode(format!("{}:{pwd}", url.username()));
+				cached_headers.append(
+					hyper::header::AUTHORIZATION,
+					HeaderValue::from_str(&format!("Basic {digest}"))
+						.map_err(|_| Error::Url("Header value `authorization basic user:pwd` invalid".into()))?,
+				);
 			}
-			_ => (),
-		};
+		}
 
 		Ok(HttpTransportClient {
 			target: url.as_str().to_owned(),

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -263,7 +263,7 @@ impl<L> HttpTransportClientBuilder<L> {
 		if let Some(pwd) = url.password() {
 			if !cached_headers.contains_key(hyper::header::AUTHORIZATION) {
 				let digest = base64::engine::general_purpose::STANDARD.encode(format!("{}:{pwd}", url.username()));
-				cached_headers.append(
+				cached_headers.insert(
 					hyper::header::AUTHORIZATION,
 					HeaderValue::from_str(&format!("Basic {digest}"))
 						.map_err(|_| Error::Url("Header value `authorization basic user:pwd` invalid".into()))?,

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -26,6 +26,7 @@ tokio-util = { version = "0.7", features = ["compat"], optional = true }
 tokio = { version = "1.16", features = ["net", "time", "macros"], optional = true }
 pin-project = { version = "1", optional = true }
 url = { version = "2.4.0", optional = true }
+base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }
 
 # tls
 tokio-rustls = { version = "0.26", default-features = false, optional = true, features = ["logging", "tls12", "ring"] }
@@ -43,6 +44,7 @@ gloo-net = { version = "0.5.0", default-features = false, features = ["json", "w
 tls = ["tokio-rustls", "rustls-pki-types", "rustls-platform-verifier", "rustls"]
 
 ws = [
+    "base64",
     "futures-util",
     "http",
     "tokio",

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -440,7 +440,7 @@ impl WsTransportClientBuilder {
 		);
 
 		let headers: Vec<_> = match &target.basic_auth {
-			Some(basic_auth) if self.headers.contains_key(http::header::AUTHORIZATION) => {
+			Some(basic_auth) if !self.headers.contains_key(http::header::AUTHORIZATION) => {
 				let it1 =
 					self.headers.iter().map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() });
 				let it2 = std::iter::once(Header {

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -30,6 +30,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use base64::Engine;
 use futures_util::io::{BufReader, BufWriter};
 use jsonrpsee_core::client::{MaybeSend, ReceivedMessage, TransportReceiverT, TransportSenderT};
 use jsonrpsee_core::TEN_MB_SIZE_BYTES;
@@ -438,8 +439,23 @@ impl WsTransportClientBuilder {
 			&target.path_and_query,
 		);
 
-		let headers: Vec<_> =
-			self.headers.iter().map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() }).collect();
+		let headers: Vec<_> = if let Some(basic_auth) = &target.basic_auth {
+			if !self.headers.contains_key(http::header::AUTHORIZATION) {
+				let it1 =
+					self.headers.iter().map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() });
+				let it2 = std::iter::once(Header {
+					name: http::header::AUTHORIZATION.as_str(),
+					value: basic_auth.as_bytes(),
+				});
+
+				it1.chain(it2).collect()
+			} else {
+				self.headers.iter().map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() }).collect()
+			}
+		} else {
+			self.headers.iter().map(|(key, value)| Header { name: key.as_str(), value: value.as_bytes() }).collect()
+		};
+
 		client.set_headers(&headers);
 
 		// Perform the initial handshake.
@@ -531,8 +547,8 @@ impl From<soketto::connection::Error> for WsError {
 }
 
 /// Represents a verified remote WebSocket address.
-#[derive(Debug, Clone)]
-pub struct Target {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Target {
 	/// Socket addresses resolved the host name.
 	sockaddrs: Vec<SocketAddr>,
 	/// The host name (domain or IP address).
@@ -543,6 +559,8 @@ pub struct Target {
 	_mode: Mode,
 	/// The path and query parts from an URL.
 	path_and_query: String,
+	/// Optional <username:password> from an URL.
+	basic_auth: Option<HeaderValue>,
 }
 
 impl TryFrom<url::Url> for Target {
@@ -569,14 +587,20 @@ impl TryFrom<url::Url> for Target {
 			path_and_query.push_str(query);
 		}
 
+		let basic_auth = match url.password() {
+			Some(pwd) if !url.username().is_empty() => {
+				let digest = base64::engine::general_purpose::STANDARD.encode(format!("{}:{}", url.username(), pwd));
+				let val = HeaderValue::from_str(&format!("Basic {digest}"))
+					.map_err(|_| WsHandshakeError::Url("Header value `authorization basic user:pwd` invalid".into()))?;
+
+				Some(val)
+			}
+			_ => None,
+		};
+		let host_header = if let Some(port) = url.port() { format!("{host}:{port}") } else { host.to_string() };
+
 		let sockaddrs = url.socket_addrs(|| None).map_err(WsHandshakeError::ResolutionFailed)?;
-		Ok(Self {
-			sockaddrs,
-			host,
-			host_header: url.authority().to_string(),
-			_mode,
-			path_and_query: path_and_query.to_string(),
-		})
+		Ok(Self { sockaddrs, host, host_header, _mode, path_and_query: path_and_query.to_string(), basic_auth })
 	}
 }
 
@@ -593,13 +617,23 @@ fn build_tls_config(cert_store: &CertificateStore) -> Result<tokio_rustls::TlsCo
 
 #[cfg(test)]
 mod tests {
+	use http::HeaderValue;
+
 	use super::{Mode, Target, Url, WsHandshakeError};
 
-	fn assert_ws_target(target: Target, host: &str, host_header: &str, mode: Mode, path_and_query: &str) {
+	fn assert_ws_target(
+		target: Target,
+		host: &str,
+		host_header: &str,
+		mode: Mode,
+		path_and_query: &str,
+		basic_auth: Option<HeaderValue>,
+	) {
 		assert_eq!(&target.host, host);
 		assert_eq!(&target.host_header, host_header);
 		assert_eq!(target._mode, mode);
 		assert_eq!(&target.path_and_query, path_and_query);
+		assert_eq!(target.basic_auth, basic_auth);
 	}
 
 	fn parse_target(uri: &str) -> Result<Target, WsHandshakeError> {
@@ -609,14 +643,14 @@ mod tests {
 	#[test]
 	fn ws_works_with_port() {
 		let target = parse_target("ws://127.0.0.1:9933").unwrap();
-		assert_ws_target(target, "127.0.0.1", "127.0.0.1:9933", Mode::Plain, "/");
+		assert_ws_target(target, "127.0.0.1", "127.0.0.1:9933", Mode::Plain, "/", None);
 	}
 
 	#[cfg(feature = "tls")]
 	#[test]
 	fn wss_works_with_port() {
 		let target = parse_target("wss://kusama-rpc.polkadot.io:9999").unwrap();
-		assert_ws_target(target, "kusama-rpc.polkadot.io", "kusama-rpc.polkadot.io:9999", Mode::Tls, "/");
+		assert_ws_target(target, "kusama-rpc.polkadot.io", "kusama-rpc.polkadot.io:9999", Mode::Tls, "/", None);
 	}
 
 	#[cfg(not(feature = "tls"))]
@@ -643,31 +677,42 @@ mod tests {
 	#[test]
 	fn url_with_path_works() {
 		let target = parse_target("ws://127.0.0.1/my-special-path").unwrap();
-		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/my-special-path");
+		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/my-special-path", None);
 	}
 
 	#[test]
 	fn url_with_query_works() {
 		let target = parse_target("ws://127.0.0.1/my?name1=value1&name2=value2").unwrap();
-		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/my?name1=value1&name2=value2");
+		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/my?name1=value1&name2=value2", None);
 	}
 
 	#[test]
 	fn url_with_fragment_is_ignored() {
 		let target = parse_target("ws://127.0.0.1:/my.htm#ignore").unwrap();
-		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/my.htm");
+		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/my.htm", None);
 	}
 
 	#[cfg(feature = "tls")]
 	#[test]
 	fn wss_default_port_is_omitted() {
 		let target = parse_target("wss://127.0.0.1:443").unwrap();
-		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Tls, "/");
+		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Tls, "/", None);
 	}
 
 	#[test]
 	fn ws_default_port_is_omitted() {
 		let target = parse_target("ws://127.0.0.1:80").unwrap();
-		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/");
+		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/", None);
+	}
+
+	#[test]
+	fn ws_with_username_and_password() {
+		use base64::Engine;
+
+		let target = parse_target("ws://user:pwd@127.0.0.1").unwrap();
+		let digest = base64::engine::general_purpose::STANDARD.encode("user:pwd");
+		let basic_auth = HeaderValue::from_str(&format!("Basic {digest}")).unwrap();
+
+		assert_ws_target(target, "127.0.0.1", "127.0.0.1", Mode::Plain, "/", Some(basic_auth));
 	}
 }


### PR DESCRIPTION
Close #1371 

The rationale is to unify the behavior how cuRL, browsers and similar are handling username and passwords from URLs.

## Testing

### curl
```
$ curl -sSG "http://user:pwd@localhost:9944"
2024-05-31 09:25:59.366 TRACE tokio-runtime-worker jsonrpsee-server: Request { method: GET, uri: /, version: HTTP/1.1, headers: {"host": "localhost:9944", "authorization": "Basic dXNlcjpwd2Q=", "user-agent": "curl/8.2.1", "accept": "*/*"}, body: Body(UnsyncBoxBody) }
```

### jsonrpsee ws client
```
$ jsonrpsee-ws
2024-05-31 09:28:32.016 TRACE tokio-runtime-worker jsonrpsee-server: Request { method: GET, uri: /, version: HTTP/1.1, headers: {"host": "localhost:9944", "upgrade": "websocket", "connection": "Upgrade", "sec-websocket-key": "amixRuJIg8sPqd0K2tNSTw==", "authorization": "Basic dXNlcjpwd2Q=", "sec-websocket-version": "13"}, body: Body(UnsyncBoxBody) }
```

### jsonrpsee http client
```
$ jsonrpsee-http 
2024-05-31 09:39:21.580 TRACE tokio-runtime-worker jsonrpsee-server: Request { method: POST, uri: /, version: HTTP/1.1, headers: {"content-type": "application/json", "accept": "application/json", "authorization": "Basic dXNlcjpwd2Q=", "host": "localhost:9944", "content-length": "62"}, body: Body(UnsyncBoxBody) }
```


