### PR TITLE
chore(deps): bump soketto to 0.8.1

### DIFF
--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -34,7 +34,7 @@ rustls-platform-verifier = { version = "0.4.0", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
 
 # ws
-soketto = { version = "0.8", optional = true }
+soketto = { version = "0.8.1", optional = true }
 
 # web-sys
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,7 +26,7 @@ pin-project = "1.1.3"
 route-recognizer = "0.3.1"
 serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
-soketto = { version = "0.8", features = ["http"] }
+soketto = { version = "0.8.1", features = ["http"] }
 thiserror = "2"
 tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -15,6 +15,6 @@ http-body-util = "0.1.0"
 tracing = "0.1.34"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
-soketto = { version = "0.8.0", features = ["http"] }
+soketto = { version = "0.8.1", features = ["http"] }
 tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }


### PR DESCRIPTION
This fixes some faulty I/O error when the WS connection was closed down cleanly.

Close #871 