### PR TITLE
[RFC] impl ToParams for json::Value

### DIFF
--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -27,6 +27,7 @@
 use jsonrpsee_types::SubscriptionId;
 use serde::Serialize;
 use serde_json::value::RawValue;
+use serde_json::Value;
 
 /// Marker trait for types that can be serialized as JSON compatible strings.
 ///
@@ -102,6 +103,10 @@ impl<P, const N: usize> ToRpcParams for [P; N]
 where
 	[P; N]: Serialize,
 {
+	to_rpc_params_impl!();
+}
+
+impl ToRpcParams for Value {
 	to_rpc_params_impl!();
 }
 


### PR DESCRIPTION
I am having a problem passing a json object to my rpc server.

This PR is starting the work to allow a `{...}` as a Params. Suggestions on how to improve this will be super welcome.


The related part of the spec is https://www.jsonrpc.org/specification

```
4.2 Parameter Structures
If present, parameters for the rpc call MUST be provided as a Structured value. Either by-position through an Array or by-name through an Object.

by-position: params MUST be an Array, containing the values in the Server expected order.
by-name: params MUST be an Object, with member names that match the Server expected parameter names. The absence of expected names MAY result in an error being generated. The names MUST match exactly, including case, to the method's expected parameters.
```