### PR TITLE
chore: remove anyhow dependency in types

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 publish = true
 
 [dependencies]
-anyhow = "1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -29,7 +29,6 @@
 
 use std::fmt;
 
-use anyhow::anyhow;
 use beef::Cow;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::ser::Serializer;
@@ -225,7 +224,7 @@ impl<'a> ParamsSequence<'a> {
 	{
 		match self.next_inner() {
 			Some(result) => result,
-			None => Err(invalid_params(anyhow!("No more params"))),
+			None => Err(invalid_params("No more params")),
 		}
 	}
 


### PR DESCRIPTION
`invalid_params` accepts ToString and anyhow to_string returns the original message.