### PR TITLE
fix(client): support notifications with no params

### DIFF
--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -191,6 +191,26 @@ async fn notification_handler_works() {
 }
 
 #[tokio::test]
+async fn notification_no_params() {
+	let server = WebSocketTestServer::with_hardcoded_notification(
+		"127.0.0.1:0".parse().unwrap(),
+		server_notification_without_params("no_params"),
+	)
+	.with_default_timeout()
+	.await
+	.unwrap();
+
+	let uri = to_ws_uri_string(server.local_addr());
+	let client = WsClientBuilder::default().build(&uri).with_default_timeout().await.unwrap().unwrap();
+	{
+		let mut nh: Subscription<serde_json::Value> =
+			client.subscribe_to_method("no_params").with_default_timeout().await.unwrap().unwrap();
+		let response = nh.next().with_default_timeout().await.unwrap().unwrap().unwrap();
+		assert_eq!(response, serde_json::Value::Null);
+	}
+}
+
+#[tokio::test]
 async fn batched_notifs_works() {
 	init_logger();
 

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -192,6 +192,11 @@ pub fn server_notification(method: &str, params: Value) -> String {
 	format!(r#"{{"jsonrpc":"2.0","method":"{}", "params":{} }}"#, method, serde_json::to_string(&params).unwrap())
 }
 
+/// Server originated notification without params.
+pub fn server_notification_without_params(method: &str) -> String {
+	format!(r#"{{"jsonrpc":"2.0","method":"{}"}}"#, method)
+}
+
 pub async fn http_request(body: Body, uri: Uri) -> Result<HttpResponse, String> {
 	let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
 	http_post(client, body, uri).await


### PR DESCRIPTION
Close #1435

Technically notifications can omit the params field according to JSON-RPC spec which this fixes.
However, it's quite weird to emit notifications without data in them in such scenarios we just push `null` to the notification handler.

In contrary, subscriptions requires params field where the subscription ID is sent in every message and that's why I didn't change the notification type i.e, just a type alias `Notification<'a, Option<serde_json::Value>>`