### PR TITLE
feat: impl From<Infallible> for ErrorObject

### DIFF
--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -24,6 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::convert::Infallible;
 use std::fmt;
 
 use serde::de::Deserializer;
@@ -107,6 +108,12 @@ impl PartialEq for ErrorObject<'_> {
 impl From<ErrorCode> for ErrorObject<'_> {
 	fn from(code: ErrorCode) -> Self {
 		Self { code, message: code.message().into(), data: None }
+	}
+}
+
+impl From<Infallible> for ErrorObject<'_> {
+	fn from(e: Infallible) -> Self {
+		match e {}
 	}
 }
 


### PR DESCRIPTION
This is useful for users that are providing something similar to Infallible for rpcs that returns Infallible.

```rust
#[rpc(server, client)]
pub trait Rpc
{
	#[method(name = "say_something)]
	async fn say_something(&self) -> Result<String, Infallible>;
}
```