### PR TITLE
feat(keepalive): expose tcp keep-alive options

### DIFF
--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -213,6 +213,24 @@ impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddlew
 		self
 	}
 
+	/// Set the keep-alive duration.
+	pub fn set_keep_alive(mut self, duration: Option<Duration>) -> Self {
+		self.keep_alive_duration = duration;
+		self
+	}
+
+	/// Set the keep-alive interval.
+	pub fn set_keep_alive_interval(mut self, interval: Option<Duration>) -> Self {
+		self.keep_alive_interval = interval;
+		self
+	}
+
+	/// Set the number of keep-alive retires.
+	pub fn set_keep_alive_retires(mut self, retires: Option<u32>) -> Self {
+		self.keep_alive_retires = retires;
+		self
+	}
+
 	/// Set the RPC middleware.
 	pub fn set_rpc_middleware<T>(self, rpc_builder: RpcServiceBuilder<T>) -> HttpClientBuilder<HttpMiddleware, T> {
 		HttpClientBuilder {

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -90,6 +90,9 @@ pub struct HttpClientBuilder<HttpMiddleware = Identity, RpcMiddleware = Logger> 
 	rpc_middleware: RpcServiceBuilder<RpcMiddleware>,
 	tcp_no_delay: bool,
 	max_concurrent_requests: Option<usize>,
+	keep_alive_duration: Option<Duration>,
+	keep_alive_interval: Option<Duration>,
+	keep_alive_retires: Option<u32>,
 }
 
 impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddleware> {
@@ -224,6 +227,9 @@ impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddlew
 			request_timeout: self.request_timeout,
 			tcp_no_delay: self.tcp_no_delay,
 			max_concurrent_requests: self.max_concurrent_requests,
+			keep_alive_duration: self.keep_alive_duration,
+			keep_alive_interval: self.keep_alive_interval,
+			keep_alive_retires: self.keep_alive_retires,
 		}
 	}
 
@@ -244,6 +250,9 @@ impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddlew
 			request_timeout: self.request_timeout,
 			tcp_no_delay: self.tcp_no_delay,
 			max_concurrent_requests: self.max_concurrent_requests,
+			keep_alive_duration: self.keep_alive_duration,
+			keep_alive_retires: self.keep_alive_retires,
+			keep_alive_interval: self.keep_alive_interval,
 		}
 	}
 }
@@ -271,6 +280,9 @@ where
 			service_builder,
 			tcp_no_delay,
 			rpc_middleware,
+			keep_alive_duration,
+			keep_alive_interval,
+			keep_alive_retires,
 			..
 		} = self;
 
@@ -280,6 +292,9 @@ where
 			headers,
 			tcp_no_delay,
 			service_builder,
+			keep_alive_duration,
+			keep_alive_interval,
+			keep_alive_retires,
 			#[cfg(feature = "tls")]
 			certificate_store,
 		}
@@ -313,6 +328,9 @@ impl Default for HttpClientBuilder {
 			rpc_middleware: RpcServiceBuilder::default().rpc_logger(1024),
 			tcp_no_delay: true,
 			max_concurrent_requests: None,
+			keep_alive_duration: None,
+			keep_alive_interval: None,
+			keep_alive_retires: None,
 		}
 	}
 }

--- a/client/http-client/src/client.rs
+++ b/client/http-client/src/client.rs
@@ -92,7 +92,7 @@ pub struct HttpClientBuilder<HttpMiddleware = Identity, RpcMiddleware = Logger> 
 	max_concurrent_requests: Option<usize>,
 	keep_alive_duration: Option<Duration>,
 	keep_alive_interval: Option<Duration>,
-	keep_alive_retires: Option<u32>,
+	keep_alive_retries: Option<u32>,
 }
 
 impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddleware> {
@@ -225,9 +225,9 @@ impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddlew
 		self
 	}
 
-	/// Set the number of keep-alive retires.
-	pub fn set_keep_alive_retires(mut self, retires: Option<u32>) -> Self {
-		self.keep_alive_retires = retires;
+	/// Set the number of keep-alive retries.
+	pub fn set_keep_alive_retries(mut self, retries: Option<u32>) -> Self {
+		self.keep_alive_retries = retries;
 		self
 	}
 
@@ -247,7 +247,7 @@ impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddlew
 			max_concurrent_requests: self.max_concurrent_requests,
 			keep_alive_duration: self.keep_alive_duration,
 			keep_alive_interval: self.keep_alive_interval,
-			keep_alive_retires: self.keep_alive_retires,
+			keep_alive_retries: self.keep_alive_retries,
 		}
 	}
 
