### PR TITLE
feat: add `PendingSubscriptionSink::method_name`

### DIFF
--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -305,6 +305,11 @@ impl PendingSubscriptionSink {
 	pub fn connection_id(&self) -> ConnectionId {
 		self.uniq_sub.conn_id
 	}
+
+	/// Get the method name.
+	pub fn method_name(&self) -> &str {
+		self.method
+	}
 }
 
 /// Represents a single subscription that hasn't been processed yet.


### PR DESCRIPTION
Unify the API because the `SubscriptionSink` is already exposing it and it may be useful in some context for debugging.