### PR TITLE
chore(deps): upgrade tower-http to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.7" }
 jsonrpsee-client-transport = { path = "client/transport", version = "0.24.7" }
 jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.7" }
 
-tower = "0.4"
-tower-http = "0.5"
+tower = "0.4" # used in public APIs
+tower-http = "0.6" # only used in tests and examples

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@ tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 tokio = { version = "1.23.1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde_json = { version = "1" }
-tower-http = { version = "0.5.2", features = ["full"] }
+tower-http = { workspace = true, features = ["full"] }
 tower = { workspace = true, features = ["full"] }
 hyper = "1.3"
 hyper-util = { version = "0.1.3", features = ["client", "client-legacy"]}


### PR DESCRIPTION
This PR bumps the version of `tower-http` crate which is only used in examples and tests(thus this change should be non-breaking).