### PR TITLE
feat(server): add `Methods::extensions/extensions_mut`

### DIFF
--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -501,8 +501,8 @@ impl Methods {
 	///     }).unwrap();
 	///
 	///     // inject arbitrary data into the extensions.
-	/// 	let mut ext = Extensions::new();
-	/// 	ext.insert(33_u64);
+	///     let mut ext = Extensions::new();
+	///     ext.insert(33_u64);
 	///
 	///     module.with_extensions(ext);
 	///

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -374,7 +374,6 @@ impl Methods {
 		let max_response_size = usize::MAX;
 		let conn_id = ConnectionId(0);
 		let mut ext = self.extensions.clone();
-
 		ext.insert(conn_id);
 
 		let response = match self.method(&method) {

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -479,7 +479,7 @@ impl Methods {
 
 	/// Insert extensions to the methods.
 	///
-	/// This only affects direct calls to the methods and subscriptions.
+	/// This only affects direct calls to the methods and subscriptions
 	/// and can be used for example to unit test the API without a server.
 	///
 	/// If an instance of a specific type exists in both, the one in self is


### PR DESCRIPTION
The RpcModule/Methods may need to inject extensions which could be needed by the RPC implementations.

For example in substrate I have moved the `deny unsafe stuff` to an extension but the unit tests fails because it's needs be added by the RpcModule.

Thus, this PR adds additional API to be used for unit testing a RpcModule. For instance one may inject some arbitary data which can't be unit tested unless it's explictly injected by the RpcModule.