### PR TITLE
Add request timeout getter to `Client` and `HttpClient`

### DIFF
--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -326,6 +326,11 @@ impl HttpClient<HttpBackend> {
 	pub fn builder() -> HttpClientBuilder<Identity> {
 		HttpClientBuilder::new()
 	}
+
+	/// Returns configured request timeout.
+	pub fn request_timeout(&self) -> Duration {
+		self.request_timeout
+	}
 }
 
 #[async_trait]

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -449,6 +449,11 @@ impl Client {
 	pub async fn on_disconnect(&self) -> Error {
 		self.error.read_error().await
 	}
+
+	/// Returns configured request timeout.
+	pub fn request_timeout(&self) -> Duration {
+		self.request_timeout
+	}
 }
 
 impl Drop for Client {


### PR DESCRIPTION
Closes https://github.com/paritytech/jsonrpsee/issues/1532

Adds getter for request timeout to `Client` and `HttpClient`