@@ -269,7 +269,7 @@ impl<HttpMiddleware, RpcMiddleware> HttpClientBuilder<HttpMiddleware, RpcMiddlew
 			tcp_no_delay: self.tcp_no_delay,
 			max_concurrent_requests: self.max_concurrent_requests,
 			keep_alive_duration: self.keep_alive_duration,
-			keep_alive_retires: self.keep_alive_retires,
+			keep_alive_retries: self.keep_alive_retries,
 			keep_alive_interval: self.keep_alive_interval,
 		}
 	}
@@ -300,7 +300,7 @@ where
 			rpc_middleware,
 			keep_alive_duration,
 			keep_alive_interval,
-			keep_alive_retires,
+			keep_alive_retries,
 			..
 		} = self;
 
@@ -312,7 +312,7 @@ where
 			service_builder,
 			keep_alive_duration,
 			keep_alive_interval,
-			keep_alive_retires,
+			keep_alive_retries,
 			#[cfg(feature = "tls")]
 			certificate_store,
 		}
@@ -348,7 +348,7 @@ impl Default for HttpClientBuilder {
 			max_concurrent_requests: None,
 			keep_alive_duration: None,
 			keep_alive_interval: None,
-			keep_alive_retires: None,
+			keep_alive_retries: None,
 		}
 	}
 }

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -124,8 +124,8 @@ impl HttpTransportClientBuilder<Identity> {
 			service_builder: tower::ServiceBuilder::new(),
 			tcp_no_delay: true,
 			keep_alive_duration: None,
-            keep_alive_interval: None,
-            keep_alive_retires: None,
+			keep_alive_interval: None,
+			keep_alive_retires: None,
 		}
 	}
 }
@@ -172,6 +172,18 @@ impl<L> HttpTransportClientBuilder<L> {
 		self
 	}
 
