### PR TITLE
feat(core): replace callbacks in `RpcModule` and `Methods`

### DIFF
--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -1159,9 +1159,6 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		R: IntoSubscriptionCloseResponse + Send,
 	{
 		let prev = self.methods.remove(subscribe_method_name);
-		// This method is auto-generated within the `register_subscription`
-		// method. As such we can safely remove it without returning it.
-		self.methods.remove(unsubscribe_method_name);
 
 		// Errors here can be ignored, as we know the method is not already
 		// registered (we just removed it).

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -261,6 +261,9 @@ impl Methods {
 	/// to determine whether to replace the existing method.
 	///
 	/// Returns the previous method callback if it was replaced.
+	///
+	/// Note: If a conflict exists, and `cond` evaluates to false, the method
+	/// will not be replaced and the new method will be dropped.
 	pub fn insert_or_replace_if(
 		&mut self,
 		name: &'static str,
@@ -325,7 +328,14 @@ impl Methods {
 	/// Merge two [`Methods`]'s by adding all [`MethodCallback`]s from `other`
 	/// into `self`. If a method with the same name already exists, evaluates
 	/// the provided `cond` with the method name to determine whether to
-	/// replace the existing method. Returns a list of removed methods.
+	/// replace the existing method. Uses [`Self::insert_or_replace_if`]
+	/// internally.
+	///
+	/// Returns a list of removed methods.
+	///
+	/// Note: If a conflict exists, and `cond` evaluates to false, the method
+	/// will not be replaced and the new method will be dropped. Methods
+	/// dropped this way will **not** be included in the returned list.
 	pub fn merge_replacing_if(
 		&mut self,
 		other: impl Into<Methods>,

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -980,6 +980,8 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		R: IntoSubscriptionCloseResponse + Send,
 	{
 		let prev = self.methods.remove(subscribe_method_name);
+		// This method is auto-generated within the `register_subscription`
+		// method. As such we can safely remove it without returning it.
 		self.methods.remove(unsubscribe_method_name);
 
 		// Errors here can be ignored, as we know the method is not already

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -250,10 +250,8 @@ impl Methods {
 
 	/// Inserts the method callback for a given name, replacing any existing
 	/// method with the same name.
-	pub fn insert_replacing(&mut self, name: &'static str, callback: MethodCallback) -> Option<MethodCallback> {
-		let prev = self.remove(name);
-		let _ = self.verify_and_insert(name, callback);
-		prev
+	pub fn insert(&mut self, name: &'static str, callback: MethodCallback) -> Option<MethodCallback> {
+		self.mut_callbacks().insert(name, callback)
 	}
 
 	/// Inserts the method callback for a given name. If a method with the same
@@ -264,7 +262,7 @@ impl Methods {
 	///
 	/// Note: If a conflict exists, and `cond` evaluates to false, the method
 	/// will not be replaced and the new method will be dropped.
-	pub fn insert_or_replace_if(
+	pub fn replace_if(
 		&mut self,
 		name: &'static str,
 		callback: MethodCallback,
@@ -328,7 +326,7 @@ impl Methods {
 	/// Merge two [`Methods`]'s by adding all [`MethodCallback`]s from `other`
 	/// into `self`. If a method with the same name already exists, evaluates
 	/// the provided `cond` with the method name to determine whether to
-	/// replace the existing method. Uses [`Self::insert_or_replace_if`]
+	/// replace the existing method. Uses [`Self::replace_if`]
 	/// internally.
 	///
 	/// Returns a list of removed methods.
@@ -345,7 +343,7 @@ impl Methods {
 
 		let mut removed = Vec::with_capacity(other.callbacks.len());
 		for (name, callback) in other.mut_callbacks().drain() {
-			if let Some(prev) = self.insert_or_replace_if(name, callback, &cond) {
+			if let Some(prev) = self.replace_if(name, callback, &cond) {
 				removed.push((name, prev));
 			}
 		}

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -311,7 +311,7 @@ impl Methods {
 	/// Merge two [`Methods`]'s by adding all [`MethodCallback`]s from `other`
 	/// into `self`, removing and returning any existing methods with the same
 	/// name.
-	pub fn merge_replacing(&mut self, other: impl Into<Methods>) -> Vec<(&'static str, MethodCallback)> {
+	pub fn merge_replace(&mut self, other: impl Into<Methods>) -> Vec<(&'static str, MethodCallback)> {
 		let mut other = other.into();
 		let callbacks = self.mut_callbacks();
 
@@ -336,7 +336,7 @@ impl Methods {
 	/// Note: If a conflict exists, and `cond` evaluates to false, the method
 	/// will not be replaced and the new method will be dropped. Methods
 	/// dropped this way will **not** be included in the returned list.
-	pub fn merge_replacing_if(
+	pub fn merge_replace_if(
 		&mut self,
 		other: impl Into<Methods>,
 		cond: impl Fn(&'static str) -> bool,

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -257,8 +257,8 @@ impl Methods {
 	}
 
 	/// Inserts the method callback for a given name. If a method with the same
-	/// name already exists, evaluates the provided closure to determine whether
-	/// to replace the existing method.
+	/// name already exists, evaluates the provided `cond` with the method name
+	/// to determine whether to replace the existing method.
 	///
 	/// Returns the previous method callback if it was replaced.
 	pub fn insert_or_replace_if(
@@ -324,8 +324,8 @@ impl Methods {
 
 	/// Merge two [`Methods`]'s by adding all [`MethodCallback`]s from `other`
 	/// into `self`. If a method with the same name already exists, evaluates
-	/// the provided `cond` to determine whether to replace the existing
-	/// method. Returns a list of removed methods.
+	/// the provided `cond` with the method name to determine whether to
+	/// replace the existing method. Returns a list of removed methods.
 	pub fn merge_replacing_if(
 		&mut self,
 		other: impl Into<Methods>,

--- a/server/src/middleware/rpc/layer/rpc_service.rs
+++ b/server/src/middleware/rpc/layer/rpc_service.rs
@@ -106,7 +106,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 					let rp = (callback)(id, params, max_response_body_size, extensions);
 					ResponseFuture::ready(rp)
 				}
-				MethodCallback::Subscription(callback) => {
+				MethodCallback::Subscription { method: callback, .. } => {
 					let RpcServiceCfg::CallsAndSubscriptions {
 						bounded_subscriptions,
 						sink,
@@ -131,7 +131,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 						ResponseFuture::ready(rp)
 					}
 				}
-				MethodCallback::Unsubscription(callback) => {
+				MethodCallback::Unsubscription { method: callback, .. } => {
 					// Don't adhere to any resource or subscription limits; always let unsubscribing happen!
 
 					let RpcServiceCfg::CallsAndSubscriptions { .. } = self.cfg else {
@@ -143,6 +143,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 					let rp = callback(id, params, conn_id, max_response_body_size, extensions);
 					ResponseFuture::ready(rp)
 				}
+				MethodCallback::Alias(_) => unreachable!("alias resolved in `method_with_name"),
 			},
 		}
 	}


### PR DESCRIPTION
Allows users to remove or replace methods in the `Methods` and `RpcModule` collections

closes #1053 

this is effectively a successor to #1058, that follows the `HashMap` idiom of returning items when they are replaced. This addresses the [earlier PR review](https://github.com/paritytech/jsonrpsee/pull/1058/files#r1151498070) that it is possible to replace without realizing it, by making all replacements explicit. The caller can then decide whether to drop the replaced functions or not

Also includes `insert_or_replace_if` and `merge_replacing_if` as proposed in #1058 pr review