### PR TITLE
middleware: RpcServiceT distinct return types for notif, batch, call

### DIFF
--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -463,7 +463,7 @@ impl<L> Client<L> {
 
 		match futures_util::future::select(fut, futures_timer::Delay::new(self.request_timeout)).await {
 			Either::Left((Ok(r), _)) => Ok(r),
-			Either::Left((Err(Error::FetchFromBackend), _)) => Err(self.on_disconnect().await),
+			Either::Left((Err(Error::ServiceDisconnect), _)) => Err(self.on_disconnect().await),
 			Either::Left((Err(e), _)) => Err(e),
 			Either::Right(_) => Err(Error::RequestTimeout),
 		}

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -31,7 +31,7 @@ mod manager;
 mod rpc_service;
 mod utils;
 
-pub use rpc_service::{Error as RpcServiceError, RpcService};
+pub use rpc_service::RpcService;
 
 use std::borrow::Cow as StdCow;
 use std::time::Duration;
@@ -66,7 +66,10 @@ use tokio::sync::{mpsc, oneshot};
 use tower::layer::util::Identity;
 
 use self::utils::{InactivityCheck, IntervalStream};
-use super::{FrontToBack, IdKind, MethodResponse, RequestIdManager, generate_batch_id_range, subscription_channel};
+use super::{
+	FrontToBack, IdKind, MiddlewareBatchResponse, MiddlewareMethodResponse, MiddlewareNotifResponse, RequestIdManager,
+	generate_batch_id_range, subscription_channel,
+};
 
 pub(crate) type Notification<'a> = jsonrpsee_types::Notification<'a, Option<Box<JsonRawValue>>>;
 
@@ -455,16 +458,13 @@ impl<L> Client<L> {
 		!self.to_back.is_closed()
 	}
 
-	async fn run_future_until_timeout(
-		&self,
-		fut: impl Future<Output = Result<MethodResponse, RpcServiceError>>,
-	) -> Result<MethodResponse, Error> {
+	async fn run_future_until_timeout<T>(&self, fut: impl Future<Output = Result<T, Error>>) -> Result<T, Error> {
 		tokio::pin!(fut);
 
 		match futures_util::future::select(fut, futures_timer::Delay::new(self.request_timeout)).await {
 			Either::Left((Ok(r), _)) => Ok(r),
-			Either::Left((Err(RpcServiceError::Client(e)), _)) => Err(e),
-			Either::Left((Err(RpcServiceError::FetchFromBackend), _)) => Err(self.on_disconnect().await),
+			Either::Left((Err(Error::FetchFromBackend), _)) => Err(self.on_disconnect().await),
+			Either::Left((Err(e), _)) => Err(e),
 			Either::Right(_) => Err(Error::RequestTimeout),
 		}
 	}
@@ -495,7 +495,12 @@ impl<L> Drop for Client<L> {
 
 impl<L> ClientT for Client<L>
 where
-	L: RpcServiceT<Error = RpcServiceError, Response = MethodResponse> + Send + Sync,
+	L: RpcServiceT<
+			MethodResponse = Result<MiddlewareMethodResponse, Error>,
+			BatchResponse = Result<MiddlewareBatchResponse, Error>,
+			NotificationResponse = Result<MiddlewareNotifResponse, Error>,
+		> + Send
+		+ Sync,
 {
 	fn notification<Params>(&self, method: &str, params: Params) -> impl Future<Output = Result<(), Error>> + Send
 	where
@@ -520,8 +525,8 @@ where
 			let id = self.id_manager.next_request_id();
 			let params = params.to_rpc_params()?;
 			let fut = self.service.call(Request::borrowed(method, params.as_deref(), id.clone()));
-			let rp = self.run_future_until_timeout(fut).await?.into_method_call().expect("Method call response");
-			let success = ResponseSuccess::try_from(rp.into_inner())?;
+			let rp = self.run_future_until_timeout(fut).await?;
+			let success = ResponseSuccess::try_from(rp.into_response().into_inner())?;
 
 			serde_json::from_str(success.result.get()).map_err(Into::into)
 		}
@@ -554,7 +559,7 @@ where
 			b.extensions_mut().insert(IsBatch { id_range });
 
 			let fut = self.service.batch(b);
-			let json_values = self.run_future_until_timeout(fut).await?.into_batch().expect("Batch response");
+			let json_values = self.run_future_until_timeout(fut).await?;
 
 			let mut responses = Vec::with_capacity(json_values.len());
 			let mut successful_calls = 0;
@@ -580,7 +585,12 @@ where
 
 impl<L> SubscriptionClientT for Client<L>
 where
-	L: RpcServiceT<Error = RpcServiceError, Response = MethodResponse> + Send + Sync,
+	L: RpcServiceT<
+			MethodResponse = Result<MiddlewareMethodResponse, Error>,
+			BatchResponse = Result<MiddlewareBatchResponse, Error>,
+			NotificationResponse = Result<MiddlewareNotifResponse, Error>,
+		> + Send
+		+ Sync,
 {
 	/// Send a subscription request to the server.
 	///
@@ -617,10 +627,12 @@ where
 			};
 
 			let fut = self.service.call(req);
-			let (sub_id, notifs_rx) =
-				self.run_future_until_timeout(fut).await?.into_subscription().expect("Subscription response");
-
-			Ok(Subscription::new(self.to_back.clone(), notifs_rx, SubscriptionKind::Subscription(sub_id)))
+			let sub = self
+				.run_future_until_timeout(fut)
+				.await?
+				.into_subscription()
+				.expect("Extensions set to subscription, must return subscription; qed");
+			Ok(Subscription::new(self.to_back.clone(), sub.stream, SubscriptionKind::Subscription(sub.sub_id)))
 		}
 	}
 

--- a/core/src/client/async_client/rpc_service.rs
+++ b/core/src/client/async_client/rpc_service.rs
@@ -11,13 +11,13 @@ use tokio::sync::{mpsc, oneshot};
 
 impl From<mpsc::error::SendError<FrontToBack>> for Error {
 	fn from(_: mpsc::error::SendError<FrontToBack>) -> Self {
-		Error::FetchFromBackend
+		Error::ServiceDisconnect
 	}
 }
 
 impl From<oneshot::error::RecvError> for Error {
 	fn from(_: oneshot::error::RecvError) -> Self {
-		Error::FetchFromBackend
+		Error::ServiceDisconnect
 	}
 }
 

--- a/core/src/client/async_client/rpc_service.rs
+++ b/core/src/client/async_client/rpc_service.rs
@@ -79,7 +79,7 @@ impl RpcServiceT for RpcService {
 					.await?;
 					let mut rp = send_back_rx.await??;
 
-					rp.0.extensions = request.extensions.clone();
+					rp.0.extensions = request.extensions;
 
 					Ok(MiddlewareMethodResponse::response(rp))
 				}

--- a/core/src/client/error.rs
+++ b/core/src/client/error.rs
@@ -26,7 +26,7 @@
 
 //! Error type for client(s).
 
-use crate::{params::EmptyBatchRequest, BoxError, RegisterMethodError};
+use crate::{BoxError, RegisterMethodError, params::EmptyBatchRequest};
 use jsonrpsee_types::{ErrorObjectOwned, InvalidRequestId};
 use std::sync::Arc;
 
@@ -66,4 +66,8 @@ pub enum Error {
 	/// The error returned when registering a method or subscription failed.
 	#[error(transparent)]
 	RegisterMethod(#[from] RegisterMethodError),
+	#[error("Fetch from backend")]
+	/// Internal error state when the underlying channel is closed
+	/// and the error reason needs to be fetched from the backend.
+	FetchFromBackend,
 }

--- a/core/src/client/error.rs
+++ b/core/src/client/error.rs
@@ -66,8 +66,15 @@ pub enum Error {
 	/// The error returned when registering a method or subscription failed.
 	#[error(transparent)]
 	RegisterMethod(#[from] RegisterMethodError),
-	#[error("Fetch from backend")]
-	/// Internal error state when the underlying channel is closed
-	/// and the error reason needs to be fetched from the backend.
-	FetchFromBackend,
+	/// An internal state when the underlying RpcService
+	/// got disconnected and the error must be fetched
+	/// from the backend.
+	//
+	// NOTE: This is a workaround where an error occurred in
+	// underlying RpcService implementation in the async client
+	// but we don't want to expose different error types for
+	// ergonomics when writing middleware.
+	#[error("RPC service disconnected")]
+	#[doc(hidden)]
+	ServiceDisconnect,
 }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -820,15 +820,6 @@ impl MiddlewareNotifResponse {
 	}
 }
 
-impl Serialize for MiddlewareNotifResponse {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		Ok("null".serialize(serializer)?)
-	}
-}
-
 impl<T: Serialize> ToJson for Result<T, Error> {
 	fn to_json(&self) -> Result<Box<RawValue>, serde_json::Error> {
 		match self {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -655,19 +655,6 @@ fn subscription_channel(max_buf_size: usize) -> (SubscriptionSender, Subscriptio
 	(SubscriptionSender { inner: tx, lagged: lagged_tx }, SubscriptionReceiver { inner: rx, lagged: lagged_rx })
 }
 
-/// Represents the kind of response that can be received from the server.
-#[derive(Debug)]
-pub enum MethodResponseKind {
-	/// Method call response.
-	MethodCall(RawResponseOwned),
-	/// Subscription response.
-	Subscription(SubscriptionResponse),
-	/// Notification response (no payload).
-	Notification,
-	/// Batch response.
-	Batch(Vec<RawResponseOwned>),
-}
-
 /// Represents an active subscription returned by the server.
 #[derive(Debug)]
 pub struct SubscriptionResponse {
@@ -676,121 +663,12 @@ pub struct SubscriptionResponse {
 	// The receiver is used to receive notifications from the server and shouldn't be exposed to the user
 	// from the middleware.
 	stream: SubscriptionReceiver,
-	/// The raw response from the server (mostly used for middleware).
-	rp: RawResponseOwned,
 }
 
 impl SubscriptionResponse {
 	/// Get the subscription ID.
 	pub fn subscription_id(&self) -> &SubscriptionId<'static> {
 		&self.sub_id
-	}
-
-	/// Get the raw response.
-	pub fn response(&self) -> &RawResponseOwned {
-		&self.rp
-	}
-}
-
-/// Represents a response from the server which can be a method call, notification or batch.
-#[derive(Debug)]
-pub struct MethodResponse {
-	extensions: Extensions,
-	inner: MethodResponseKind,
-}
-
-impl MethodResponse {
-	/// Create a new method response.
-	pub fn method_call(rp: RawResponseOwned, extensions: Extensions) -> Self {
-		Self { inner: MethodResponseKind::MethodCall(rp), extensions }
-	}
-
-	/// Create a new subscription response.
-	pub fn subscription(sub: SubscriptionResponse, extensions: Extensions) -> Self {
-		Self { inner: MethodResponseKind::Subscription(sub), extensions }
-	}
-
-	/// Create a new notification response.
-	pub fn notification(extensions: Extensions) -> Self {
-		Self { inner: MethodResponseKind::Notification, extensions }
-	}
-
-	/// Create a new batch response.
-	pub fn batch(json: Vec<RawResponseOwned>, extensions: Extensions) -> Self {
-		Self { inner: MethodResponseKind::Batch(json), extensions }
-	}
-
-	/// Get the method call if this response is a method call.
-	pub fn into_method_call(self) -> Option<RawResponseOwned> {
-		match self.inner {
-			MethodResponseKind::MethodCall(call) => Some(call),
-			_ => None,
-		}
-	}
-
-	/// Get the batch if this response is a batch.
-	pub fn into_batch(self) -> Option<Vec<RawResponseOwned>> {
-		match self.inner {
-			MethodResponseKind::Batch(batch) => Some(batch),
-			_ => None,
-		}
-	}
-
-	/// Get the subscription if this response is a subscription.
-	fn into_subscription(self) -> Option<(SubscriptionId<'static>, SubscriptionReceiver)> {
-		match self.inner {
-			MethodResponseKind::Subscription(s) => Some((s.sub_id, s.stream)),
-			_ => None,
-		}
-	}
-
-	/// Returns whether this response is a method call.
-	pub fn is_method_call(&self) -> bool {
-		matches!(self.inner, MethodResponseKind::MethodCall(_))
-	}
-
-	/// Returns whether this response is a notification.
-	pub fn is_notification(&self) -> bool {
-		matches!(self.inner, MethodResponseKind::Notification)
-	}
-
-	/// Returns whether this response is a batch.
-	pub fn is_batch(&self) -> bool {
-		matches!(self.inner, MethodResponseKind::Batch(_))
-	}
-
-	/// Returns whether this response is a subscription.
-	pub fn is_subscription(&self) -> bool {
-		matches!(self.inner, MethodResponseKind::Subscription { .. })
-	}
-
-	/// Returns a reference to the associated extensions.
-	pub fn extensions(&self) -> &Extensions {
-		&self.extensions
-	}
-
-	/// Returns a mutable reference to the associated extensions.
-	pub fn extensions_mut(&mut self) -> &mut Extensions {
-		&mut self.extensions
-	}
-}
-
-impl std::ops::Deref for MethodResponse {
-	type Target = MethodResponseKind;
-
-	fn deref(&self) -> &Self::Target {
-		&self.inner
-	}
-}
-
-impl ToJson for MethodResponse {
-	fn to_json(&self) -> Result<Box<RawValue>, serde_json::Error> {
-		match &self.inner {
-			MethodResponseKind::MethodCall(call) => call.to_json(),
-			MethodResponseKind::Notification => Ok(RawValue::NULL.to_owned()),
-			MethodResponseKind::Batch(json) => serde_json::value::to_raw_value(json),
-			MethodResponseKind::Subscription(s) => serde_json::value::to_raw_value(&s.rp),
-		}
 	}
 }
 
@@ -862,5 +740,92 @@ impl<'a> RawResponse<'a> {
 impl ToJson for RawResponse<'_> {
 	fn to_json(&self) -> Result<Box<RawValue>, serde_json::Error> {
 		serde_json::value::to_raw_value(&self.0)
+	}
+}
+
+/// Middleware batch response.
+pub type MiddlewareBatchResponse = Vec<RawResponseOwned>;
+
+/// Middleware method response which can be either a method call or a subscription response.
+/// and treated differently.
+#[derive(Debug)]
+pub struct MiddlewareMethodResponse {
+	rp: RawResponseOwned,
+	subscription: Option<SubscriptionResponse>,
+}
+
+impl Serialize for MiddlewareMethodResponse {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		self.rp.serialize(serializer)
+	}
+}
+
+impl MiddlewareMethodResponse {
+	/// Create a new [`MiddlewareMethodResponse`] which is plain response.
+	pub fn response(rp: RawResponseOwned) -> Self {
+		Self { rp, subscription: None }
+	}
+
+	/// Create a new [`MiddlewareMethodResponse`] which is a subscription response.
+	pub fn subscription_response(rp: RawResponseOwned, subscription: SubscriptionResponse) -> Self {
+		Self { rp, subscription: Some(subscription) }
+	}
+
+	/// Convert the response into parts.
+	pub fn into_parts(self) -> (RawResponseOwned, Option<SubscriptionResponse>) {
+		(self.rp, self.subscription)
+	}
+
+	/// Extract the response.
+	pub fn into_response(self) -> RawResponseOwned {
+		self.rp
+	}
+
+	/// Extract the subscription response if it is a subscription.
+	pub fn into_subscription(self) -> Option<SubscriptionResponse> {
+		self.subscription
+	}
+}
+
+/// Middleware notification response.
+#[derive(Debug, Clone)]
+pub struct MiddlewareNotifResponse(Extensions);
+
+impl From<Extensions> for MiddlewareNotifResponse {
+	fn from(extensions: Extensions) -> Self {
+		Self(extensions)
+	}
+}
+
+impl MiddlewareNotifResponse {
+	/// Get the extensions.
+	pub fn extensions(&self) -> &Extensions {
+		&self.0
+	}
+
+	/// Get the extensions mutable.
+	pub fn extensions_mut(&mut self) -> &mut Extensions {
+		&mut self.0
+	}
+}
+
+impl Serialize for MiddlewareNotifResponse {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		Ok("null".serialize(serializer)?)
+	}
+}
+
+impl<T: Serialize> ToJson for Result<T, Error> {
+	fn to_json(&self) -> Result<Box<RawValue>, serde_json::Error> {
+		match self {
+			Ok(v) => serde_json::value::to_raw_value(v),
+			Err(e) => serde_json::value::to_raw_value(&e.to_string()),
+		}
 	}
 }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -42,11 +42,9 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::task::{self, Poll};
-use tokio::sync::mpsc::error::TrySendError;
 
-use crate::middleware::ToJson;
 use crate::params::BatchRequestBuilder;
-use crate::traits::ToRpcParams;
+use crate::traits::{ToJson, ToRpcParams};
 
 use core::marker::PhantomData;
 use futures_util::stream::{Stream, StreamExt};
@@ -55,6 +53,7 @@ use jsonrpsee_types::{ErrorObject, Id, InvalidRequestId, SubscriptionId};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::value::RawValue;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, oneshot};
 
 /// Shared state whether a subscription has lagged or not.

--- a/core/src/middleware/layer/either.rs
+++ b/core/src/middleware/layer/either.rs
@@ -62,29 +62,31 @@ where
 impl<A, B> RpcServiceT for Either<A, B>
 where
 	A: RpcServiceT + Send,
-	B: RpcServiceT<Error = A::Error, Response = A::Response> + Send,
+	B: RpcServiceT<
+			MethodResponse = A::MethodResponse,
+			NotificationResponse = A::NotificationResponse,
+			BatchResponse = A::BatchResponse,
+		> + Send,
 {
-	type Error = A::Error;
-	type Response = A::Response;
+	type BatchResponse = A::BatchResponse;
+	type MethodResponse = A::MethodResponse;
+	type NotificationResponse = A::NotificationResponse;
 
-	fn call<'a>(&self, request: Request<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn call<'a>(&self, request: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 		match self {
 			Either::Left(service) => futures_util::future::Either::Left(service.call(request)),
 			Either::Right(service) => futures_util::future::Either::Right(service.call(request)),
 		}
 	}
 
-	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 		match self {
 			Either::Left(service) => futures_util::future::Either::Left(service.batch(batch)),
 			Either::Right(service) => futures_util::future::Either::Right(service.batch(batch)),
 		}
 	}
 
-	fn notification<'a>(
-		&self,
-		n: Notification<'a>,
-	) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 		match self {
 			Either::Left(service) => futures_util::future::Either::Left(service.notification(n)),
 			Either::Right(service) => futures_util::future::Either::Right(service.notification(n)),

--- a/core/src/middleware/layer/logger.rs
+++ b/core/src/middleware/layer/logger.rs
@@ -62,6 +62,8 @@ pub struct RpcLogger<S> {
 impl<S> RpcServiceT for RpcLogger<S>
 where
 	S: RpcServiceT + Send + Sync + Clone + 'static,
+	S::MethodResponse: ToJson,
+	S::BatchResponse: ToJson,
 {
 	type MethodResponse = S::MethodResponse;
 	type NotificationResponse = S::NotificationResponse;

--- a/core/src/middleware/layer/logger.rs
+++ b/core/src/middleware/layer/logger.rs
@@ -26,7 +26,8 @@
 
 //! RPC Logger layer.
 
-use crate::middleware::{Batch, Notification, RpcServiceT, ToJson};
+use crate::middleware::{Batch, Notification, RpcServiceT};
+use crate::traits::ToJson;
 
 use futures_util::Future;
 use jsonrpsee_types::Request;

--- a/core/src/middleware/mod.rs
+++ b/core/src/middleware/mod.rs
@@ -321,12 +321,6 @@ pub trait RpcServiceT {
 	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a;
 }
 
-/// Interface for types that can be serialized into JSON.
-pub trait ToJson {
-	/// Convert the type into a JSON value.
-	fn to_json(&self) -> Result<Box<RawValue>, serde_json::Error>;
-}
-
 /// Similar to [`tower::ServiceBuilder`] but doesn't
 /// support any tower middleware implementations.
 #[derive(Debug, Clone)]

--- a/core/src/middleware/mod.rs
+++ b/core/src/middleware/mod.rs
@@ -297,11 +297,11 @@ impl<'a> BatchEntry<'a> {
 /// explain that.
 pub trait RpcServiceT {
 	/// Response type for `RpcServiceT::call`.
-	type MethodResponse: ToJson;
+	type MethodResponse;
 	/// Response type for `RpcServiceT::notification`.
-	type NotificationResponse: ToJson;
+	type NotificationResponse;
 	/// Response type for `RpcServiceT::batch`.
-	type BatchResponse: ToJson;
+	type BatchResponse;
 
 	/// Processes a single JSON-RPC call, which may be a subscription or regular call.
 	fn call<'a>(&self, request: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a;

--- a/core/src/server/method_response.rs
+++ b/core/src/server/method_response.rs
@@ -31,6 +31,8 @@ const LOG_TARGET: &str = "jsonrpsee-core";
 use std::io;
 use std::task::Poll;
 
+use crate::traits::ToJson;
+
 use futures_util::{Future, FutureExt};
 use http::Extensions;
 use jsonrpsee_types::error::{
@@ -39,8 +41,6 @@ use jsonrpsee_types::error::{
 use jsonrpsee_types::{ErrorObjectOwned, Id, Response, ResponsePayload as InnerResponsePayload};
 use serde::Serialize;
 use serde_json::value::{RawValue, to_raw_value};
-
-use crate::middleware::ToJson;
 
 #[derive(Debug, Clone)]
 enum ResponseKind {

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -150,3 +150,9 @@ impl<T: IdProvider + ?Sized> IdProvider for Box<T> {
 		(**self).next_id()
 	}
 }
+
+/// Interface for types that can be serialized into JSON.
+pub trait ToJson {
+	/// Convert the type into a JSON value.
+	fn to_json(&self) -> Result<Box<RawValue>, serde_json::Error>;
+}

--- a/examples/examples/jsonrpsee_as_service.rs
+++ b/examples/examples/jsonrpsee_as_service.rs
@@ -73,14 +73,7 @@ struct Identity<S>(S);
 
 impl<S> RpcServiceT for Identity<S>
 where
-	S: RpcServiceT<
-			MethodResponse = MethodResponse,
-			NotificationResponse = MethodResponse,
-			BatchResponse = MethodResponse,
-		> + Send
-		+ Sync
-		+ Clone
-		+ 'static,
+	S: RpcServiceT + Send + Sync + Clone + 'static,
 {
 	type MethodResponse = S::MethodResponse;
 	type BatchResponse = S::BatchResponse;
@@ -149,14 +142,9 @@ impl<S> AuthorizationMiddleware<S> {
 
 impl<S> RpcServiceT for AuthorizationMiddleware<S>
 where
-	S: RpcServiceT<
-			MethodResponse = MethodResponse,
-			NotificationResponse = MethodResponse,
-			BatchResponse = MethodResponse,
-		> + Send
-		+ Sync
-		+ Clone
-		+ 'static,
+	// We need to specify the concrete types here because otherwise we return an error or specific response
+	// in the middleware implementation.
+	S: RpcServiceT<MethodResponse = MethodResponse, BatchResponse = MethodResponse> + Send + Sync + Clone + 'static,
 {
 	type MethodResponse = S::MethodResponse;
 	type BatchResponse = S::BatchResponse;
@@ -211,7 +199,7 @@ where
 		self.inner.batch(Batch::from(entries))
 	}
 
-	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 		self.inner.notification(n)
 	}
 }

--- a/examples/examples/rpc_middleware.rs
+++ b/examples/examples/rpc_middleware.rs
@@ -74,21 +74,19 @@ impl<S> RpcServiceT for Identity<S>
 where
 	S: RpcServiceT + Send + Sync + Clone + 'static,
 {
-	type Response = S::Response;
-	type Error = S::Error;
+	type MethodResponse = S::MethodResponse;
+	type NotificationResponse = S::NotificationResponse;
+	type BatchResponse = S::BatchResponse;
 
-	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 		self.0.batch(batch)
 	}
 
-	fn call<'a>(&self, request: Request<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn call<'a>(&self, request: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 		self.0.call(request)
 	}
 
-	fn notification<'a>(
-		&self,
-		n: Notification<'a>,
-	) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 		self.0.notification(n)
 	}
 }
@@ -106,10 +104,11 @@ impl<S> RpcServiceT for CallsPerConn<S>
 where
 	S: RpcServiceT + Send + Sync + Clone + 'static,
 {
-	type Error = S::Error;
-	type Response = S::Response;
+	type MethodResponse = S::MethodResponse;
+	type NotificationResponse = S::NotificationResponse;
+	type BatchResponse = S::BatchResponse;
 
-	fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 		let count = self.count.clone();
 		let service = self.service.clone();
 		let role = self.role;
@@ -122,17 +121,14 @@ where
 		}
 	}
 
-	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 		let len = batch.len();
 		self.count.fetch_add(len, Ordering::SeqCst);
 		println!("{} processed calls={} on the connection", self.role, self.count.load(Ordering::SeqCst));
 		self.service.batch(batch)
 	}
 
-	fn notification<'a>(
-		&self,
-		n: Notification<'a>,
-	) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 		self.service.notification(n)
 	}
 }
