### PR TITLE
fix: Remove username and password from URL after building Authorization header

### DIFF
--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -264,6 +264,8 @@ impl<L> HttpTransportClientBuilder<L> {
 				);
 			}
 		}
+		let _ = url.set_password(None);
+		let _ = url.set_username("");
 
 		Ok(HttpTransportClient {
 			target: url.as_str().to_owned(),


### PR DESCRIPTION
Keeping the username and password in the URL makes the whole HTTP client unusable because it just returns a 404.