### PR TITLE
feat(types): add `lenient` feature

### DIFF
--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -37,6 +37,7 @@ http-client = ["jsonrpsee-http-client", "jsonrpsee-types", "jsonrpsee-core/clien
 wasm-client = ["jsonrpsee-wasm-client", "jsonrpsee-types", "jsonrpsee-core/client"]
 ws-client = ["jsonrpsee-ws-client", "jsonrpsee-types", "jsonrpsee-core/client"]
 macros = ["jsonrpsee-proc-macros", "jsonrpsee-types", "tracing"]
+lenient = ["jsonrpsee-types/lenient"]
 
 client = ["http-client", "ws-client", "wasm-client", "client-ws-transport-tls", "client-web-transport", "async-client", "async-wasm-client", "client-core"]
 client-core = ["jsonrpsee-core/client"]

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -48,6 +48,7 @@
 //! - **`client-ws-transport`** - Enables `ws` transport with TLS.
 //! - **`client-ws-transport-no-tls`** - Enables `ws` transport without TLS.
 //! - **`client-web-transport`** - Enables `websys` transport.
+//! - **`lenient`** - Enables lenient request parsing, allowing requests without a `jsonrpc` field.
 
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,3 +18,6 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
 http = "1"
+
+[features]
+lenient = []

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -41,6 +41,7 @@ use serde_json::value::RawValue;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Request<'a> {
 	/// JSON-RPC version.
+	#[cfg_attr(feature = "lenient", serde(default))]
 	pub jsonrpc: TwoPointZero,
 	/// Request ID
 	#[serde(borrow)]
@@ -101,6 +102,7 @@ pub struct InvalidRequest<'a> {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Notification<'a, T> {
 	/// JSON-RPC version.
+	#[cfg_attr(feature = "lenient", serde(default))]
 	pub jsonrpc: TwoPointZero,
 	/// Name of the method to be invoked.
 	#[serde(borrow)]
@@ -237,6 +239,16 @@ mod test {
 	#[test]
 	fn deserialize_call_bad_id_should_fail() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[],"id":{}}"#;
+		assert!(serde_json::from_str::<Request>(ser).is_err());
+	}
+
+	#[test]
+	fn deserialize_missing_jsonrpc_field() {
+		let ser = r#"{"method":"say_hello","params":[],"id":1}"#;
+		#[cfg(feature = "lenient")]
+		assert!(serde_json::from_str::<Request>(ser).is_ok());
+
+		#[cfg(not(feature = "lenient"))]
 		assert!(serde_json::from_str::<Request>(ser).is_err());
 	}
 


### PR DESCRIPTION
The `lenient` feature allows for parsing `Request`s and `Notification`s that doesn't have `jsonrpc` fields. This is useful for interacting with some implementations that are not completely standards-conforming.

I need this in order to communicate with Shelly devices: https://shelly-api-docs.shelly.cloud/gen2/General/RPCProtocol They are supposed to communicate with Jsonrpc 2.0, but don't supply `jsonrpc` fields.

This is of course very similar to #1385 except that it is behind a feature flag so that users have to opt-in to this behavior.