### PR TITLE
dependencies: warn on `unused_crate_dependencies`

### DIFF
--- a/client/http-client/src/lib.rs
+++ b/client/http-client/src/lib.rs
@@ -33,6 +33,7 @@
 //! [`async-std`](https://docs.rs/async-std/), [`smol`](https://docs.rs/smol) and similar.
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod client;

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -19,7 +19,6 @@ tracing = "0.1.34"
 
 # optional
 thiserror = { version = "1", optional = true }
-futures-channel = { version = "0.3.14", default-features = false, optional = true }
 futures-util = { version = "0.3.14", default-features = false, features = ["alloc"], optional = true }
 http = { version = "1", optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
@@ -38,7 +37,9 @@ rustls = { version = "0.23", default-features = false, optional = true }
 soketto = { version = "0.8", optional = true }
 
 # web-sys
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-net = { version = "0.5.0", default-features = false, features = ["json", "websocket"], optional = true }
+futures-channel = { version = "0.3.14", default-features = false, optional = true }
 
 [features]
 tls = ["tokio-rustls", "rustls-pki-types", "rustls-platform-verifier", "rustls"]

--- a/client/transport/src/lib.rs
+++ b/client/transport/src/lib.rs
@@ -25,10 +25,10 @@
 // DEALINGS IN THE SOFTWARE.
 
 #![warn(missing_debug_implementations, missing_docs, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # jsonrpsee-client-transports
-//!
 
 /// Websocket transport
 #[cfg(feature = "ws")]

--- a/client/wasm-client/Cargo.toml
+++ b/client/wasm-client/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 readme.workspace = true
 publish = true
 
-[dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 jsonrpsee-types = { workspace = true }
 jsonrpsee-client-transport = { workspace = true, features = ["web"] }
 jsonrpsee-core = { workspace = true, features = ["async-wasm-client"] }

--- a/client/wasm-client/src/lib.rs
+++ b/client/wasm-client/src/lib.rs
@@ -27,6 +27,7 @@
 //! # jsonrpsee-wasm-client
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg(target_arch = "wasm32")]
 

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -33,6 +33,7 @@
 //! This library uses `tokio` as the runtime and does not support other runtimes.
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(test)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,10 +33,12 @@ rustc-hash = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }
 parking_lot = { version = "0.12", optional = true }
 tokio = { version = "1.23.1", optional = true }
-wasm-bindgen-futures = { version = "0.4.19", optional = true }
 futures-timer = { version = "3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 pin-project = { version = "1", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { version = "0.4.19", optional = true }
 
 [features]
 default = []

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,6 +27,7 @@
 //! Shared utilities for `jsonrpsee`.
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Macros useful internally within this crate, but not to be exposed outside of it.

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -50,6 +50,7 @@
 //! - **`client-web-transport`** - Enables `websys` transport.
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Macros useful below, but not to be exposed outside of the crate.

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -24,7 +24,10 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate proc_macro;
+//! # jsonrpsee-proc-macros
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use proc_macro::TokenStream;
 use rpc_macro::RpcDescription;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -38,7 +38,6 @@ pin-project = "1.1.3"
 [dev-dependencies]
 anyhow = "1"
 jsonrpsee-test-utils = { path = "../test-utils" }
-rand = "0.8"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 tower = { version = "0.4.13", features = ["timeout"] }
 socket2 = "0.5.1"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -29,6 +29,7 @@
 //! `jsonrpsee-server` is a [JSON RPC](https://www.jsonrpc.org/specification) server that supports both HTTP and WebSocket transport.
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod future;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -27,6 +27,7 @@
 //! JSON-RPC specific types.
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate alloc;


### PR DESCRIPTION
Add and fix crate-level `#![warn(unused_crate_dependencies)]`.

This moves wasm-only dependencies to `target.cfg.dependencies` to avoid downloading and compiling them outside of wasm.