@@ -148,10 +144,11 @@ impl<S> RpcServiceT for GlobalCalls<S>
 where
 	S: RpcServiceT + Send + Sync + Clone + 'static,
 {
-	type Error = S::Error;
-	type Response = S::Response;
+	type MethodResponse = S::MethodResponse;
+	type NotificationResponse = S::NotificationResponse;
+	type BatchResponse = S::BatchResponse;
 
-	fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 		let count = self.count.clone();
 		let service = self.service.clone();
 		let role = self.role;
@@ -165,17 +162,14 @@ where
 		}
 	}
 
-	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 		let len = batch.len();
 		self.count.fetch_add(len, Ordering::SeqCst);
 		println!("{}, processed calls={} in total", self.role, self.count.load(Ordering::SeqCst));
 		self.service.batch(batch)
 	}
 
-	fn notification<'a>(
-		&self,
-		n: Notification<'a>,
-	) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 		self.service.notification(n)
 	}
 }
@@ -188,24 +182,22 @@ pub struct Logger<S> {
 
 impl<S> RpcServiceT for Logger<S>
 where
-	S: RpcServiceT + Send + Sync,
+	S: RpcServiceT + Send + Sync + Clone + 'static,
 {
-	type Error = S::Error;
-	type Response = S::Response;
+	type MethodResponse = S::MethodResponse;
+	type NotificationResponse = S::NotificationResponse;
+	type BatchResponse = S::BatchResponse;
 
-	fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 		println!("{} logger middleware: method `{}`", self.role, req.method);
 		self.service.call(req)
 	}
 
-	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 		println!("{} logger middleware: batch {batch}", self.role);
 		self.service.batch(batch)
 	}
