### PR TITLE
http client: add `max_concurrent_requests`

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -468,8 +468,6 @@ impl RequestIdManager {
 	}
 
 	/// Attempts to get the next request ID.
-	///
-	/// Fails if request limit has been exceeded.
 	pub fn next_request_id(&self) -> Id<'static> {
 		self.id_kind.into_id(self.current_id.next())
 	}


### PR DESCRIPTION
I decided to add back `max_concurrent_requests` to provide a uniform API because the ws-client already provides it.
This is only opt-in because it may be annoying with the extra sempahore overhead which some use-cases may not want..

Superseeds #1470 