+	/// Configure the keep-alive interval for the connection.
+	pub fn set_keep_alive_interval(mut self, interval: Option<std::time::Duration>) -> Self {
+		self.keep_alive_interval = interval;
+		self
+	}
+
+	/// Configure the number of keep-alive retries for the connection.
+	pub fn set_keep_alive_retries(mut self, retries: Option<u32>) -> Self {
+		self.keep_alive_retires = retries;
+		self
+	}
+
 	/// Configure a tower service.
 	pub fn set_service<T>(self, service: tower::ServiceBuilder<T>) -> HttpTransportClientBuilder<T> {
 		HttpTransportClientBuilder {
@@ -183,8 +195,8 @@ impl<L> HttpTransportClientBuilder<L> {
 			service_builder: service,
 			tcp_no_delay: self.tcp_no_delay,
 			keep_alive_duration: self.keep_alive_duration,
-            keep_alive_retires: self.keep_alive_retires,
-            keep_alive_interval: self.keep_alive_interval,
+			keep_alive_retires: self.keep_alive_retires,
+			keep_alive_interval: self.keep_alive_interval,
 		}
 	}
 
@@ -237,8 +249,8 @@ impl<L> HttpTransportClientBuilder<L> {
 				http_conn.set_nodelay(tcp_no_delay);
 				http_conn.enforce_http(false);
 				http_conn.set_keepalive(keep_alive_duration);
-                http_conn.set_keepalive_interval(keep_alive_interval);
-                http_conn.set_keepalive_retries(keep_alive_retires);
+				http_conn.set_keepalive_interval(keep_alive_interval);
+				http_conn.set_keepalive_retries(keep_alive_retires);
 
 				let https_conn = match certificate_store {
 					CertificateStore::Native => {

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -98,6 +98,12 @@ pub struct HttpTransportClientBuilder<L> {
 	pub(crate) service_builder: tower::ServiceBuilder<L>,
 	/// TCP_NODELAY
 	pub(crate) tcp_no_delay: bool,
+	/// KEEP_ALIVE duration
+	pub(crate) keep_alive_duration: Option<std::time::Duration>,
+	/// KEEP_ALIVE interval
+	pub(crate) keep_alive_interval: Option<std::time::Duration>,
+	/// KEEP_ALIVE retries
+	pub(crate) keep_alive_retires: Option<u32>,
 }
 
 impl Default for HttpTransportClientBuilder<Identity> {
@@ -117,6 +123,9 @@ impl HttpTransportClientBuilder<Identity> {
 			headers: HeaderMap::new(),
 			service_builder: tower::ServiceBuilder::new(),
 			tcp_no_delay: true,
+			keep_alive_duration: None,
+            keep_alive_interval: None,
+            keep_alive_retires: None,
 		}
 	}
 }
@@ -157,6 +166,12 @@ impl<L> HttpTransportClientBuilder<L> {
 		self
 	}
 
+	/// Configure the keep-alive duration for the connection.
+	pub fn set_keep_alive(mut self, duration: Option<std::time::Duration>) -> Self {
+		self.keep_alive_duration = duration;
+		self
+	}
+
 	/// Configure a tower service.
 	pub fn set_service<T>(self, service: tower::ServiceBuilder<T>) -> HttpTransportClientBuilder<T> {
 		HttpTransportClientBuilder {
@@ -167,6 +182,9 @@ impl<L> HttpTransportClientBuilder<L> {
 			max_response_size: self.max_response_size,
 			service_builder: service,
 			tcp_no_delay: self.tcp_no_delay,
+			keep_alive_duration: self.keep_alive_duration,
+            keep_alive_retires: self.keep_alive_retires,
+            keep_alive_interval: self.keep_alive_interval,
 		}
 	}
 
@@ -187,6 +205,9 @@ impl<L> HttpTransportClientBuilder<L> {
 			headers,
 			service_builder,
 			tcp_no_delay,
+			keep_alive_duration,
+			keep_alive_interval,
+			keep_alive_retires,
 		} = self;
 		let mut url = Url::parse(target.as_ref()).map_err(|e| Error::Url(format!("Invalid URL: {e}")))?;
 
@@ -199,6 +220,9 @@ impl<L> HttpTransportClientBuilder<L> {
 			"http" => {
 				let mut connector = HttpConnector::new();
 				connector.set_nodelay(tcp_no_delay);
+				connector.set_keepalive(keep_alive_duration);
+				connector.set_keepalive_interval(keep_alive_interval);
+				connector.set_keepalive_retries(keep_alive_retires);
 				HttpBackend::Http(Client::builder(TokioExecutor::new()).build(connector))
 			}
 			#[cfg(feature = "tls")]
@@ -212,6 +236,9 @@ impl<L> HttpTransportClientBuilder<L> {
 				let mut http_conn = HttpConnector::new();
 				http_conn.set_nodelay(tcp_no_delay);
 				http_conn.enforce_http(false);
+				http_conn.set_keepalive(keep_alive_duration);
+                http_conn.set_keepalive_interval(keep_alive_interval);
+                http_conn.set_keepalive_retries(keep_alive_retires);
 
 				let https_conn = match certificate_store {
 					CertificateStore::Native => {

--- a/client/http-client/src/transport.rs
+++ b/client/http-client/src/transport.rs
@@ -103,7 +103,7 @@ pub struct HttpTransportClientBuilder<L> {
 	/// KEEP_ALIVE interval
 	pub(crate) keep_alive_interval: Option<std::time::Duration>,
 	/// KEEP_ALIVE retries
-	pub(crate) keep_alive_retires: Option<u32>,
+	pub(crate) keep_alive_retries: Option<u32>,
 }
 
 impl Default for HttpTransportClientBuilder<Identity> {
@@ -125,7 +125,7 @@ impl HttpTransportClientBuilder<Identity> {
 			tcp_no_delay: true,
 			keep_alive_duration: None,
 			keep_alive_interval: None,
-			keep_alive_retires: None,
+			keep_alive_retries: None,
 		}
 	}
 }
@@ -180,7 +180,7 @@ impl<L> HttpTransportClientBuilder<L> {
 
 	/// Configure the number of keep-alive retries for the connection.
 	pub fn set_keep_alive_retries(mut self, retries: Option<u32>) -> Self {
-		self.keep_alive_retires = retries;
+		self.keep_alive_retries = retries;
 		self
 	}
 
@@ -195,7 +195,7 @@ impl<L> HttpTransportClientBuilder<L> {
 			service_builder: service,
 			tcp_no_delay: self.tcp_no_delay,
 			keep_alive_duration: self.keep_alive_duration,
-			keep_alive_retires: self.keep_alive_retires,
+			keep_alive_retries: self.keep_alive_retries,
 			keep_alive_interval: self.keep_alive_interval,
 		}
 	}
@@ -219,7 +219,7 @@ impl<L> HttpTransportClientBuilder<L> {
 			tcp_no_delay,
 			keep_alive_duration,
 			keep_alive_interval,
-			keep_alive_retires,
+			keep_alive_retries,
 		} = self;
 		let mut url = Url::parse(target.as_ref()).map_err(|e| Error::Url(format!("Invalid URL: {e}")))?;
 
@@ -234,7 +234,7 @@ impl<L> HttpTransportClientBuilder<L> {
 				connector.set_nodelay(tcp_no_delay);
 				connector.set_keepalive(keep_alive_duration);
 				connector.set_keepalive_interval(keep_alive_interval);
-				connector.set_keepalive_retries(keep_alive_retires);
+				connector.set_keepalive_retries(keep_alive_retries);
 				HttpBackend::Http(Client::builder(TokioExecutor::new()).build(connector))
 			}
 			#[cfg(feature = "tls")]
@@ -250,7 +250,7 @@ impl<L> HttpTransportClientBuilder<L> {
 				http_conn.enforce_http(false);
 				http_conn.set_keepalive(keep_alive_duration);
 				http_conn.set_keepalive_interval(keep_alive_interval);
-				http_conn.set_keepalive_retries(keep_alive_retires);
+				http_conn.set_keepalive_retries(keep_alive_retries);
 
 				let https_conn = match certificate_store {
 					CertificateStore::Native => {

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 	let server_addr = run_server().await?;
 	let url = format!("http://{}", server_addr);
 
-	let client = HttpClient::builder().set_tcp_no_delay().build(url)?;
+	let client = HttpClient::builder().build(url)?;
 	let params = rpc_params![1_u64, 2, 3];
 	let response: Result<String, _> = client.request("say_hello", params).await;
 	tracing::info!("r: {:?}", response);

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 	let server_addr = run_server().await?;
 	let url = format!("http://{}", server_addr);
 
-	let client = HttpClient::builder().build(url)?;
+	let client = HttpClient::builder().set_tcp_no_delay().build(url)?;
 	let params = rpc_params![1_u64, 2, 3];
 	let response: Result<String, _> = client.request("say_hello", params).await;
 	tracing::info!("r: {:?}", response);

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1196,7 +1196,6 @@ where
 	}
 
 	let keep_alive = server_cfg.keep_alive;
-	let is_keep_alive = keep_alive.is_some();
 	let keep_alive_timeout = server_cfg.keep_alive_timeout;
 
 	let tower_service = TowerServiceNoHttp {
@@ -1219,8 +1218,9 @@ where
 		let io = TokioIo::new(socket);
 		let mut builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
 
-		builder.http1().keep_alive(is_keep_alive);
-		builder.http2().keep_alive_interval(keep_alive).keep_alive_timeout(keep_alive_timeout);
+		if builder.is_http2_available() {
+			builder.http2().keep_alive_interval(keep_alive).keep_alive_timeout(keep_alive_timeout);
+		}
 
 		let conn = builder.serve_connection_with_upgrades(io, service);
 		let stopped = stop_handle.shutdown();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -532,6 +532,7 @@ impl ServerConfigBuilder {
 	}
 
 	/// Configure `KEEP_ALIVE` hyper to the supplied value `keep_alive`.
+	#[cfg(feature = "http2")]
 	pub fn set_keep_alive(mut self, keep_alive: Option<std::time::Duration>) -> Self {
 		self.keep_alive = keep_alive;
 		self
@@ -1218,9 +1219,8 @@ where
 		let io = TokioIo::new(socket);
 		let mut builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
 
-		if builder.is_http2_available() {
-			builder.http2().keep_alive_interval(keep_alive).keep_alive_timeout(keep_alive_timeout);
-		}
+		//default is true for http1, if set to false then websocket connections will not be upgraded.
+		builder.http2().keep_alive_interval(keep_alive).keep_alive_timeout(keep_alive_timeout);
 
 		let conn = builder.serve_connection_with_upgrades(io, service);
 		let stopped = stop_handle.shutdown();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -532,7 +532,6 @@ impl ServerConfigBuilder {
 	}
 
 	/// Configure `KEEP_ALIVE` hyper to the supplied value `keep_alive`.
-	#[cfg(feature = "http2")]
 	pub fn set_keep_alive(mut self, keep_alive: Option<std::time::Duration>) -> Self {
 		self.keep_alive = keep_alive;
 		self


### PR DESCRIPTION
Exposes TCP keepalive options to the base client.

related to this [issue](https://github.com/paritytech/jsonrpsee/issues/1571).
opening a pr to expose the following options upstream from the internal http-connector.

- tcp_keepalive_interval
- tcp_keepalive_duration
- tcp_keepalive_retires