-	fn notification<'a>(
-		&self,
-		n: Notification<'a>,
-	) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 		self.service.notification(n)
 	}
 }
@@ -245,11 +237,7 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 	let global_cnt = Arc::new(AtomicUsize::new(0));
 
 	let rpc_middleware = RpcServiceBuilder::new()
-		.layer_fn(|service| Logger { service, role: "server" })
-		// This state is created per connection.
-		.layer_fn(|service| CallsPerConn { service, count: Default::default(), role: "server" })
-		// This state is shared by all connections.
-		.layer_fn(move |service| GlobalCalls { service, count: global_cnt.clone(), role: "server" })
+		.rpc_logger(1024)
 		// Optional layer that does not do anything, useful if have an optional layer.
 		.option_layer(Some(IdentityLayer));
 	let server = Server::builder().set_rpc_middleware(rpc_middleware).build("127.0.0.1:0").await?;

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -160,19 +160,19 @@ pub async fn server() -> SocketAddr {
 		fn call<'a>(
 			&self,
 			mut request: jsonrpsee::types::Request<'a>,
-		) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+		) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 			request.extensions_mut().insert(self.connection_id);
 			self.inner.call(request)
 		}
 
-		fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+		fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 			self.inner.batch(batch)
 		}
 
 		fn notification<'a>(
 			&self,
 			notif: Notification<'a>,
