### PR TITLE
chore: fix clippy warnings when using rust 1.83

### DIFF
--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -61,7 +61,7 @@ impl BoundedWriter {
 	}
 }
 
-impl<'a> io::Write for &'a mut BoundedWriter {
+impl io::Write for &mut BoundedWriter {
 	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
 		let len = self.buf.len() + buf.len();
 		if self.max_len >= len {

--- a/core/src/server/method_response.rs
+++ b/core/src/server/method_response.rs
@@ -394,7 +394,7 @@ where
 	}
 }
 
-impl<'a, T> From<ErrorCode> for ResponsePayload<'a, T>
+impl<T> From<ErrorCode> for ResponsePayload<'_, T>
 where
 	T: Clone,
 {

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -96,7 +96,7 @@ impl<'a> ErrorObject<'a> {
 	}
 }
 
-impl<'a> PartialEq for ErrorObject<'a> {
+impl PartialEq for ErrorObject<'_> {
 	fn eq(&self, other: &Self) -> bool {
 		let this_raw = self.data.as_ref().map(|r| r.get());
 		let other_raw = other.data.as_ref().map(|r| r.get());
@@ -104,7 +104,7 @@ impl<'a> PartialEq for ErrorObject<'a> {
 	}
 }
 
-impl<'a> From<ErrorCode> for ErrorObject<'a> {
+impl From<ErrorCode> for ErrorObject<'_> {
 	fn from(code: ErrorCode) -> Self {
 		Self { code, message: code.message().into(), data: None }
 	}

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -44,7 +44,7 @@ pub struct TwoPointZero;
 
 struct TwoPointZeroVisitor;
 
-impl<'de> Visitor<'de> for TwoPointZeroVisitor {
+impl Visitor<'_> for TwoPointZeroVisitor {
 	type Value = TwoPointZero;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -269,7 +269,7 @@ pub enum SubscriptionId<'a> {
 	Str(Cow<'a, str>),
 }
 
-impl<'a> From<SubscriptionId<'a>> for JsonValue {
+impl From<SubscriptionId<'_>> for JsonValue {
 	fn from(sub_id: SubscriptionId) -> Self {
 		match sub_id {
 			SubscriptionId::Num(n) => n.into(),
@@ -278,13 +278,13 @@ impl<'a> From<SubscriptionId<'a>> for JsonValue {
 	}
 }
 
-impl<'a> From<u64> for SubscriptionId<'a> {
+impl From<u64> for SubscriptionId<'_> {
 	fn from(sub_id: u64) -> Self {
 		Self::Num(sub_id)
 	}
 }
 
-impl<'a> From<String> for SubscriptionId<'a> {
+impl From<String> for SubscriptionId<'_> {
 	fn from(sub_id: String) -> Self {
 		Self::Str(sub_id.into())
 	}
@@ -308,7 +308,7 @@ impl<'a> TryFrom<JsonValue> for SubscriptionId<'a> {
 	}
 }
 
-impl<'a> SubscriptionId<'a> {
+impl SubscriptionId<'_> {
 	/// Convert `SubscriptionId<'a>` to `SubscriptionId<'static>` so that it can be moved across threads.
 	///
 	/// This can cause an allocation if the id is a string.
@@ -350,7 +350,7 @@ pub enum Id<'a> {
 	Str(Cow<'a, str>),
 }
 
-impl<'a> Id<'a> {
+impl Id<'_> {
 	/// If the Id is a number, returns the associated number. Returns None otherwise.
 	pub fn as_number(&self) -> Option<&u64> {
 		match self {
@@ -396,7 +396,7 @@ impl<'a> Id<'a> {
 	}
 }
 
-impl<'a> std::fmt::Display for Id<'a> {
+impl std::fmt::Display for Id<'_> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			Id::Null => f.write_str("null"),

--- a/types/src/response.rs
+++ b/types/src/response.rs
@@ -59,7 +59,7 @@ impl<'a, T: Clone> Response<'a, T> {
 	}
 }
 
-impl<'a, T> fmt::Display for Response<'a, T>
+impl<T> fmt::Display for Response<'_, T>
 where
 	T: Serialize + Clone,
 {
@@ -68,7 +68,7 @@ where
 	}
 }
 
-impl<'a, T> fmt::Debug for Response<'a, T>
+impl<T> fmt::Debug for Response<'_, T>
 where
 	T: Serialize + Clone,
 {
@@ -205,7 +205,7 @@ where
 			{
 				struct FieldVisitor;
 
-				impl<'de> serde::de::Visitor<'de> for FieldVisitor {
+				impl serde::de::Visitor<'_> for FieldVisitor {
 					type Value = Field;
 
 					fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -313,7 +313,7 @@ where
 	}
 }
 
-impl<'a, T> Serialize for Response<'a, T>
+impl<T> Serialize for Response<'_, T>
 where
 	T: Serialize + Clone,
 {


### PR DESCRIPTION
```
cargo clippy --release --all-targets --all-features --fix
```