### PR TITLE
server: pass `extensions` from http layer

### DIFF
--- a/examples/examples/rpc_middleware.rs
+++ b/examples/examples/rpc_middleware.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use jsonrpsee::core::{async_trait, client::ClientT};
+use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
 use jsonrpsee::server::middleware::rpc::{RpcServiceBuilder, RpcServiceT};
 use jsonrpsee::server::{MethodResponse, RpcModule, Server};
@@ -85,7 +85,6 @@ pub struct GlobalCalls<S> {
 	count: Arc<AtomicUsize>,
 }
 
-#[async_trait]
 impl<'a, S> RpcServiceT<'a> for GlobalCalls<S>
 where
 	S: RpcServiceT<'a> + Send + Sync + Clone + 'static,

--- a/examples/examples/server_with_connection_details.rs
+++ b/examples/examples/server_with_connection_details.rs
@@ -114,8 +114,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
-	let rpc_middleware =
-		jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(|service| LoggingMiddleware(service));
+	let rpc_middleware = jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
 
 	let server = jsonrpsee::server::Server::builder().set_rpc_middleware(rpc_middleware).build("127.0.0.1:0").await?;
 	let addr = server.local_addr()?;

--- a/server/src/middleware/rpc/layer/rpc_service.rs
+++ b/server/src/middleware/rpc/layer/rpc_service.rs
@@ -89,7 +89,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 		match self.methods.method_with_name(&method) {
 			None => {
 				let rp =
-					MethodResponse::error_with_extensions(id, ErrorObject::from(ErrorCode::MethodNotFound), extensions);
+					MethodResponse::error(id, ErrorObject::from(ErrorCode::MethodNotFound)).with_extensions(extensions);
 				ResponseFuture::ready(rp)
 			}
 			Some((_name, method)) => match method {
@@ -113,11 +113,8 @@ impl<'a> RpcServiceT<'a> for RpcService {
 					} = self.cfg.clone()
 					else {
 						tracing::warn!("Subscriptions not supported");
-						let rp = MethodResponse::error_with_extensions(
-							id,
-							ErrorObject::from(ErrorCode::InternalError),
-							extensions,
-						);
+						let rp = MethodResponse::error(id, ErrorObject::from(ErrorCode::InternalError))
+							.with_extensions(extensions);
 						return ResponseFuture::ready(rp);
 					};
 
@@ -130,7 +127,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
 					} else {
 						let max = bounded_subscriptions.max();
 						let rp =
-							MethodResponse::error_with_extensions(id, reject_too_many_subscriptions(max), extensions);
+							MethodResponse::error(id, reject_too_many_subscriptions(max)).with_extensions(extensions);
 						ResponseFuture::ready(rp)
 					}
 				}
@@ -139,11 +136,8 @@ impl<'a> RpcServiceT<'a> for RpcService {
 
 					let RpcServiceCfg::CallsAndSubscriptions { .. } = self.cfg else {
 						tracing::warn!("Subscriptions not supported");
-						let rp = MethodResponse::error_with_extensions(
-							id,
-							ErrorObject::from(ErrorCode::InternalError),
-							extensions,
-						);
+						let rp = MethodResponse::error(id, ErrorObject::from(ErrorCode::InternalError))
+							.with_extensions(extensions);
 						return ResponseFuture::ready(rp);
 					};
 

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -95,7 +95,8 @@ where
 				}
 			};
 
-			let rp = handle_rpc_call(&body, is_single, batch_config, max_response_size, &rpc_service).await;
+			let rp = handle_rpc_call(&body, is_single, batch_config, max_response_size, &rpc_service, parts.extensions)
+				.await;
 
 			// If the response is empty it means that it was a notification or empty batch.
 			// For HTTP these are just ACK:ed with a empty body.

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -78,3 +78,26 @@ where
 		self.project().future.poll(cx)
 	}
 }
+
+/// Helpers to deserialize a request with extensions.
+pub(crate) mod deserialize {
+	/// Helper to deserialize a request with extensions.
+	pub(crate) fn from_slice_with_extensions(
+		data: &[u8],
+		extensions: http::Extensions,
+	) -> Result<jsonrpsee_types::Request, serde_json::Error> {
+		let mut req: jsonrpsee_types::Request = serde_json::from_slice(data)?;
+		*req.extensions_mut() = extensions;
+		Ok(req)
+	}
+
+	/// Helper to deserialize a request with extensions.
+	pub(crate) fn from_str_with_extensions(
+		data: &str,
+		extensions: http::Extensions,
+	) -> Result<jsonrpsee_types::Request, serde_json::Error> {
+		let mut req: jsonrpsee_types::Request = serde_json::from_str(data)?;
+		*req.extensions_mut() = extensions;
+		Ok(req)
+	}
+}

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use helpers::init_logger;
-use jsonrpsee::core::{async_trait, client::ClientT, ClientError};
+use jsonrpsee::core::{client::ClientT, ClientError};
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::{RpcServiceBuilder, RpcServiceT};
@@ -62,7 +62,6 @@ pub struct CounterMiddleware<S> {
 	counter: Arc<Mutex<Counter>>,
 }
 
-#[async_trait]
 impl<'a, S> RpcServiceT<'a> for CounterMiddleware<S>
 where
 	S: RpcServiceT<'a> + Send + Sync + Clone + 'static,


### PR DESCRIPTION
Close #1388 

This PR changes that we pass the `Extensions` from the origin HTTP request which means that is seen every RpcMiddleware layer. This causes us to inject connectionID in the origin HTTP request to be seen by all layers.

Recall, that our RpcService is the lowest layer in the RpcMiddleware call tree and it doesn't work to inject stuff because it will not be seen by other middleware layers.

An annoyance with this is that we to clone the Extensions for every JSON-RPC call which includes `ConnectionId` and `hyper::upgrade::OnUpgrade` which roughly is 16 bytes of overhead but I'm okay with that.