### PR TITLE
deps: remove anyhow

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 publish = true
 
 [dependencies]
-anyhow = "1"
 async-trait = "0.1"
 beef = { version = "0.5.1", features = ["impl_serde"] }
 jsonrpsee-types = { workspace = true }

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -1030,7 +1030,7 @@ where
 			}
 			_ = inactivity_stream.next() => {
 				if inactivity_check.is_inactive() {
-					break Err(Error::Transport(anyhow::anyhow!("WebSocket ping/pong inactive")));
+					break Err(Error::Transport("WebSocket ping/pong inactive".into()));
 				}
 			}
 		}

--- a/core/src/client/error.rs
+++ b/core/src/client/error.rs
@@ -26,7 +26,7 @@
 
 //! Error type for client(s).
 
-use crate::{params::EmptyBatchRequest, RegisterMethodError};
+use crate::{params::EmptyBatchRequest, BoxError, RegisterMethodError};
 use jsonrpsee_types::{ErrorObjectOwned, InvalidRequestId};
 use std::sync::Arc;
 
@@ -37,8 +37,8 @@ pub enum Error {
 	#[error("{0}")]
 	Call(#[from] ErrorObjectOwned),
 	/// Networking error or error on the low-level protocol layer.
-	#[error("{0}")]
-	Transport(#[source] anyhow::Error),
+	#[error(transparent)]
+	Transport(BoxError),
 	/// The background task has been terminated.
 	#[error("The background task closed {0}; restart required")]
 	RestartNeeded(Arc<Error>),

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 publish = true
 
 [dependencies]
-anyhow = "1"
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["server", "http-helpers"] }
@@ -36,7 +35,6 @@ route-recognizer = "0.3.1"
 pin-project = "1.1.3"
 
 [dev-dependencies]
-anyhow = "1"
 jsonrpsee-test-utils = { path = "../test-utils" }
 rand = "0.8"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/server/src/middleware/http/proxy_get_request.rs
+++ b/server/src/middleware/http/proxy_get_request.rs
@@ -172,7 +172,7 @@ where
 			let mut bytes = Vec::new();
 
 			while let Some(frame) = body.frame().await {
-				let data = frame?.into_data().map_err(|e| anyhow::anyhow!("{:?}", e))?;
+				let data = frame?.into_data().map_err(|e| format!("{e:?}"))?;
 				bytes.extend(data);
 			}
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -839,11 +839,7 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 	///                   // Call the jsonrpsee service which
 	///                   // may upgrade it to a WebSocket connection
 	///                   // or treat it as "ordinary HTTP request".
-	///                   //
-	///                   // https://github.com/rust-lang/rust/issues/102211 the error type can't be inferred
-	///                   // to be `Box<dyn std::error::Error + Send + Sync>` so we need to convert it to a concrete type
-	///                   // as workaround.
-	///                   async move { svc.call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e)) }
+	///                   async move { svc.call(req).await }
 	///               });
 	///
 	///               // Upgrade the connection to a HTTP service with graceful shutdown.

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -252,12 +252,9 @@ pub(crate) async fn ws_server_with_stats(metrics: Metrics) -> SocketAddr {
 							tokio::join!(session_close2, session_close1);
 							metrics.ws_sessions_closed.fetch_add(1, Ordering::SeqCst);
 						});
-
-						async move { rpc_svc.call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e)) }.boxed()
-					} else {
-						// HTTP.
-						async move { rpc_svc.call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e)) }.boxed()
 					}
+
+					async move { rpc_svc.call(req).await }.boxed()
 				});
 
 				tokio::spawn(serve_with_graceful_shutdown(sock, svc, stop_handle.clone().shutdown()));

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -225,7 +225,7 @@ pub async fn server() -> SocketAddr {
 					.connection_id(connection_id)
 					.build(methods2.clone(), stop_hdl2.clone());
 
-				async move { tower_service.call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e)) }
+				async move { tower_service.call(req).await }
 			});
 
 			// Spawn a new task to serve each respective (Hyper) connection.


### PR DESCRIPTION
Removes the `anyhow` dependency from published crates by replacing it with `BoxError`.

Follow-up to https://github.com/paritytech/jsonrpsee/pull/1398, although this is a breaking change as it's exposed in the client `Error` type.