### PR TITLE
deps: tokio ^1.23.1

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -27,7 +27,7 @@ rustls-platform-verifier = { version = "0.3", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1.16", features = ["time"] }
+tokio = { version = "1.23.1", features = ["time"] }
 tracing = "0.1.34"
 tower = { version = "0.4.13", features = ["util"] }
 url = "2.4.0"
@@ -35,7 +35,7 @@ url = "2.4.0"
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 jsonrpsee-test-utils = { path = "../../test-utils" }
-tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros"] }
+tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["tls"]

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -23,7 +23,7 @@ futures-channel = { version = "0.3.14", default-features = false, optional = tru
 futures-util = { version = "0.3.14", default-features = false, features = ["alloc"], optional = true }
 http = { version = "1", optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
-tokio = { version = "1.16", features = ["net", "time", "macros"], optional = true }
+tokio = { version = "1.23.1", features = ["net", "time", "macros"], optional = true }
 pin-project = { version = "1", optional = true }
 url = { version = "2.4.0", optional = true }
 base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -23,7 +23,7 @@ url = "2.4.0"
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 jsonrpsee-test-utils = { path = "../../test-utils" }
-tokio = { version = "1.16", features = ["macros"] }
+tokio = { version = "1.23.1", features = ["macros"] }
 serde_json = "1"
 serde = "1"
 rustls = { version = "0.23.7", default-features = false, features = ["logging", "std", "tls12", "ring"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,7 +32,7 @@ http-body-util = { version = "0.1.1", optional = true }
 rustc-hash = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }
 parking_lot = { version = "0.12", optional = true }
-tokio = { version = "1.16", optional = true }
+tokio = { version = "1.23.1", optional = true }
 wasm-bindgen-futures = { version = "0.4.19", optional = true }
 futures-timer = { version = "3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
@@ -67,7 +67,7 @@ async-wasm-client = [
 
 [dev-dependencies]
 serde_json = "1.0"
-tokio = { version = "1.16", features = ["macros", "rt"] }
+tokio = { version = "1.23.1", features = ["macros", "rt"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "macros"] }
 http-body-util = "0.1.1"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-tls"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1.23.1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde_json = { version = "1" }
 tower-http = { version = "0.5.2", features = ["full"] }

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -25,7 +25,7 @@ jsonrpsee-proc-macros = { workspace = true, optional = true }
 jsonrpsee-core = { workspace = true, optional = true }
 jsonrpsee-types = { workspace = true, optional = true }
 tracing = { version = "0.1.34", optional = true }
-tokio = { version = "1", optional = true }
+tokio = { version = "1.23.1", optional = true }
 
 [features]
 client-ws-transport-tls = ["jsonrpsee-client-transport/ws", "jsonrpsee-client-transport/tls"]

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -32,5 +32,5 @@ futures-util = { version = "0.3.14", default-features = false }
 serde_json = "1"
 serde = "1"
 trybuild = "1.0"
-tokio = { version = "1.16", features = ["rt", "macros"] }
+tokio = { version = "1.23.1", features = ["rt", "macros"] }
 tower = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.34"
 serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = { version = "0.8", features = ["http"] }
-tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 hyper = { version = "1.3", features = ["server", "http1", "http2"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -16,5 +16,5 @@ tracing = "0.1.34"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 soketto = { version = "0.8.0", features = ["http"] }
-tokio = { version = "1.16", features = ["net", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpsee = { path = "../jsonrpsee", features = ["server", "client-core", "http-
 jsonrpsee-test-utils = { path = "../test-utils" }
 serde = "1"
 serde_json = "1"
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1.23.1", features = ["full"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["compat"]}
 tower = { version = "0.4.13", features = ["full"] }


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2023-0001.html

Users can update this themselves via `Cargo.lock` but let's require ^1.23.1 to be on the safe side.