### PR TITLE
refactor(server): make `ProxyGetRequestLayer` http middleware support multiple path-method pairs

### DIFF
--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -87,7 +87,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	// Custom tower service to handle the RPC requests
 	let service_builder = tower::ServiceBuilder::new()
 		// Proxy `GET /health` requests to internal `system_health` method.
-		.layer(ProxyGetRequestLayer::new("/health", "system_health")?)
+		.layer(ProxyGetRequestLayer::new([("/health", "system_health")])?)
 		.timeout(Duration::from_secs(2));
 
 	let server =

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,27 +15,28 @@ publish = true
 
 [dependencies]
 futures-util = { version = "0.3.14", default-features = false, features = ["io", "async-await-macro"] }
-jsonrpsee-types = { workspace = true }
-jsonrpsee-core = { workspace = true, features = ["server", "http-helpers"] }
-tracing = "0.1.34"
-serde = "1"
-serde_json = { version = "1", features = ["raw_value"] }
-soketto = { version = "0.8", features = ["http"] }
-tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
-tokio-util = { version = "0.7", features = ["compat"] }
-tokio-stream = { version = "0.1.7", features = ["sync"] }
-hyper = { version = "1.3", features = ["server", "http1", "http2"] }
-hyper-util = { version = "0.1", features = ["tokio", "service", "tokio", "server-auto"] }
 http = "1"
 http-body = "1"
 http-body-util = "0.1.0"
-tower = { workspace = true, features = ["util"] }
-thiserror = "2"
-route-recognizer = "0.3.1"
+hyper = { version = "1.3", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio", "service", "tokio", "server-auto"] }
+jsonrpsee-core = { workspace = true, features = ["server", "http-helpers"] }
+jsonrpsee-types = { workspace = true }
 pin-project = "1.1.3"
+route-recognizer = "0.3.1"
+rustc-hash = "2.0.0"
+serde = "1"
+serde_json = { version = "1", features = ["raw_value"] }
+soketto = { version = "0.8", features = ["http"] }
+thiserror = "2"
+tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
+tokio-util = { version = "0.7", features = ["compat"] }
+tokio-stream = { version = "0.1.7", features = ["sync"] }
+tower = { workspace = true, features = ["util"] }
+tracing = "0.1.34"
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }
-tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tower = { workspace = true, features = ["timeout"] }
 socket2 = "0.5.1"
+tower = { workspace = true, features = ["timeout"] }
+tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,7 +24,6 @@ jsonrpsee-core = { workspace = true, features = ["server", "http-helpers"] }
 jsonrpsee-types = { workspace = true }
 pin-project = "1.1.3"
 route-recognizer = "0.3.1"
-rustc-hash = "2.0.0"
 serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = { version = "0.8", features = ["http"] }

--- a/server/src/middleware/http/proxy_get_request.rs
+++ b/server/src/middleware/http/proxy_get_request.rs
@@ -72,21 +72,21 @@ impl ProxyGetRequestLayer {
 	/// Fails if the path does not start with `/`.
 	pub fn new<P, M>(pairs: impl IntoIterator<Item = (P, M)>) -> Result<Self, ProxyGetRequestError>
 	where
-		P: AsRef<str>,
-		M: AsRef<str>,
+		P: Into<String>,
+		M: Into<String>,
 	{
 		let mut methods = HashMap::new();
 
 		for (path, method) in pairs {
-			let path = path.as_ref();
-			let method = method.as_ref();
+			let path = path.into();
+			let method = method.into();
 
 			if !path.starts_with('/') {
-				return Err(ProxyGetRequestError::InvalidPath(path.to_owned()));
+				return Err(ProxyGetRequestError::InvalidPath(path));
 			}
 
-			if let Some(path) = methods.insert(path.to_owned(), method.to_owned()) {
-				return Err(ProxyGetRequestError::DuplicatedPath(path.to_owned()));
+			if let Some(path) = methods.insert(path, method) {
+				return Err(ProxyGetRequestError::DuplicatedPath(path));
 			}
 		}
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -746,8 +746,8 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 	/// fn run_server() -> ServerHandle {
 	///     let (stop_handle, server_handle) = stop_channel();
 	///     let svc_builder = jsonrpsee_server::Server::builder()
-	///     	.set_config(ServerConfig::builder().max_connections(33).build())
-	///  		.to_service_builder();
+	///         .set_config(ServerConfig::builder().max_connections(33).build())
+	///         .to_service_builder();
 	///     let methods = Methods::new();
 	///     let stop_handle = stop_handle.clone();
 	///

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -279,7 +279,7 @@ pub async fn server_with_health_api() -> (SocketAddr, ServerHandle) {
 pub async fn server_with_cors(cors: CorsLayer) -> (SocketAddr, ServerHandle) {
 	let middleware = tower::ServiceBuilder::new()
 		// Proxy `GET /health` requests to internal `system_health` method.
-		.layer(ProxyGetRequestLayer::new("/health", "system_health").unwrap())
+		.layer(ProxyGetRequestLayer::new([("/health", "system_health")]).unwrap())
 		// Add `CORS` layer.
 		.layer(cors);
 


### PR DESCRIPTION
**BREAKING CHNAGES**:

- change `ProxyGetRequestLayer::new` method to support multiple path-method pairs
- remove `ProxyGetRequest::new` method, which is useless