### PR TITLE
server: Enable tower util feature

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,7 +29,7 @@ hyper-util = { version = "0.1", features = ["tokio", "service", "tokio", "server
 http = "1"
 http-body = "1"
 http-body-util = "0.1.0"
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["util"] }
 thiserror = "1"
 route-recognizer = "0.3.1"
 pin-project = "1.1.3"


### PR DESCRIPTION
I don't see why it only started today but we got quite a lot of bug reports for this error message:
```
error[E0432]: unresolved import `tower::util`                                                                                                      
   --> A:\_packages\cargo\registry\src\index.crates.io-6f17d22bba15001f\jsonrpsee-server-0.24.4\src\utils.rs:37:12
    |
37  | use tower::util::Oneshot;
    |            ^^^^ could not find `util` in `tower`
    |
note: found an item that was configured out
   --> A:\_packages\cargo\registry\src\index.crates.io-6f17d22bba15001f\tower-0.4.13\src\lib.rs:215:9
    |
215 | pub mod util;
    |         ^^^^
    = note: the item is gated behind the `util` feature

error[E0432]: unresolved import `tower::ServiceExt`
   --> A:\_packages\cargo\registry\src\index.crates.io-6f17d22bba15001f\jsonrpsee-server-0.24.4\src\utils.rs:38:5
    |
38  | use tower::ServiceExt;
    |     ^^^^^^^----------
    |     |      |
    |     |      help: a similar name exists in the module: `Service`
    |     no `ServiceExt` in the root
    |
note: found an item that was configured out
   --> A:\_packages\cargo\registry\src\index.crates.io-6f17d22bba15001f\tower-0.4.13\src\lib.rs:223:34
    |
223 | pub use self::util::{service_fn, ServiceExt};
    |                                  ^^^^^^^^^^
    = note: the item is gated behind the `util` feature

error[E0599]: the method `graceful_shutdown` exists for struct `Pin<&mut UpgradeableConnection<'_, TokioIo<TcpStream>, TowerToHyperService<<... as Layer<...>>::Service>, ...>>`, but its trait bounds were not satisfied
    --> A:\_packages\cargo\registry\src\index.crates.io-6f17d22bba15001f\jsonrpsee-server-0.24.4\src\server.rs:1233:19
     |
1233 |                 conn.as_mut().graceful_shutdown();
     |                               ^^^^^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
     |
    ::: A:\_packages\cargo\registry\src\index.crates.io-6f17d22bba15001f\hyper-util-0.1.9\src\rt\tokio.rs:16:1
     |
16   | pub struct TokioExecutor {}
     | ------------------------ doesn't satisfy `_: HttpServerConnExec<TowerToHyperServiceFuture<<HttpMiddleware as Layer<TowerServiceNoHttp<RpcMiddleware>>>::Service, Request<Body>>, Body>`
     |
     = note: the full type name has been written to 'A:\_target\debug\deps\jsonrpsee_server-ab8a35524401df3d.long-type-10406918538042668016.txt'   
     = note: consider using `--verbose` to print the full type name to the console
     = note: the following trait bounds were not satisfied:
             `{type error}: Sized`
             which is required by `TokioExecutor: HttpServerConnExec<utils::TowerToHyperServiceFuture<<HttpMiddleware as Layer<TowerServiceNoHttp<RpcMiddleware>>>::Service, hyper::Request<jsonrpsee_core::http_helpers::Body>>, Body>`

error[E0599]: no method named `oneshot` found for type parameter `S` in the current scope
  --> A:\_packages\cargo\registry\src\index.crates.io-6f17d22bba15001f\jsonrpsee-server-0.24.4\src\utils.rs:61:60
   |
51 | impl<S> hyper::service::Service<HttpRequest<hyper::body::Incoming>> for TowerToHyperService<S>
   |      - method `oneshot` not found for this type parameter
...
61 |         TowerToHyperServiceFuture { future: self.service.clone().oneshot(req) }
   |                                                                  ^^^^^^^ method not found in `S`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `jsonrpsee-server` (lib) due to 4 previous errors
```
Enabling the feature seems to work (added tower with the feature to our direct deps for a quick test)