### PR TITLE
chore: make  `TowerServiceNoHttp` pub

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -48,7 +48,7 @@ pub use jsonrpsee_core::{id_providers::*, traits::IdProvider};
 pub use jsonrpsee_types as types;
 pub use server::{
 	BatchRequestConfig, Builder as ServerBuilder, ConnectionState, PingConfig, Server, ServerConfig,
-	ServerConfigBuilder, TowerService, TowerServiceBuilder,
+	ServerConfigBuilder, TowerService, TowerServiceBuilder, TowerServiceNoHttp,
 };
 pub use tracing;
 


### PR DESCRIPTION
This PR makes `TowerServiceNoHttp` pub. This is useful as `Server` directly bounds `HttpMiddleware` with respect to `TowerServiceNoHttp`, so constraining a generic tower `Layer` within the `Server` is not possible