### PR TITLE
fix: version parsing in `scripts/publish.sh` 

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,7 +6,6 @@
 set -eu
 
 ORDER=(types proc-macros core client/http-client client/transport client/ws-client client/wasm-client server jsonrpsee)
-DIR=$(pwd)
 
 function read_toml () {
 	NAME=""

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,7 +12,7 @@ function read_toml () {
 	NAME=""
 	VERSION=""
 	NAME=$(grep "^name" ./Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
-	VERSION=$(grep "^version" $DIR/Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
+	VERSION=$(grep "^version" ./Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
 }
 function remote_version () {
 	REMOTE_VERSION=""


### PR DESCRIPTION
Previously, the `read_toml` function always read the version from the root `Cargo.toml`, regardless of the current crate being processed in the loop. This was due to referencing `$DIR/Cargo.toml`, which pointed to the original working directory before `cd` into the sub-crate.

Switched to using `./Cargo.toml` to correctly read the version from each crate's local `Cargo.toml`.

Now it properly fetches the version for each submodule instead of reusing the root version.
