### PR TITLE
types: make jsonrpc field optional

### DIFF
--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -385,12 +385,7 @@ where
 		let mut batch_request = Vec::with_capacity(batch.len());
 		for ((method, params), id) in batch.into_iter().zip(id_range.clone()) {
 			let id = self.id_manager.as_id_kind().into_id(id);
-			batch_request.push(RequestSer {
-				jsonrpc: TwoPointZero,
-				id,
-				method: method.into(),
-				params: params.map(StdCow::Owned),
-			});
+			batch_request.push(RequestSer::owned(id, method, params));
 		}
 
 		let fut = self.transport.send_and_read_body(serde_json::to_string(&batch_request).map_err(Error::ParseError)?);

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -24,7 +24,6 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::borrow::Cow as StdCow;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
@@ -41,7 +40,7 @@ use jsonrpsee_core::client::{
 use jsonrpsee_core::params::BatchRequestBuilder;
 use jsonrpsee_core::traits::ToRpcParams;
 use jsonrpsee_core::{BoxError, JsonRawValue, TEN_MB_SIZE_BYTES};
-use jsonrpsee_types::{ErrorObject, InvalidRequestId, ResponseSuccess, TwoPointZero};
+use jsonrpsee_types::{ErrorObject, InvalidRequestId, ResponseSuccess};
 use serde::de::DeserializeOwned;
 use tower::layer::util::Identity;
 use tower::{Layer, Service};

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -545,12 +545,7 @@ impl ClientT for Client {
 		let mut batches = Vec::with_capacity(batch.len());
 		for ((method, params), id) in batch.into_iter().zip(id_range.clone()) {
 			let id = self.id_manager.as_id_kind().into_id(id);
-			batches.push(RequestSer {
-				jsonrpc: TwoPointZero,
-				id,
-				method: method.into(),
-				params: params.map(StdCow::Owned),
-			});
+			batches.push(RequestSer::owned(id, method, params));
 		}
 
 		let (send_back_tx, send_back_rx) = oneshot::channel();

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -41,14 +41,13 @@ use crate::params::{BatchRequestBuilder, EmptyBatchRequest};
 use crate::tracing::client::{rx_log_from_json, tx_log_from_str};
 use crate::traits::ToRpcParams;
 use crate::JsonRawValue;
-use std::borrow::Cow as StdCow;
 
 use core::time::Duration;
 use helpers::{
 	build_unsubscribe_message, call_with_timeout, process_batch_response, process_notification,
 	process_single_response, process_subscription_response, stop_subscription,
 };
-use jsonrpsee_types::{InvalidRequestId, ResponseSuccess, TwoPointZero};
+use jsonrpsee_types::{InvalidRequestId, ResponseSuccess};
 use manager::RequestManager;
 use std::sync::Arc;
 

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -398,7 +398,7 @@ async fn invalid_request_object() {
 	let (addr, _handle) = server().with_default_timeout().await.unwrap();
 	let uri = to_http_uri(addr);
 
-	let req = r#"{"method":"bar","id":1}"#;
+	let req = r#"{"nethod":"bar","id":1}"#;
 	let response = http_request(req.into(), uri).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response.status, StatusCode::OK);
 	assert_eq!(response.body, invalid_request(Id::Num(1)));

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -465,7 +465,7 @@ async fn invalid_request_should_not_close_connection() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
-	let req = r#"{"method":"bar","id":1}"#;
+	let req = r#"{"nethod":"bar","id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_request(Id::Num(1)));
 	let request = r#"{"jsonrpc":"2.0","method":"say_hello","id":33}"#;

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -399,7 +399,7 @@ async fn invalid_request_object() {
 	let addr = server().await;
 	let mut client = WebSocketTestClient::new(addr).with_default_timeout().await.unwrap().unwrap();
 
-	let req = r#"{"method":"bar","id":1}"#;
+	let req = r#"{"nethod":"bar","id":1}"#;
 	let response = client.send_request_text(req).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(response, invalid_request(Id::Num(1)));
 }

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -300,7 +300,7 @@ mod test {
 			// Without params field
 			(r#"{"jsonrpc":"2.0","id":1,"method":"subtract"}"#, Some(id), None, method, Some(TwoPointZero)),
 			// Without params and ID.
-			(r#"{"jsonrpc":"2.0","id":null,"method":"subtract"}"#, None, None, method, Some(TwoPointZero)),
+			(r#"{"id":null,"method":"subtract"}"#, None, None, method, None),
 		];
 
 		for (ser, id, params, method, version) in test_vector.iter().cloned() {


### PR DESCRIPTION
Close #1142 

Previously, we made the interpretation that jsonrpc field must exist but recently https://github.com/paritytech/jsonrpsee/issues/1045 explained to me that it could be interpreted as optional.

So, let's change it to optional all over jsonrpsee.

I'm not 100% convinced by the interpretation of request object but it doesn't bother me to support it for stuff without the jsonrpc header...