### PR TITLE
deps: remove beef

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,6 @@ publish = true
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-beef = { version = "0.5.1", features = ["impl_serde"] }
 jsonrpsee-types = { workspace = true }
 thiserror = "1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -81,12 +81,12 @@ pub mod __reexports {
 	}
 }
 
-pub use beef::Cow;
 pub use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json::{
 	to_value as to_json_value, value::to_raw_value as to_json_raw_value, value::RawValue as JsonRawValue,
 	Value as JsonValue,
 };
+pub use std::borrow::Cow;
 
 /// Ten megabytes.
 pub const TEN_MB_SIZE_BYTES: u32 = 10 * 1024 * 1024;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [dev-dependencies]
 anyhow = "1"
-beef = { version = "0.5.1", features = ["impl_serde"] }
 fast-socks5 = { version = "0.9.1" }
 futures = { version = "0.3.14", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.14", default-features = false, features = ["alloc"]}

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 publish = true
 
 [dependencies]
-beef = { version = "0.5.1", features = ["impl_serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"


### PR DESCRIPTION
Since 1.76, `Cow<str>` is 3 words wide (see https://github.com/rust-lang/rust/issues/117763), and the `lean::Cow` type is not used, thus making the `beef` dependency obsolete.

This is a breaking change as it's exposed in `Id`, `SubscriptionId`, and `jsonrpsee::core::Cow`, and the `beef::Cow` and `std::borrow::Cow` APIs are slightly different.