### PR TITLE
chore(macros): fix typo in internal type name

### DIFF
--- a/proc-macros/src/render_client.rs
+++ b/proc-macros/src/render_client.rs
@@ -63,7 +63,7 @@ impl RpcDescription {
 				#(#sub_impls)*
 			}
 
-			impl<TypeJsonRpseeInteral #(,#type_idents)*> #trait_name #type_generics for TypeJsonRpseeInteral where TypeJsonRpseeInteral: #super_trait #(,#where_clause)* {}
+			impl<TypeJsonRpseeInternal #(,#type_idents)*> #trait_name #type_generics for TypeJsonRpseeInternal where TypeJsonRpseeInternal: #super_trait #(,#where_clause)* {}
 		};
 
 		Ok(trait_impl)


### PR DESCRIPTION
Fix a typo.