### PR TITLE
server: use `ConnectionId` in subscription APIs

### DIFF
--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -302,8 +302,8 @@ impl PendingSubscriptionSink {
 	}
 
 	/// Returns connection identifier, which was used to perform pending subscription request
-	pub fn connection_id(&self) -> usize {
-		self.uniq_sub.conn_id.0
+	pub fn connection_id(&self) -> ConnectionId {
+		self.uniq_sub.conn_id
 	}
 }
 
@@ -336,8 +336,8 @@ impl SubscriptionSink {
 	}
 
 	/// Get the connection ID.
-	pub fn connection_id(&self) -> usize {
-		self.uniq_sub.conn_id.0
+	pub fn connection_id(&self) -> ConnectionId {
+		self.uniq_sub.conn_id
 	}
 
 	/// Send out a response on the subscription and wait until there is capacity.


### PR DESCRIPTION
The reason is to unify the APIs such that we were using `usize` as connectionID in the subscriptions APIs and `ConnectionId` in the extensions which was awkward. 

Let's unify them and break the API compared to v0.22



