### PR TITLE
chore: release v0.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.24.4] - 2024-09-11
+
+This is non-breaking release that changes the error variants to be `thiserror(transparent)` for wrapped errors and adds ConnectionGuard to
+the extensions to make it possible to get the number of active connections.
+
+### [Added]
+- server: expose ConnectionGuard as request extension ([#1443](https://github.com/paritytech/jsonrpsee/pull/1443))
+
+### [Fixed]
+- types: use error(transparent) for wrapped errors when possible ([#1449](https://github.com/paritytech/jsonrpsee/pull/1449))
+
 ## [v0.24.3] - 2024-08-14
 
 This is a small release that adds two new APIs to inject data via the extensions to the `RpcModule/Methods`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
-version = "0.24.3"
+version = "0.24.4"
 edition = "2021"
 rust-version = "1.74.1"
 license = "MIT"
@@ -31,11 +31,11 @@ keywords = ["jsonrpc", "json", "http", "websocket", "WASM"]
 readme = "README.md"
 
 [workspace.dependencies]
-jsonrpsee-types = { path = "types", version = "0.24.3" }
-jsonrpsee-core = { path = "core", version = "0.24.3" }
-jsonrpsee-server = { path = "server", version = "0.24.3" }
-jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.3" }
-jsonrpsee-http-client = { path = "client/http-client", version = "0.24.3" }
-jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.3" }
-jsonrpsee-client-transport = { path = "client/transport", version = "0.24.3" }
-jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.3" }
+jsonrpsee-types = { path = "types", version = "0.24.4" }
+jsonrpsee-core = { path = "core", version = "0.24.4" }
+jsonrpsee-server = { path = "server", version = "0.24.4" }
+jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.4" }
+jsonrpsee-http-client = { path = "client/http-client", version = "0.24.4" }
+jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.4" }
+jsonrpsee-client-transport = { path = "client/transport", version = "0.24.4" }
+jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.4" }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![MIT](https://img.shields.io/crates/l/jsonrpsee.svg)
 [![CI](https://github.com/paritytech/jsonrpsee/actions/workflows/ci.yml/badge.svg)](https://github.com/paritytech/jsonrpsee/actions/workflows/ci.yml)
 [![Benchmarks](https://github.com/paritytech/jsonrpsee/actions/workflows/benchmarks_gitlab.yml/badge.svg)](https://github.com/paritytech/jsonrpsee/actions/workflows/benchmarks_gitlab.yml)
-[![dependency status](https://deps.rs/crate/jsonrpsee/0.24.3/status.svg)](https://deps.rs/crate/jsonrpsee/0.24.3)
+[![dependency status](https://deps.rs/crate/jsonrpsee/0.24.4/status.svg)](https://deps.rs/crate/jsonrpsee/0.24.4)
 
 JSON-RPC library designed for async/await in Rust.
 

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -358,8 +358,14 @@ impl WsTransportClientBuilder {
 
 			for sockaddr in &sockaddrs {
 				#[cfg(feature = "tls")]
-				let tcp_stream = match connect(*sockaddr, self.connection_timeout, &target.host, connector.as_ref(), self.tcp_no_delay)
-					.await
+				let tcp_stream = match connect(
+					*sockaddr,
+					self.connection_timeout,
+					&target.host,
+					connector.as_ref(),
+					self.tcp_no_delay,
+				)
+				.await
 				{
 					Ok(stream) => stream,
 					Err(e) => {


### PR DESCRIPTION
```markdown
## [v0.24.4] - 2024-09-11

This is non-breaking release that changes the error variants to be `thiserror(transparent)` for wrapped errors and adds ConnectionGuard to
the extensions to make it possible to get the number of active connections.

### [Added]
- server: expose ConnectionGuard as request extension ([#1443](https://github.com/paritytech/jsonrpsee/pull/1443))

### [Fixed]
- types: use error(transparent) for wrapped errors when possible ([#1449](https://github.com/paritytech/jsonrpsee/pull/1449))

```