### PR TITLE
client: enable http/2 in hyper-rustls for http client on v0.20.x

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 [dependencies]
 async-trait = "0.1"
 hyper = { version = "0.14.10", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.24", optional = true, default-features = false, features = ["http1", "tls12", "logging"] }
+hyper-rustls = { version = "0.24", optional = true, default-features = false, features = ["http1", "http2", "tls12", "logging"] }
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["client", "http-helpers"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -125,6 +125,7 @@ where
 						.with_native_roots()
 						.https_or_http()
 						.enable_http1()
+						.enable_http2()
 						.build(),
 					#[cfg(feature = "webpki-tls")]
 					CertificateStore::WebPki => hyper_rustls::HttpsConnectorBuilder::new()


### PR DESCRIPTION
**Motivation:**

- HTTP/2 offers several improvements over HTTP/1.1, including multiplexing, header compression, and reduced latency.
- Enabling HTTP/2 support in the jsonrpsee HTTP client aligns with modern web standards and provides potential performance benefits for applications using this library.

**Branch Context:**

- This PR is based on the v0.20.x branch due to compatibility issues with certain crates that depend on older versions of zerois. These crates are not compatible with the newer versions of jsonrpsee. By maintaining and improving the v0.20.x branch, we ensure that users who depend on this version can still benefit from enhancements like HTTP/2 support  without being forced to upgrade to a newer version of jsonrpsee that may not be compatible with their existing dependencies.

**Notes:**

- This change maintains backward compatibility as the client will still support HTTP/1.1 when HTTP/2 is not available.