### PR TITLE
fix: Explicitly set rustls provider before using rustls

### DIFF
--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -219,6 +219,12 @@ impl<L> HttpTransportClientBuilder<L> {
 			}
 			#[cfg(feature = "tls")]
 			"https" => {
+				// Make sure that the TLS provider is set. If not, set a default one.
+				// Otherwise, creating `tls` configuration may panic if there are multiple
+				// providers available due to `rustls` features (e.g. both `ring` and `aws-lc-rs`).
+				// Function returns an error if the provider is already installed, and we're fine with it.
+				let _ = rustls::crypto::ring::default_provider().install_default();
+
 				let mut http_conn = HttpConnector::new();
 				http_conn.set_nodelay(tcp_no_delay);
 				http_conn.enforce_http(false);


### PR DESCRIPTION
Recently `rustls` changed default crypto provider from `ring` to `aws-lc-rs`, and it caused some crates to depend on both features (e.g. if one dependency uses a default provider, and other one enables `ring`).
In such cases, `rustls` would panic, because it can't choose a default provider (see [this issue](https://github.com/rustls/rustls/issues/1877)).

This PR makes sure that the provider is set before using `rustls` functionality, thus preventing panics in runtime.

This isn't the most elegant solution to the problem, but it does fix it (confirmed in my project), so I hope it's fine to merge it as a quickfix.