### PR TITLE
refactor(client+transport)!: split `tls` into `tls` and`tls-rustls-platform-verifier` features

### DIFF
--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -44,7 +44,6 @@ futures-channel = { version = "0.3.14", default-features = false, optional = tru
 [features]
 tls = ["rustls", "tokio-rustls", "rustls-pki-types"]
 tls-rustls-platform-verifier = ["tls", "rustls-platform-verifier"]
-default = ["tls-rustls-platform-verifier"]
 
 ws = [
     "base64",

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -42,7 +42,9 @@ gloo-net = { version = "0.5.0", default-features = false, features = ["json", "w
 futures-channel = { version = "0.3.14", default-features = false, optional = true }
 
 [features]
-tls = ["tokio-rustls", "rustls-pki-types", "rustls-platform-verifier", "rustls"]
+tls = ["rustls", "tokio-rustls", "rustls-pki-types"]
+tls-rustls-platform-verifier = ["tls", "rustls-platform-verifier"]
+default = ["tls-rustls-platform-verifier"]
 
 ws = [
     "base64",

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -61,7 +61,6 @@ pub type CustomCertStore = rustls::ClientConfig;
 #[cfg(feature = "tls")]
 #[derive(Debug, Clone)]
 pub enum CertificateStore {
-	#[cfg(feature = "tls-rustls-platform-verifier")]
 	/// Native.
 	Native,
 	/// Custom certificate store.
@@ -102,22 +101,10 @@ pub struct WsTransportClientBuilder {
 }
 
 impl Default for WsTransportClientBuilder {
-	#[cfg(feature = "tls-rustls-platform-verifier")]
 	fn default() -> Self {
 		Self {
+			#[cfg(feature = "tls")]
 			certificate_store: CertificateStore::Native,
-			max_request_size: TEN_MB_SIZE_BYTES,
-			max_response_size: TEN_MB_SIZE_BYTES,
-			connection_timeout: Duration::from_secs(10),
-			headers: http::HeaderMap::new(),
-			max_redirections: 5,
-			tcp_no_delay: true,
-		}
-	}
-
-	#[cfg(not(feature = "tls"))]
-	fn default() -> Self {
-		Self {
 			max_request_size: TEN_MB_SIZE_BYTES,
 			max_response_size: TEN_MB_SIZE_BYTES,
 			connection_timeout: Duration::from_secs(10),
@@ -629,6 +616,13 @@ fn build_tls_config(cert_store: &CertificateStore) -> Result<tokio_rustls::TlsCo
 	let config = match cert_store {
 		#[cfg(feature = "tls-rustls-platform-verifier")]
 		CertificateStore::Native => rustls_platform_verifier::tls_config(),
+		#[cfg(not(feature = "tls-rustls-platform-verifier"))]
+		CertificateStore::Native => {
+			return Err(WsHandshakeError::CertificateStore(io::Error::new(
+				io::ErrorKind::Other,
+				"Native certificate store not supported, either call `Builder::with_custom_cert_store` or enable the `tls-rustls-platform-verifier` feature.",
+			)))
+		}
 		CertificateStore::Custom(cfg) => cfg.clone(),
 	};
 

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 [dependencies]
 http = "1"
 jsonrpsee-types = { workspace = true }
-jsonrpsee-client-transport = { workspace = true, features = ["ws"] }
+jsonrpsee-client-transport = { workspace = true, features = ["ws"], default-features = false }
 jsonrpsee-core = { workspace = true, features = ["async-client"] }
 url = "2.4.0"
 
@@ -30,7 +30,8 @@ rustls = { version = "0.23.7", default-features = false, features = ["logging", 
 
 [features]
 tls = ["jsonrpsee-client-transport/tls"]
-default = ["tls"]
+tls-rustls-platform-verifier = ["jsonrpsee-client-transport/tls-rustls-platform-verifier"]
+default = ["tls-rustls-platform-verifier"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 [dependencies]
 http = "1"
 jsonrpsee-types = { workspace = true }
-jsonrpsee-client-transport = { workspace = true, features = ["ws"], default-features = false }
+jsonrpsee-client-transport = { workspace = true, features = ["ws"] }
 jsonrpsee-core = { workspace = true, features = ["async-client"] }
 url = "2.4.0"
 
@@ -30,7 +30,7 @@ rustls = { version = "0.23.7", default-features = false, features = ["logging", 
 
 [features]
 tls = ["jsonrpsee-client-transport/tls"]
-tls-rustls-platform-verifier = ["jsonrpsee-client-transport/tls-rustls-platform-verifier"]
+tls-rustls-platform-verifier = ["jsonrpsee-client-transport/tls-rustls-platform-verifier", "tls"]
 default = ["tls-rustls-platform-verifier"]
 
 [package.metadata.docs.rs]

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -53,7 +53,7 @@ use url::Url;
 #[cfg(feature = "tls")]
 pub use jsonrpsee_client_transport::ws::CustomCertStore;
 
-#[cfg(any(feature = "tls", feature = "tls-rustls-platform-verifier"))]
+#[cfg(feature = "tls")]
 use jsonrpsee_client_transport::ws::CertificateStore;
 
 /// Builder for [`WsClient`].
@@ -83,7 +83,7 @@ use jsonrpsee_client_transport::ws::CertificateStore;
 /// ```
 #[derive(Clone, Debug)]
 pub struct WsClientBuilder {
-	#[cfg(any(feature = "tls", feature = "tls-rustls-platform-verifier"))]
+	#[cfg(feature = "tls")]
 	certificate_store: CertificateStore,
 	max_request_size: u32,
 	max_response_size: u32,
@@ -100,28 +100,10 @@ pub struct WsClientBuilder {
 }
 
 impl Default for WsClientBuilder {
-	#[cfg(feature = "tls-rustls-platform-verifier")]
 	fn default() -> Self {
 		Self {
+			#[cfg(feature = "tls")]
 			certificate_store: CertificateStore::Native,
-			max_request_size: TEN_MB_SIZE_BYTES,
-			max_response_size: TEN_MB_SIZE_BYTES,
-			request_timeout: Duration::from_secs(60),
-			connection_timeout: Duration::from_secs(10),
-			ping_config: None,
-			headers: HeaderMap::new(),
-			max_concurrent_requests: 256,
-			max_buffer_capacity_per_subscription: 1024,
-			max_redirections: 5,
-			id_kind: IdKind::Number,
-			max_log_length: 4096,
-			tcp_no_delay: true,
-		}
-	}
-
-	#[cfg(not(any(feature = "tls", feature = "tls-rustls-platform-verifier")))]
-	fn default() -> Self {
-		Self {
 			max_request_size: TEN_MB_SIZE_BYTES,
 			max_response_size: TEN_MB_SIZE_BYTES,
 			request_timeout: Duration::from_secs(60),
@@ -140,29 +122,8 @@ impl Default for WsClientBuilder {
 
 impl WsClientBuilder {
 	/// Create a new WebSocket client builder.
-	#[cfg(any(not(feature = "tls"), feature = "tls-rustls-platform-verifier"))]
 	pub fn new() -> WsClientBuilder {
 		WsClientBuilder::default()
-	}
-
-	/// Create a new WebSocket client builder.
-	#[cfg(feature = "tls")]
-	pub fn new(cfg: CustomCertStore) -> WsClientBuilder {
-		WsClientBuilder {
-			certificate_store: CertificateStore::Custom(cfg),
-			max_request_size: TEN_MB_SIZE_BYTES,
-			max_response_size: TEN_MB_SIZE_BYTES,
-			request_timeout: Duration::from_secs(60),
-			connection_timeout: Duration::from_secs(10),
-			ping_config: None,
-			headers: HeaderMap::new(),
-			max_concurrent_requests: 256,
-			max_buffer_capacity_per_subscription: 1024,
-			max_redirections: 5,
-			id_kind: IdKind::Number,
-			max_log_length: 4096,
-			tcp_no_delay: true,
-		}
 	}
 
 	/// Force to use a custom certificate store.
@@ -359,7 +320,7 @@ impl WsClientBuilder {
 		T: AsyncRead + AsyncWrite + Unpin + MaybeSend + 'static,
 	{
 		let transport_builder = WsTransportClientBuilder {
-			#[cfg(any(feature = "tls", feature = "tls-rustls-platform-verifier"))]
+			#[cfg(feature = "tls")]
 			certificate_store: self.certificate_store.clone(),
 			connection_timeout: self.connection_timeout,
 			headers: self.headers.clone(),
@@ -385,7 +346,7 @@ impl WsClientBuilder {
 	/// Panics if being called outside of `tokio` runtime context.
 	pub async fn build(self, url: impl AsRef<str>) -> Result<WsClient, Error> {
 		let transport_builder = WsTransportClientBuilder {
-			#[cfg(any(feature = "tls", feature = "tls-rustls-platform-verifier"))]
+			#[cfg(feature = "tls")]
 			certificate_store: self.certificate_store.clone(),
 			connection_timeout: self.connection_timeout,
 			headers: self.headers.clone(),

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { version = "0.1.34", optional = true }
 tokio = { version = "1.23.1", optional = true }
 
 [features]
-client-ws-transport-tls = ["jsonrpsee-client-transport/ws", "jsonrpsee-client-transport/tls"]
+client-ws-transport-tls = ["jsonrpsee-client-transport/ws", "jsonrpsee-client-transport/tls-rustls-platform-verifier"]
 client-ws-transport-no-tls = ["jsonrpsee-client-transport/ws"]
 client-web-transport = ["jsonrpsee-client-transport/web"]
 async-client = ["jsonrpsee-core/async-client"]


### PR DESCRIPTION
fixes  #1407 