### PR TITLE
chore: fix `http request body` log 

### DIFF
--- a/core/src/http_helpers.rs
+++ b/core/src/http_helpers.rs
@@ -180,7 +180,7 @@ where
 		Some(single) if !received_data.is_empty() => {
 			tracing::trace!(
 				target: "jsonrpsee-http",
-				"HTTP response body: {}",
+				"HTTP body: {}",
 				std::str::from_utf8(&received_data).unwrap_or("Invalid UTF-8 data")
 			);
 			Ok((received_data, single))


### PR DESCRIPTION
Randomly found a log labelling a request body with "response" today :pray:. 