### PR TITLE
fix: use error(transparent) for wrapped errors when possible

### DIFF
--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -25,7 +25,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::types::error::{ErrorCode, ErrorObject};
-
 use crate::HttpClientBuilder;
 use jsonrpsee_core::client::{BatchResponse, ClientT, IdKind};
 use jsonrpsee_core::params::BatchRequestBuilder;

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -364,7 +364,7 @@ pub enum Error {
 	Url(String),
 
 	/// Error during the HTTP request, including networking errors and HTTP protocol errors.
-	#[error("{0}")]
+	#[error(transparent)]
 	Http(#[from] HttpError),
 
 	/// Server returned a non-success status code.

--- a/client/transport/src/web.rs
+++ b/client/transport/src/web.rs
@@ -20,7 +20,7 @@ pub enum Error {
 	#[error("JS Error: {0:?}")]
 	Js(String),
 	/// WebSocket error
-	#[error("{0}")]
+	#[error(transparent)]
 	WebSocket(WebSocketError),
 	/// Operation not supported
 	#[error("Operation not supported")]

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -358,8 +358,14 @@ impl WsTransportClientBuilder {
 
 			for sockaddr in &sockaddrs {
 				#[cfg(feature = "tls")]
-				let tcp_stream = match connect(*sockaddr, self.connection_timeout, &target.host, connector.as_ref(), self.tcp_no_delay)
-					.await
+				let tcp_stream = match connect(
+					*sockaddr,
+					self.connection_timeout,
+					&target.host,
+					connector.as_ref(),
+					self.tcp_no_delay,
+				)
+				.await
 				{
 					Ok(stream) => stream,
 					Err(e) => {

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -358,14 +358,8 @@ impl WsTransportClientBuilder {
 
 			for sockaddr in &sockaddrs {
 				#[cfg(feature = "tls")]
-				let tcp_stream = match connect(
-					*sockaddr,
-					self.connection_timeout,
-					&target.host,
-					connector.as_ref(),
-					self.tcp_no_delay,
-				)
-				.await
+				let tcp_stream = match connect(*sockaddr, self.connection_timeout, &target.host, connector.as_ref(), self.tcp_no_delay)
+					.await
 				{
 					Ok(stream) => stream,
 					Err(e) => {

--- a/core/src/client/error.rs
+++ b/core/src/client/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
 	#[error("Invalid subscription ID")]
 	InvalidSubscriptionId,
 	/// Invalid request ID.
-	#[error("{0}")]
+	#[error(transparent)]
 	InvalidRequestId(#[from] InvalidRequestId),
 	/// Request timeout
 	#[error("Request timeout")]
@@ -61,9 +61,9 @@ pub enum Error {
 	#[error("Not implemented")]
 	HttpNotImplemented,
 	/// Empty batch request.
-	#[error("{0}")]
+	#[error(transparent)]
 	EmptyBatchRequest(#[from] EmptyBatchRequest),
 	/// The error returned when registering a method or subscription failed.
-	#[error("{0}")]
+	#[error(transparent)]
 	RegisterMethod(#[from] RegisterMethodError),
 }

--- a/core/src/http_helpers.rs
+++ b/core/src/http_helpers.rs
@@ -115,7 +115,7 @@ pub enum HttpError {
 	#[error("Malformed request")]
 	Malformed,
 	/// Represents error that can happen when dealing with HTTP streams.
-	#[error("{0}")]
+	#[error(transparent)]
 	Stream(#[from] BoxError),
 }
 

--- a/core/src/server/rpc_module.rs
+++ b/core/src/server/rpc_module.rs
@@ -101,10 +101,10 @@ pub type RawRpcResponse = (String, mpsc::Receiver<String>);
 #[derive(thiserror::Error, Debug)]
 pub enum MethodsError {
 	/// Failed to parse the call as valid JSON-RPC.
-	#[error("{0}")]
+	#[error(transparent)]
 	Parse(#[from] serde_json::Error),
 	/// Specific JSON-RPC error.
-	#[error("{0}")]
+	#[error(transparent)]
 	JsonRpc(#[from] ErrorObjectOwned),
 	#[error("Invalid subscription ID: `{0}`")]
 	/// Invalid subscription ID.

--- a/server/src/middleware/http/authority.rs
+++ b/server/src/middleware/http/authority.rs
@@ -45,10 +45,10 @@ pub struct Authority {
 #[derive(Debug, thiserror::Error)]
 pub enum AuthorityError {
 	/// Invalid URI.
-	#[error("{0}")]
+	#[error(transparent)]
 	InvalidUri(InvalidUri),
 	/// Invalid port.
-	#[error("{0}")]
+	#[error("Invalid port: {0}")]
 	InvalidPort(String),
 	/// The host was not found.
 	#[error("The host was not found")]


### PR DESCRIPTION
This changes the jsonrpsee's error to use transparent for wrapped errors for more idiomatic backtraces to avoid print errors etc more than once.

Close #1447 