### PR TITLE
refactor(server): user `ServerConfigBuilder` to replace `ServerBuilder`'s duplicate setter methods

### DIFF
--- a/benches/helpers.rs
+++ b/benches/helpers.rs
@@ -111,16 +111,15 @@ pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpc_ws_se
 /// Run jsonrpsee HTTP server for benchmarks.
 #[cfg(not(feature = "jsonrpc-crate"))]
 pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::server::ServerHandle) {
-	use jsonrpsee::server::ServerBuilder;
+	use jsonrpsee::server::{ServerBuilder, ServerConfig};
 
-	let server = ServerBuilder::default()
+	let config = ServerConfig::builder()
 		.max_request_body_size(u32::MAX)
 		.max_response_body_size(u32::MAX)
 		.max_connections(10 * 1024)
 		.custom_tokio_runtime(handle)
-		.build("127.0.0.1:0")
-		.await
-		.unwrap();
+		.build();
+	let server = ServerBuilder::default().set_config(config).build("127.0.0.1:0").await.unwrap();
 
 	let module = gen_rpc_module();
 
@@ -132,16 +131,15 @@ pub async fn http_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::
 /// Run jsonrpsee WebSocket server for benchmarks.
 #[cfg(not(feature = "jsonrpc-crate"))]
 pub async fn ws_server(handle: tokio::runtime::Handle) -> (String, jsonrpsee::server::ServerHandle) {
-	use jsonrpsee::server::{ServerBuilder, SubscriptionMessage};
+	use jsonrpsee::server::{ServerBuilder, ServerConfig, SubscriptionMessage};
 
-	let server = ServerBuilder::default()
+	let config = ServerConfig::builder()
 		.max_request_body_size(u32::MAX)
 		.max_response_body_size(u32::MAX)
 		.max_connections(10 * 1024)
 		.custom_tokio_runtime(handle)
-		.build("127.0.0.1:0")
-		.await
-		.unwrap();
+		.build();
+	let server = ServerBuilder::default().set_config(config).build("127.0.0.1:0").await.unwrap();
 
 	let mut module = gen_rpc_module();
 

--- a/examples/examples/jsonrpsee_as_service.rs
+++ b/examples/examples/jsonrpsee_as_service.rs
@@ -42,7 +42,9 @@ use jsonrpsee::core::async_trait;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::middleware::rpc::{ResponseFuture, RpcServiceBuilder, RpcServiceT};
-use jsonrpsee::server::{serve_with_graceful_shutdown, stop_channel, ServerHandle, StopHandle, TowerServiceBuilder};
+use jsonrpsee::server::{
+	serve_with_graceful_shutdown, stop_channel, ServerConfig, ServerHandle, StopHandle, TowerServiceBuilder,
+};
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Request};
 use jsonrpsee::ws_client::{HeaderValue, WsClientBuilder};
 use jsonrpsee::{MethodResponse, Methods};
@@ -174,8 +176,8 @@ async fn run_server(metrics: Metrics) -> anyhow::Result<ServerHandle> {
 		stop_handle: stop_handle.clone(),
 		metrics,
 		svc_builder: jsonrpsee::server::Server::builder()
+			.set_config(ServerConfig::builder().max_connections(33).build())
 			.set_http_middleware(tower::ServiceBuilder::new().layer(CorsLayer::permissive()))
-			.max_connections(33)
 			.to_service_builder(),
 	};
 

--- a/examples/examples/ws_pubsub_broadcast.rs
+++ b/examples/examples/ws_pubsub_broadcast.rs
@@ -33,7 +33,7 @@ use futures::StreamExt;
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use jsonrpsee::core::server::SubscriptionMessage;
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, Server};
+use jsonrpsee::server::{RpcModule, Server, ServerConfig};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::PendingSubscriptionSink;
 use tokio::sync::broadcast;
@@ -66,7 +66,8 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	// let's configure the server only hold 5 messages in memory.
-	let server = Server::builder().set_message_buffer_capacity(5).build("127.0.0.1:0").await?;
+	let config = ServerConfig::builder().set_message_buffer_capacity(5).build();
+	let server = Server::builder().set_config(config).build("127.0.0.1:0").await?;
 	let (tx, _rx) = broadcast::channel::<usize>(16);
 
 	let mut module = RpcModule::new(tx.clone());

--- a/examples/examples/ws_pubsub_with_params.rs
+++ b/examples/examples/ws_pubsub_with_params.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use jsonrpsee::core::Serialize;
-use jsonrpsee::server::{RpcModule, Server, SubscriptionMessage, TrySendError};
+use jsonrpsee::server::{RpcModule, Server, ServerConfig, SubscriptionMessage, TrySendError};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, PendingSubscriptionSink};
 use tokio::time::interval;