-		) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+		) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 			self.inner.notification(notif)
 		}
 	}

--- a/proc-macros/tests/ui/correct/basic.rs
+++ b/proc-macros/tests/ui/correct/basic.rs
@@ -154,8 +154,9 @@ pub async fn server() -> SocketAddr {
 	where
 		S: RpcServiceT,
 	{
-		type Error = S::Error;
-		type Response = S::Response;
+		type MethodResponse = S::MethodResponse;
+		type BatchResponse = S::BatchResponse;
+		type NotificationResponse = S::NotificationResponse;
 
 		fn call<'a>(
 			&self,
@@ -165,14 +166,14 @@ pub async fn server() -> SocketAddr {
 			self.inner.call(request)
 		}
 
-		fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+		fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 			self.inner.batch(batch)
 		}
 
 		fn notification<'a>(
 			&self,
 			notif: Notification<'a>,
-		) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+		) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 			self.inner.notification(notif)
 		}
 	}

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -674,8 +674,9 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 	/// impl<S> RpcServiceT for MyMiddleware<S>
 	/// where S: RpcServiceT + Send + Sync + Clone + 'static,
 	/// {
-	///    type Error = S::Error;
-	///    type Response = S::Response;
+	///    type MethodResponse = S::MethodResponse;
+	///    type BatchResponse = S::BatchResponse;
+	///    type NotificationResponse = S::NotificationResponse;
 	///
 	///    fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 	///         tracing::info!("MyMiddleware processed call {}", req.method);
