### PR TITLE
add `RpcModule::remove`

### DIFF
--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -243,11 +243,6 @@ impl Methods {
 		}
 	}
 
-	// Removes the method callback for a given name, if it exists.
-	fn remove(&mut self, name: &'static str) -> Option<MethodCallback> {
-		self.mut_callbacks().remove(name)
-	}
-
 	/// Helper for obtaining a mut ref to the callbacks HashMap.
 	fn mut_callbacks(&mut self) -> &mut FxHashMap<&'static str, MethodCallback> {
 		Arc::make_mut(&mut self.callbacks)
@@ -557,11 +552,12 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 		)
 	}
 
-	/// Removes method if it exists.
+	/// Removes the method if it exists.
 	///
-	/// It is caller responsibility to remove both `subscribe` and `unsubscribe` methods for subscriptions.
+	/// Be aware that a subscription consist of two methods, `subscribe` and `unsubscribe` and
+	/// it's the caller responsibility to remove both `subscribe` and `unsubscribe` methods for subscriptions.
 	pub fn remove_method(&mut self, method_name: &'static str) -> Option<MethodCallback> {
-		self.methods.remove(method_name)
+		self.methods.mut_callbacks().remove(method_name)
 	}
 
 	/// Register a new asynchronous RPC method, which computes the response with the given callback.

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -243,6 +243,11 @@ impl Methods {
 		}
 	}
 
+	// Removes the method callback for a given name, if it exists.
+	fn remove(&mut self, name: &'static str) -> Option<MethodCallback> {
+		self.mut_callbacks().remove(name)
+	}
+
 	/// Helper for obtaining a mut ref to the callbacks HashMap.
 	fn mut_callbacks(&mut self) -> &mut FxHashMap<&'static str, MethodCallback> {
 		Arc::make_mut(&mut self.callbacks)
@@ -550,6 +555,13 @@ impl<Context: Send + Sync + 'static> RpcModule<Context> {
 				MethodResponse::response(id, rp, max_response_size).with_extensions(extensions)
 			})),
 		)
+	}
+
+	/// Removes method if it exists.
+	///
+	/// It is caller responsibility to remove both `subscribe` and `unsubscribe` methods for subscriptions.
+	pub fn remove_method(&mut self, method_name: &'static str) -> Option<MethodCallback> {
+		self.methods.remove(method_name)
 	}
 
 	/// Register a new asynchronous RPC method, which computes the response with the given callback.


### PR DESCRIPTION
Currently it's not possible to remove or replace a method. This is useful for overriding methods from an RpcModule with manual implementation or another module.