@@ -63,7 +63,8 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_server() -> anyhow::Result<SocketAddr> {
 	const LETTERS: &str = "abcdefghijklmnopqrstuvxyz";
-	let server = Server::builder().set_message_buffer_capacity(10).build("127.0.0.1:0").await?;
+	let config = ServerConfig::builder().set_message_buffer_capacity(10).build();
+	let server = Server::builder().set_config(config).build("127.0.0.1:0").await?;
 	let mut module = RpcModule::new(());
 	module
 		.register_subscription(

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -49,8 +49,8 @@ pub use jsonrpsee_core::{id_providers::*, traits::IdProvider};
 pub use jsonrpsee_types as types;
 pub use middleware::rpc::RpcServiceBuilder;
 pub use server::{
-	BatchRequestConfig, Builder as ServerBuilder, ConnectionState, PingConfig, Server, ServerConfig, TowerService,
-	TowerServiceBuilder,
+	BatchRequestConfig, Builder as ServerBuilder, ConnectionState, PingConfig, Server, ServerConfig,
+	ServerConfigBuilder, TowerService, TowerServiceBuilder,
 };
 pub use tracing;
 

--- a/server/src/tests/helpers.rs
+++ b/server/src/tests/helpers.rs
@@ -3,7 +3,9 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::{fmt, sync::atomic::AtomicUsize};
 
-use crate::{serve_with_graceful_shutdown, stop_channel, RpcModule, Server, ServerBuilder, ServerHandle};
+use crate::{
+	serve_with_graceful_shutdown, stop_channel, RpcModule, Server, ServerBuilder, ServerConfigBuilder, ServerHandle,
+};
 
 use futures_util::FutureExt;
 use jsonrpsee_core::server::Methods;
@@ -213,7 +215,10 @@ pub(crate) async fn ws_server_with_stats(metrics: Metrics) -> SocketAddr {
 	let (stop_handle, server_handle) = stop_channel();
 	let metrics = metrics.clone();
 
-	let rpc_svc = Server::builder().max_connections(33).to_service_builder().build(Methods::new(), stop_handle.clone());
+	let rpc_svc = Server::builder()
+		.set_config(ServerConfigBuilder::new().max_connections(33).build())
+		.to_service_builder()
+		.build(Methods::new(), stop_handle.clone());
 
 	tokio::spawn(async move {
 		loop {

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -26,7 +26,7 @@
 
 use std::net::SocketAddr;
 
-use crate::{BatchRequestConfig, RegisterMethodError, RpcModule, ServerBuilder, ServerHandle};
+use crate::{BatchRequestConfig, RegisterMethodError, RpcModule, ServerBuilder, ServerConfig, ServerHandle};
 use jsonrpsee_core::RpcResult;
 use jsonrpsee_test_utils::helpers::*;
 use jsonrpsee_test_utils::mocks::{Id, StatusCode};
@@ -455,7 +455,8 @@ async fn can_register_modules() {
 async fn can_set_the_max_request_body_size() {
 	let addr = "127.0.0.1:0";
 	// Rejects all requests larger than 100 bytes
-	let server = ServerBuilder::default().max_request_body_size(100).build(addr).await.unwrap();
+	let config = ServerConfig::builder().max_request_body_size(100).build();
+	let server = ServerBuilder::with_config(config).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx, _| "a".repeat(100)).unwrap();
 	let addr = server.local_addr().unwrap();
@@ -480,7 +481,8 @@ async fn can_set_the_max_request_body_size() {
 async fn can_set_the_max_response_size() {
 	let addr = "127.0.0.1:0";
 	// Set the max response size to 100 bytes
-	let server = ServerBuilder::default().max_response_body_size(100).build(addr).await.unwrap();
+	let config = ServerConfig::builder().max_response_body_size(100).build();
+	let server = ServerBuilder::with_config(config).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx, _| "a".repeat(101)).unwrap();
 	let addr = server.local_addr().unwrap();
@@ -500,7 +502,8 @@ async fn can_set_the_max_response_size() {
 async fn can_set_the_max_response_size_to_batch() {
 	let addr = "127.0.0.1:0";
 	// Set the max response size to 100 bytes
-	let server = ServerBuilder::default().max_response_body_size(100).build(addr).await.unwrap();
+	let config = ServerConfig::builder().max_response_body_size(100).build();
+	let server = ServerBuilder::with_config(config).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
 	module.register_method("anything", |_p, _cx, _| "a".repeat(51)).unwrap();
 	let addr = server.local_addr().unwrap();
@@ -520,8 +523,8 @@ async fn can_set_the_max_response_size_to_batch() {
 async fn disabled_batches() {
 	let addr = "127.0.0.1:0";
 	// Disable batches support.
-	let server =
-		ServerBuilder::default().set_batch_request_config(BatchRequestConfig::Disabled).build(addr).await.unwrap();
+	let config = ServerConfig::builder().set_batch_request_config(BatchRequestConfig::Disabled).build();
+	let server = ServerBuilder::with_config(config).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
 	module.register_method("should_ok", |_, _ctx, _| "ok").unwrap();
 	let addr = server.local_addr().unwrap();
@@ -544,8 +547,8 @@ async fn disabled_batches() {
 async fn batch_limit_works() {
 	let addr = "127.0.0.1:0";
 	// Disable batches support.
-	let server =
-		ServerBuilder::default().set_batch_request_config(BatchRequestConfig::Limit(1)).build(addr).await.unwrap();
+	let config = ServerConfig::builder().set_batch_request_config(BatchRequestConfig::Limit(1)).build();
+	let server = ServerBuilder::with_config(config).build(addr).await.unwrap();
 	let mut module = RpcModule::new(());
 	module.register_method("should_ok", |_, _ctx, _| "ok").unwrap();
 	let addr = server.local_addr().unwrap();

--- a/server/src/tests/shared.rs
+++ b/server/src/tests/shared.rs
@@ -1,4 +1,5 @@
 use crate::tests::helpers::{init_logger, server_with_handles};
+use crate::ServerConfig;
 use hyper::StatusCode;
 use jsonrpsee_test_utils::helpers::{http_request, ok_response, to_http_uri};
 use jsonrpsee_test_utils::mocks::{Id, WebSocketTestClient, WebSocketTestError};
@@ -42,8 +43,8 @@ async fn run_forever() {
 async fn http_only_works() {
 	use crate::{RpcModule, ServerBuilder};
 
-	let server =
-		ServerBuilder::default().http_only().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let config = ServerConfig::builder().http_only().build();
+	let server = ServerBuilder::with_config(config).build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut module = RpcModule::new(());
 	module
 		.register_method("say_hello", |_, _, _| {
@@ -68,7 +69,8 @@ async fn http_only_works() {
 async fn ws_only_works() {
 	use crate::{RpcModule, ServerBuilder};
 
-	let server = ServerBuilder::default().ws_only().build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
+	let config = ServerConfig::builder().ws_only().build();
+	let server = ServerBuilder::with_config(config).build("127.0.0.1:0").with_default_timeout().await.unwrap().unwrap();
 	let mut module = RpcModule::new(());
 	module
 		.register_method("say_hello", |_, _, _| {

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -50,7 +50,7 @@ use jsonrpsee::core::server::SubscriptionMessage;
 use jsonrpsee::core::{JsonValue, StringError};
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::server::middleware::http::HostFilterLayer;
-use jsonrpsee::server::{ConnectionGuard, ServerBuilder, ServerHandle};
+use jsonrpsee::server::{ConnectionGuard, ServerBuilder, ServerConfig, ServerHandle};
 use jsonrpsee::types::error::{ErrorObject, UNKNOWN_ERROR_CODE};
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee::{rpc_params, ResponsePayload, RpcModule};
@@ -826,7 +826,8 @@ async fn ws_server_limit_subs_per_conn_works() {
 
 	init_logger();
 
-	let server = ServerBuilder::default().max_subscriptions_per_connection(10).build("127.0.0.1:0").await.unwrap();
+	let config = ServerConfig::builder().max_subscriptions_per_connection(10).build();
+	let server = ServerBuilder::with_config(config).build("127.0.0.1:0").await.unwrap();
 	let server_url = format!("ws://{}", server.local_addr().unwrap());
 
 	let mut module = RpcModule::new(());
@@ -881,7 +882,8 @@ async fn ws_server_unsub_methods_should_ignore_sub_limit() {
 
 	init_logger();
 
-	let server = ServerBuilder::default().max_subscriptions_per_connection(10).build("127.0.0.1:0").await.unwrap();
+	let config = ServerConfig::builder().max_subscriptions_per_connection(10).build();
+	let server = ServerBuilder::with_config(config).build("127.0.0.1:0").await.unwrap();
 	let server_url = format!("ws://{}", server.local_addr().unwrap());
 
 	let mut module = RpcModule::new(());


### PR DESCRIPTION
**CHANGES**:

- add `custom_tokio_runtime` method for `ServerConfigBuilder`
- add `with_config` constructor for `ServerBuilder`
- add `set_config` method for `ServerBuilder`

**BREAKING CHANGES**:

- remove all config setter methods of `ServerBuilder`

Close #1486 