@@ -690,11 +691,11 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 	///         }
 	///    }
 	///
-	///    fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+	///    fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 	///          self.service.batch(batch)
 	///    }
 	///
-	///    fn notification<'a>(&self, notif: Notification<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+	///    fn notification<'a>(&self, notif: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 	///          self.service.notification(notif)
 	///    }
 	///

--- a/server/src/tests/http.rs
+++ b/server/src/tests/http.rs
@@ -61,10 +61,11 @@ impl<S> RpcServiceT for InjectExt<S>
 where
 	S: Send + Sync + RpcServiceT + Clone + 'static,
 {
-	type Error = S::Error;
-	type Response = S::Response;
+	type BatchResponse = S::BatchResponse;
+	type MethodResponse = S::MethodResponse;
+	type NotificationResponse = S::NotificationResponse;
 
-	fn call<'a>(&self, mut req: Request<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn call<'a>(&self, mut req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 		if req.method_name().contains("err") {
 			req.extensions_mut().insert(StatusCode::IM_A_TEAPOT);
 		} else {
@@ -74,7 +75,7 @@ where
 		self.service.call(req)
 	}
 
-	fn batch<'a>(&self, mut batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn batch<'a>(&self, mut batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 		if let Some(Ok(last)) = batch.iter_mut().last() {
 			if last.method_name().contains("err") {
 				last.extensions_mut().insert(StatusCode::IM_A_TEAPOT);
@@ -86,10 +87,7 @@ where
 		self.service.batch(batch)
 	}
 
-	fn notification<'a>(
-		&self,
-		_: Notification<'a>,
-	) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+	fn notification<'a>(&self, _: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 		async { panic!("Not used for tests") }
 	}
 }

--- a/server/src/transport/http.rs
+++ b/server/src/transport/http.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use crate::{
 	BatchRequestConfig, ConnectionState, HttpRequest, HttpResponse, LOG_TARGET,
 	middleware::rpc::{RpcService, RpcServiceCfg},
@@ -46,7 +44,11 @@ where
 	B::Data: Send,
 	B::Error: Into<BoxError>,
 	L: tower::Layer<RpcService>,
-	<L as tower::Layer<RpcService>>::Service: RpcServiceT<Response = MethodResponse, Error = Infallible> + Send,
+	<L as tower::Layer<RpcService>>::Service: RpcServiceT<
+			MethodResponse = MethodResponse,
+			BatchResponse = MethodResponse,
+			NotificationResponse = MethodResponse,
+		> + Send,
 {
 	let ServerConfig { max_response_body_size, batch_requests_config, max_request_body_size, .. } = server_cfg;
 
@@ -77,7 +79,11 @@ where
 	B: http_body::Body<Data = Bytes> + Send + 'static,
 	B::Data: Send,
 	B::Error: Into<BoxError>,
-	S: RpcServiceT<Response = MethodResponse, Error = Infallible> + Send,
+	S: RpcServiceT<
+			MethodResponse = MethodResponse,
+			BatchResponse = MethodResponse,
+			NotificationResponse = MethodResponse,
+		> + Send,
 {
 	// Only the `POST` method is allowed.
 	match *request.method() {

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -400,7 +400,7 @@ async fn graceful_shutdown<S>(
 /// ) -> HttpResponse
 /// where
 ///     L: tower::Layer<RpcService> + 'static,
-///     <L as tower::Layer<RpcService>>::Service: RpcServiceT<Response = MethodResponse, Error = Infallible> + Send + Sync + 'static,
+///     <L as tower::Layer<RpcService>>::Service: RpcServiceT<MethodResponse = MethodResponse, BatchResponse = MethodResponse, NotificationResponse = MethodResponse> + Send + Sync + 'static,
 /// {
 ///   match ws::connect(req, server_cfg, methods, conn, rpc_middleware).await {
 ///     Ok((rp, conn_fut)) => {

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -1,4 +1,3 @@
-use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -64,7 +63,13 @@ pub(crate) struct BackgroundTaskParams<S> {
 
 pub(crate) async fn background_task<S>(params: BackgroundTaskParams<S>)
 where
-	S: RpcServiceT<Response = MethodResponse, Error = Infallible> + Send + Sync + 'static,
+	S: RpcServiceT<
+			MethodResponse = MethodResponse,
+			BatchResponse = MethodResponse,
+			NotificationResponse = MethodResponse,
+		> + Send
+		+ Sync
+		+ 'static,
 {
 	let BackgroundTaskParams {
 		server_cfg,
@@ -422,8 +427,13 @@ pub async fn connect<L, B>(
 ) -> Result<(HttpResponse, impl Future<Output = ()>), HttpResponse>
 where
 	L: tower::Layer<RpcService>,
-	<L as tower::Layer<RpcService>>::Service:
-		RpcServiceT<Response = MethodResponse, Error = Infallible> + Send + Sync + 'static,
+	<L as tower::Layer<RpcService>>::Service: RpcServiceT<
+			MethodResponse = MethodResponse,
+			BatchResponse = MethodResponse,
+			NotificationResponse = MethodResponse,
+		> + Send
+		+ Sync
+		+ 'static,
 {
 	let mut server = soketto::handshake::http::Server::new();
 

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -153,25 +153,26 @@ pub async fn server() -> SocketAddr {
 	where
 		S: RpcServiceT,
 	{
-		type Error = S::Error;
-		type Response = S::Response;
+		type MethodResponse = S::MethodResponse;
+		type NotificationResponse = S::NotificationResponse;
+		type BatchResponse = S::BatchResponse;
 
 		fn call<'a>(
 			&self,
 			mut request: jsonrpsee::types::Request<'a>,
-		) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+		) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 			request.extensions_mut().insert(self.connection_id);
 			self.inner.call(request)
 		}
 
-		fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+		fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 			self.inner.batch(batch)
 		}
 
 		fn notification<'a>(
 			&self,
 			_: Notification<'a>,
-		) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + 'a {
+		) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 			async { panic!("Not used for tests") }
 		}
 	}


### PR DESCRIPTION
This PR modifies to RpcServiceT to:

```rust
pub trait RpcServiceT {
	/// Response type for `RpcServiceT::call`.
	type MethodResponse: ToJson;
	/// Response type for `RpcServiceT::notification`.
	type NotificationResponse: ToJson;
	/// Response type for `RpcServiceT::batch`.
	type BatchResponse: ToJson;

	/// Processes a single JSON-RPC call, which may be a subscription or regular call.
	fn call<'a>(&self, request: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a;

	/// Processes multiple JSON-RPC calls at once, similar to `RpcServiceT::call`.
	///
	/// This method wraps `RpcServiceT::call` and `RpcServiceT::notification`,
	/// but the root RPC service does not inherently recognize custom implementations
	/// of these methods.
	///
	/// As a result, if you have custom logic for individual calls or notifications,
	/// you must duplicate that implementation in this method or no middleware will be applied
	/// for calls inside the batch.
	fn batch<'a>(&self, requests: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a;

	/// Similar to `RpcServiceT::call` but processes a JSON-RPC notification.
	fn notification<'a>(&self, n: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a;
}
```

This is an improvement because it's now possible to return different futures for the async operations but the downside is that it's harder to chain error because it's not an associated type anymore.

Thus, for instance in the client-side impls we are wrapping the responses in Result<T, E> where the concrete error type must be returned instead of E: Into<BoxError>`