### PR TITLE
refactor(client): use native async fn in traits instead async_trait crate

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -17,7 +17,6 @@ publish = true
 workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 base64 = { workspace = true }
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
 hyper-rustls = { workspace = true, features = ["http1", "http2", "tls12", "logging", "ring"], optional = true }

--- a/client/transport/src/web.rs
+++ b/client/transport/src/web.rs
@@ -4,7 +4,6 @@ use futures_channel::mpsc;
 use futures_util::sink::SinkExt;
 use futures_util::stream::{SplitSink, SplitStream, StreamExt};
 use gloo_net::websocket::{Message, WebSocketError, futures::WebSocket};
-use jsonrpsee_core::async_trait;
 use jsonrpsee_core::client::{ReceivedMessage, TransportReceiverT, TransportSenderT};
 
 /// Web-sys transport error that can occur.
@@ -45,28 +44,30 @@ impl fmt::Debug for Receiver {
 	}
 }
 
-#[async_trait(?Send)]
 impl TransportSenderT for Sender {
 	type Error = Error;
 
-	async fn send(&mut self, msg: String) -> Result<(), Self::Error> {
-		self.0.send(Message::Text(msg)).await.map_err(|e| Error::WebSocket(e))?;
-		Ok(())
+	fn send(&mut self, msg: String) -> impl Future<Output = Result<(), Self::Error>> {
+		async {
+			self.0.send(Message::Text(msg)).await.map_err(|e| Error::WebSocket(e))?;
+			Ok(())
+		}
 	}
 }
 
-#[async_trait(?Send)]
 impl TransportReceiverT for Receiver {
 	type Error = Error;
 
-	async fn receive(&mut self) -> Result<ReceivedMessage, Self::Error> {
-		match self.0.next().await {
-			Some(Ok(msg)) => match msg {
-				Message::Bytes(bytes) => Ok(ReceivedMessage::Bytes(bytes)),
-				Message::Text(txt) => Ok(ReceivedMessage::Text(txt)),
-			},
-			Some(Err(err)) => Err(Error::WebSocket(err)),
-			None => Err(Error::SenderDisconnected),
+	fn receive(&mut self) -> impl Future<Output = Result<ReceivedMessage, Self::Error>> {
+		async {
+			match self.0.next().await {
+				Some(Ok(msg)) => match msg {
+					Message::Bytes(bytes) => Ok(ReceivedMessage::Bytes(bytes)),
+					Message::Text(txt) => Ok(ReceivedMessage::Text(txt)),
+				},
+				Some(Err(err)) => Err(Error::WebSocket(err)),
+				None => Err(Error::SenderDisconnected),
+			}
 		}
 	}
 }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -48,7 +48,6 @@ use crate::middleware::ToJson;
 use crate::params::BatchRequestBuilder;
 use crate::traits::ToRpcParams;
 
-use async_trait::async_trait;
 use core::marker::PhantomData;
 use futures_util::stream::{Stream, StreamExt};
 use http::Extensions;

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -91,15 +91,14 @@ pub mod __reexports {
 }
 
 /// [JSON-RPC](https://www.jsonrpc.org/specification) client interface that can make requests and notifications.
-#[async_trait]
 pub trait ClientT {
 	/// Send a [notification request](https://www.jsonrpc.org/specification#notification)
-	async fn notification<Params>(&self, method: &str, params: Params) -> Result<(), Error>
+	fn notification<Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<(), Error>> + Send
 	where
 		Params: ToRpcParams + Send;
 
 	/// Send a [method call request](https://www.jsonrpc.org/specification#request_object).
-	async fn request<R, Params>(&self, method: &str, params: Params) -> Result<R, Error>
+	fn request<R, Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<R, Error>> + Send
 	where
 		R: DeserializeOwned,
 		Params: ToRpcParams + Send;
@@ -111,13 +110,15 @@ pub trait ClientT {
 	///
 	/// Returns `Ok` if all requests in the batch were answered.
 	/// Returns `Error` if the network failed or any of the responses could be parsed a valid JSON-RPC response.
-	async fn batch_request<'a, R>(&self, batch: BatchRequestBuilder<'a>) -> Result<BatchResponse<'a, R>, Error>
+	fn batch_request<'a, R>(
+		&self,
+		batch: BatchRequestBuilder<'a>,
+	) -> impl Future<Output = Result<BatchResponse<'a, R>, Error>> + Send
 	where
 		R: DeserializeOwned + fmt::Debug + 'a;
 }
 
 /// [JSON-RPC](https://www.jsonrpc.org/specification) client interface that can make requests, notifications and subscriptions.
-#[async_trait]
 pub trait SubscriptionClientT: ClientT {
 	/// Initiate a subscription by performing a JSON-RPC method call where the server responds with
 	/// a `Subscription ID` that is used to fetch messages on that subscription,
@@ -131,12 +132,12 @@ pub trait SubscriptionClientT: ClientT {
 	///
 	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further
 	/// documentation.
-	async fn subscribe<'a, Notif, Params>(
+	fn subscribe<'a, Notif, Params>(
 		&self,
 		subscribe_method: &'a str,
 		params: Params,
 		unsubscribe_method: &'a str,
-	) -> Result<Subscription<Notif>, Error>
+	) -> impl Future<Output = Result<Subscription<Notif>, Error>> + Send
 	where
 		Params: ToRpcParams + Send,
 		Notif: DeserializeOwned;
@@ -145,7 +146,10 @@ pub trait SubscriptionClientT: ClientT {
 	///
 	/// The `Notif` param is a generic type to receive generic subscriptions, see [`Subscription`] for further
 	/// documentation.
-	async fn subscribe_to_method<'a, Notif>(&self, method: &'a str) -> Result<Subscription<Notif>, Error>
+	fn subscribe_to_method<Notif>(
+		&self,
+		method: &str,
+	) -> impl Future<Output = Result<Subscription<Notif>, Error>> + Send
 	where
 		Notif: DeserializeOwned;
 }

--- a/proc-macros/tests/ui/incorrect/method/method_non_result_return_type.stderr
+++ b/proc-macros/tests/ui/incorrect/method/method_non_result_return_type.stderr
@@ -4,7 +4,7 @@ error: Expecting something like 'Result<Foo, Err>' here, but got no generic args
 6 |     async fn a(&self) -> u16;
   |                          ^^^
 
-error[E0308]: mismatched types
+error[E0271]: expected `impl Future<Output = Result<_, ClientError>> + Send` to be a future that resolves to `()`, but it resolves to `Result<_, ClientError>`
  --> tests/ui/incorrect/method/method_non_result_return_type.rs:3:1
   |
 3 | #[rpc(client)]
@@ -12,7 +12,3 @@ error[E0308]: mismatched types
   |
   = note: expected unit type `()`
                   found enum `Result<_, ClientError>`
-help: consider using `Result::expect` to unwrap the `Result<_, ClientError>` value, panicking if the value is a `Result::Err`
-  |
-3 | #[rpc(client)].expect("REASON")
-  |               +++++++++++++++++

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
@@ -28,8 +28,8 @@ error[E0277]: the trait bound `<Conf as Config>::Hash: DeserializeOwned` is not 
 note: required by a bound in `request`
  --> $WORKSPACE/core/src/client/mod.rs
   |
-  |     async fn request<R, Params>(&self, method: &str, params: Params) -> Result<R, Error>
-  |              ------- required by a bound in this associated function
+  |     fn request<R, Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<R, Error>> + Send
+  |        ------- required by a bound in this associated function
   |     where
   |         R: DeserializeOwned,
   |            ^^^^^^^^^^^^^^^^ required by this bound in `ClientT::request`

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
@@ -1,3 +1,20 @@
+error[E0277]: the trait bound `<Conf as Config>::Hash: DeserializeOwned` is not satisfied
+ --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
+  |
+9 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `<Conf as Config>::Hash`
+  |
+  = note: required for `<Conf as Config>::Hash` to implement `DeserializeOwned`
+note: required by a bound in `request`
+ --> $WORKSPACE/core/src/client/mod.rs
+  |
+  |     fn request<R, Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<R, Error>> + Send
+  |        ------- required by a bound in this associated function
+  |     where
+  |         R: DeserializeOwned,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ClientT::request`
+  = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `<Conf as Config>::Hash: Serialize` is not satisfied
  --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
   |
@@ -16,21 +33,4 @@ error[E0277]: the trait bound `<Conf as Config>::Hash: Clone` is not satisfied
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Conf as Config>::Hash`
   |
   = note: required for `Result<<Conf as Config>::Hash, ErrorObject<'_>>` to implement `IntoResponse`
-  = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `<Conf as Config>::Hash: DeserializeOwned` is not satisfied
- --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
-  |
-9 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `<Conf as Config>::Hash`
-  |
-  = note: required for `<Conf as Config>::Hash` to implement `DeserializeOwned`
-note: required by a bound in `request`
- --> $WORKSPACE/core/src/client/mod.rs
-  |
-  |     fn request<R, Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<R, Error>> + Send
-  |        ------- required by a bound in this associated function
-  |     where
-  |         R: DeserializeOwned,
-  |            ^^^^^^^^^^^^^^^^ required by this bound in `ClientT::request`
   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR gets rid of the usage of async_trait usage in the client