### PR TITLE
feat: add  `capacity and max_capacity` to the subscription API

### DIFF
--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -142,6 +142,16 @@ impl MethodSink {
 		self.tx.send_timeout(msg, timeout).await.map_err(Into::into)
 	}
 
+	/// Get the capacity of the channel.
+	pub fn capacity(&self) -> usize {
+		self.tx.capacity()
+	}
+
+	/// Get the max capacity of the channel.
+	pub fn max_capacity(&self) -> usize {
+		self.tx.max_capacity()
+	}
+
 	/// Waits for there to be space on the return channel.
 	pub async fn has_capacity(&self) -> Result<(), DisconnectError> {
 		match self.tx.reserve().await {

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -142,7 +142,7 @@ impl MethodSink {
 		self.tx.send_timeout(msg, timeout).await.map_err(Into::into)
 	}
 
-	/// Get the capacity of the subscription sink.
+	/// Get the capacity of the channel.
 	pub fn capacity(&self) -> usize {
 		self.tx.capacity()
 	}

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -142,7 +142,7 @@ impl MethodSink {
 		self.tx.send_timeout(msg, timeout).await.map_err(Into::into)
 	}
 
-	/// Get the capacity of the channel.
+	/// Get the capacity of the subscription sink.
 	pub fn capacity(&self) -> usize {
 		self.tx.capacity()
 	}

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -416,7 +416,7 @@ impl SubscriptionSink {
 		}
 	}
 
-	/// Get the capacity of the channel.
+	/// Get the capacity of the subscription sink.
 	pub fn capacity(&self) -> usize {
 		self.inner.capacity()
 	}

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -305,6 +305,16 @@ impl PendingSubscriptionSink {
 	pub fn connection_id(&self) -> ConnectionId {
 		self.uniq_sub.conn_id
 	}
+
+	/// Get the capacity of the channel.
+	pub fn capacity(&self) -> usize {
+		self.inner.capacity()
+	}
+
+	/// Get the max capacity of the channel.
+	pub fn max_capacity(&self) -> usize {
+		self.inner.max_capacity()
+	}
 }
 
 /// Represents a single subscription that hasn't been processed yet.
@@ -399,6 +409,16 @@ impl SubscriptionSink {
 			_ = self.inner.closed() => (),
 			_ = self.unsubscribe.unsubscribed() => (),
 		}
+	}
+
+	/// Get the capacity of the channel.
+	pub fn capacity(&self) -> usize {
+		self.inner.capacity()
+	}
+
+	/// Get the max capacity of the channel.
+	pub fn max_capacity(&self) -> usize {
+		self.inner.max_capacity()
 	}
 
 	fn is_active_subscription(&self) -> bool {

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -416,7 +416,7 @@ impl SubscriptionSink {
 		}
 	}
 
-	/// Get the capacity of the subscription sink.
+	/// Get the capacity of the subscription.
 	pub fn capacity(&self) -> usize {
 		self.inner.capacity()
 	}

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -314,6 +314,7 @@ impl PendingSubscriptionSink {
 	/// Get the max capacity of the channel.
 	pub fn max_capacity(&self) -> usize {
 		self.inner.max_capacity()
+	}
 
 	/// Get the method name.
 	pub fn method_name(&self) -> &str {

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -421,7 +421,7 @@ impl SubscriptionSink {
 		self.inner.capacity()
 	}
 
-	/// Get the max capacity of the channel.
+	/// Get the max capacity of the subscription.
 	pub fn max_capacity(&self) -> usize {
 		self.inner.max_capacity()
 	}


### PR DESCRIPTION
This may be useful if one wants to profile whether `buf size` of the server is close to its capacity or not.