### PR TITLE
feat: add namespace_separator option for RPC methods

### DIFF
--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -80,7 +80,7 @@ pub(crate) mod visitor;
 /// that generated for it by the macro.
 ///
 /// ```ignore
-/// #[rpc(client, server, namespace = "foo")]
+/// #[rpc(client, server, namespace = "foo", namespace_separator = ".")]
 /// pub trait Rpc {
 ///     #[method(name = "foo")]
 ///     async fn async_method(&self, param_a: u8, param_b: String) -> u16;
@@ -147,6 +147,8 @@ pub(crate) mod visitor;
 ///   implementation's methods conveniently.
 /// - `namespace`: add a prefix to all the methods and subscriptions in this RPC. For example, with namespace `foo` and
 ///   method `spam`, the resulting method name will be `foo_spam`.
+/// - `namespace_separator`: customize the separator used between namespace and method name. Defaults to `_`.
+///		For example, `namespace = "foo", namespace_separator = "."` results in method names like `foo.bar` instead of `foo_bar`.
 /// - `server_bounds`: replace *all* auto-generated trait bounds with the user-defined ones for the server
 ///   implementation.
 /// - `client_bounds`: replace *all* auto-generated trait bounds with the user-defined ones for the client

--- a/proc-macros/src/rpc_macro.rs
+++ b/proc-macros/src/rpc_macro.rs
@@ -279,7 +279,14 @@ pub struct RpcDescription {
 impl RpcDescription {
 	pub fn from_item(attr: Attribute, mut item: syn::ItemTrait) -> syn::Result<Self> {
 		let [client, server, namespace, namespace_separator, client_bounds, server_bounds] =
-			AttributeMeta::parse(attr)?.retain(["client", "server", "namespace", "namespace_separator", "client_bounds", "server_bounds"])?;
+			AttributeMeta::parse(attr)?.retain([
+				"client",
+				"server",
+				"namespace",
+				"namespace_separator",
+				"client_bounds",
+				"server_bounds",
+			])?;
 
 		let needs_server = optional(server, Argument::flag)?.is_some();
 		let needs_client = optional(client, Argument::flag)?.is_some();

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -296,6 +296,15 @@ async fn macro_zero_copy_cow() {
 	assert_eq!(resp, r#"{"jsonrpc":"2.0","id":0,"result":"Zero copy params: false"}"#);
 }
 
+#[tokio::test]
+async fn namespace_separator_dot_formatting_works() {
+	let module = RpcServerImpl.into_rpc();
+
+	let res: String = module.call("foo.params", [json!(1_u64), json!("test")]).await.unwrap();
+
+	assert_eq!(&res, "Called with: 1, test");
+}
+
 // Disabled on MacOS as GH CI timings on Mac vary wildly (~100ms) making this test fail.
 #[cfg(not(target_os = "macos"))]
 #[ignore]

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -298,11 +298,56 @@ async fn macro_zero_copy_cow() {
 
 #[tokio::test]
 async fn namespace_separator_dot_formatting_works() {
-	let module = RpcServerImpl.into_rpc();
+	use jsonrpsee::core::async_trait;
+	use jsonrpsee::proc_macros::rpc;
+	use serde_json::json;
 
-	let res: String = module.call("foo.params", [json!(1_u64), json!("test")]).await.unwrap();
+	#[rpc(server, namespace = "foo", namespace_separator = ".")]
+	pub trait DotSeparatorRpc {
+		#[method(name = "dot")]
+		fn dot(&self, a: u32, b: &str) -> Result<String, jsonrpsee::types::ErrorObjectOwned>;
+	}
+
+	struct DotImpl;
+
+	#[async_trait]
+	impl DotSeparatorRpcServer for DotImpl {
+		fn dot(&self, a: u32, b: &str) -> Result<String, jsonrpsee::types::ErrorObjectOwned> {
+			Ok(format!("Called with: {}, {}", a, b))
+		}
+	}
+
+	let module = DotImpl.into_rpc();
+	let res: String = module.call("foo.dot", [json!(1_u64), json!("test")]).await.unwrap();
 
 	assert_eq!(&res, "Called with: 1, test");
+}
+
+#[tokio::test]
+async fn namespace_separator_slash_formatting_works() {
+	use jsonrpsee::core::async_trait;
+	use jsonrpsee::proc_macros::rpc;
+	use serde_json::json;
+
+	#[rpc(server, namespace = "math", namespace_separator = "/")]
+	pub trait SlashSeparatorRpc {
+		#[method(name = "add")]
+		fn add(&self, x: i32, y: i32) -> Result<i32, jsonrpsee::types::ErrorObjectOwned>;
+	}
+
+	struct SlashImpl;
+
+	#[async_trait]
+	impl SlashSeparatorRpcServer for SlashImpl {
+		fn add(&self, x: i32, y: i32) -> Result<i32, jsonrpsee::types::ErrorObjectOwned> {
+			Ok(x + y)
+		}
+	}
+
+	let module = SlashImpl.into_rpc();
+	let result: i32 = module.call("math/add", [json!(20), json!(22)]).await.unwrap();
+
+	assert_eq!(result, 42);
 }
 
 // Disabled on MacOS as GH CI timings on Mac vary wildly (~100ms) making this test fail.


### PR DESCRIPTION
Hi @niklasad1 & @tomaka! 👋

I just opened this issue (https://github.com/paritytech/jsonrpsee/issues/1543) after noticing that `jsonrpsee` doesn’t currently support namespace separators and instead defaults to using underscores.

To address this, I’ve submitted a PR that introduces a `namespace_separator` option. The implementation seems to be working, but since I’m not deeply familiar with the codebase, tests, or documentation conventions, I’d really appreciate your input.

Your feedback would be super helpful in making this PR production-ready—we're relying on this feature and would love to get it merged.

Thanks in advance! 🙏