### PR TITLE
fix(server): make tower::Service impl generic over HttpBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [v0.24.7]
 
+This is a bug-fix release that fixes the tower::Service implementation to be generic over the HttpBody to work with all middleware layers. For instance, this makes `tower_http::compression::CompressionLayer` work, which didn't compile before.
 ### [Fixed]
 - fix(server): make tower::Service impl generic over HttpBody ([#1475](https://github.com/paritytech/jsonrpsee/pull/1475))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog].
 ## [v0.24.7]
 
 ### [Fixed]
-- fix(server): compatibility issue of CompressionLayer in http middleware ([#1475](https://github.com/paritytech/jsonrpsee/pull/1475))
+- fix(server): make tower::Service impl generic over HttpBody ([#1475](https://github.com/paritytech/jsonrpsee/pull/1475))
 
 ## [v0.24.6] - 2024-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## Unrelease
+
+### [Fixed]
+- fix(server): compatibility issue of CompressionLayer in http middleware ([#1475](https://github.com/paritytech/jsonrpsee/pull/1475))
+
 ## [v0.24.6] - 2024-10-07
 
 This is a bug-fix release that fixes that the `ConnectionGuard` was dropped before the future was resolved which,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [v0.24.7]
 
-This is a bug-fix release that fixes the tower::Service implementation to be generic over the HttpBody to work with all middleware layers. For instance, this makes `tower_http::compression::CompressionLayer` work, which didn't compile before.
+This is a bug-fix release that fixes the tower::Service implementation to be generic over the HttpBody to work with all middleware layers. 
+For instance, this makes `tower_http::compression::CompressionLayer` work, which didn't compile before.
 ### [Fixed]
 - fix(server): make tower::Service impl generic over HttpBody ([#1475](https://github.com/paritytech/jsonrpsee/pull/1475))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog].
 
 This is a bug-fix release that fixes the tower::Service implementation to be generic over the HttpBody to work with all middleware layers. 
 For instance, this makes `tower_http::compression::CompressionLayer` work, which didn't compile before.
+
 ### [Fixed]
 - fix(server): make tower::Service impl generic over HttpBody ([#1475](https://github.com/paritytech/jsonrpsee/pull/1475))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## Unrelease
+## [v0.24.7]
 
 ### [Fixed]
 - fix(server): compatibility issue of CompressionLayer in http middleware ([#1475](https://github.com/paritytech/jsonrpsee/pull/1475))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ members = [
 resolver = "2"
 
 [workspace.package]
-authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
+authors = [
+	"Parity Technologies <admin@parity.io>",
+	"Pierre Krieger <pierre.krieger1708@gmail.com>",
+]
 version = "0.24.6"
 edition = "2021"
 rust-version = "1.74.1"
@@ -40,5 +43,5 @@ jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.6" }
 jsonrpsee-client-transport = { path = "client/transport", version = "0.24.6" }
 jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.6" }
 
-tower = "0.5"
-tower-http = "0.6"
+tower = "0.4"
+tower-http = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,8 @@ members = [
 resolver = "2"
 
 [workspace.package]
-authors = [
-	"Parity Technologies <admin@parity.io>",
-	"Pierre Krieger <pierre.krieger1708@gmail.com>",
-]
-version = "0.24.6"
+authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
+version = "0.24.7"
 edition = "2021"
 rust-version = "1.74.1"
 license = "MIT"
@@ -34,14 +31,14 @@ keywords = ["jsonrpc", "json", "http", "websocket", "WASM"]
 readme = "README.md"
 
 [workspace.dependencies]
-jsonrpsee-types = { path = "types", version = "0.24.6" }
-jsonrpsee-core = { path = "core", version = "0.24.6" }
-jsonrpsee-server = { path = "server", version = "0.24.6" }
-jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.6" }
-jsonrpsee-http-client = { path = "client/http-client", version = "0.24.6" }
-jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.6" }
-jsonrpsee-client-transport = { path = "client/transport", version = "0.24.6" }
-jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.6" }
+jsonrpsee-types = { path = "types", version = "0.24.7" }
+jsonrpsee-core = { path = "core", version = "0.24.7" }
+jsonrpsee-server = { path = "server", version = "0.24.7" }
+jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.7" }
+jsonrpsee-http-client = { path = "client/http-client", version = "0.24.7" }
+jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.7" }
+jsonrpsee-client-transport = { path = "client/transport", version = "0.24.7" }
+jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.7" }
 
 tower = "0.4"
 tower-http = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ jsonrpsee-http-client = { path = "client/http-client", version = "0.24.6" }
 jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.6" }
 jsonrpsee-client-transport = { path = "client/transport", version = "0.24.6" }
 jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.6" }
+
+tower = "0.5"
+tower-http = "0.6"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![MIT](https://img.shields.io/crates/l/jsonrpsee.svg)
 [![CI](https://github.com/paritytech/jsonrpsee/actions/workflows/ci.yml/badge.svg)](https://github.com/paritytech/jsonrpsee/actions/workflows/ci.yml)
 [![Benchmarks](https://github.com/paritytech/jsonrpsee/actions/workflows/benchmarks_gitlab.yml/badge.svg)](https://github.com/paritytech/jsonrpsee/actions/workflows/benchmarks_gitlab.yml)
-[![dependency status](https://deps.rs/crate/jsonrpsee/0.24.6/status.svg)](https://deps.rs/crate/jsonrpsee/0.24.6)
+[![dependency status](https://deps.rs/crate/jsonrpsee/0.24.7/status.svg)](https://deps.rs/crate/jsonrpsee/0.24.7)
 
 JSON-RPC library designed for async/await in Rust.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![MIT](https://img.shields.io/crates/l/jsonrpsee.svg)
 [![CI](https://github.com/paritytech/jsonrpsee/actions/workflows/ci.yml/badge.svg)](https://github.com/paritytech/jsonrpsee/actions/workflows/ci.yml)
 [![Benchmarks](https://github.com/paritytech/jsonrpsee/actions/workflows/benchmarks_gitlab.yml/badge.svg)](https://github.com/paritytech/jsonrpsee/actions/workflows/benchmarks_gitlab.yml)
-[![dependency status](https://deps.rs/crate/jsonrpsee/0.24.7/status.svg)](https://deps.rs/crate/jsonrpsee/0.24.7)
+[![dependency status](https://deps.rs/crate/jsonrpsee/latest/status.svg)](https://deps.rs/crate/jsonrpsee)
 
 JSON-RPC library designed for async/await in Rust.
 

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1"
 thiserror = "1"
 tokio = { version = "1.23.1", features = ["time"] }
 tracing = "0.1.34"
-tower = { version = "0.4.13", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 url = "2.4.0"
 
 [dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.23.1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde_json = { version = "1" }
 tower-http = { version = "0.5.2", features = ["full"] }
-tower = { version = "0.4.13", features = ["full"] }
+tower = { workspace = true, features = ["full"] }
 hyper = "1.3"
 hyper-util = { version = "0.1.3", features = ["client", "client-legacy"]}
 console-subscriber = "0.4.0"

--- a/examples/examples/http_middleware.rs
+++ b/examples/examples/http_middleware.rs
@@ -40,6 +40,7 @@ use jsonrpsee::rpc_params;
 use std::iter::once;
 use std::net::SocketAddr;
 use std::time::Duration;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::sensitive_headers::SetSensitiveRequestHeadersLayer;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
@@ -107,6 +108,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 		// Mark the `Authorization` request header as sensitive so it doesn't show in logs
 		.layer(SetSensitiveRequestHeadersLayer::new(once(hyper::header::AUTHORIZATION)))
 		.layer(cors)
+		.layer(CompressionLayer::new())
 		.timeout(Duration::from_secs(2));
 
 	let server =

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -33,4 +33,4 @@ serde_json = "1"
 serde = "1"
 trybuild = "1.0.97"
 tokio = { version = "1.23.1", features = ["rt", "macros"] }
-tower = "0.4"
+tower = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,7 +29,7 @@ hyper-util = { version = "0.1", features = ["tokio", "service", "tokio", "server
 http = "1"
 http-body = "1"
 http-body-util = "0.1.0"
-tower = { version = "0.4.13", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 thiserror = "1"
 route-recognizer = "0.3.1"
 pin-project = "1.1.3"
@@ -37,5 +37,5 @@ pin-project = "1.1.3"
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tower = { version = "0.4.13", features = ["timeout"] }
+tower = { workspace = true, features = ["timeout"] }
 socket2 = "0.5.1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,8 +22,8 @@ serde_json = "1"
 tokio = { version = "1.23.1", features = ["full"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["compat"]}
-tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.5.2", features = ["full"] }
+tower = { workspace = true, features = ["full"] }
+tower-http = { workspace = true, features = ["full"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 pin-project = "1"


### PR DESCRIPTION
Close https://github.com/paritytech/jsonrpsee/issues/1133 

- fix build errors when using `tower_http::compression::CompressionLayer` as http middleware
- update examples
- ~upgrade `tower` and `tower-http`~
