### PR TITLE
Fix new Rust 1.89 lifetime warnings and impl ToRpcParams on serde_json::Map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ rustls = { version = "0.23", default-features = false }
 rustls-pki-types = "1"
 rustls-platform-verifier = "0.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"] }
+serde_json = { version = "1.0.142", default-features = false, features = ["alloc", "raw_value"] }
 soketto = "0.8.1"
 syn = { version = "2", default-features = false }
 thiserror = "2"

--- a/client/http-client/src/rpc_service.rs
+++ b/client/http-client/src/rpc_service.rs
@@ -14,12 +14,14 @@ use crate::{
 	transport::{Error as TransportError, HttpTransportClient},
 };
 
+/// An [`RpcServiceT`] compliant implementation for the HTTP client.
 #[derive(Clone, Debug)]
 pub struct RpcService<HttpMiddleware> {
 	service: Arc<HttpTransportClient<HttpMiddleware>>,
 }
 
 impl<HttpMiddleware> RpcService<HttpMiddleware> {
+	/// Convert an [`HttpTransportClient`] into an [`RpcService`].
 	pub fn new(service: HttpTransportClient<HttpMiddleware>) -> Self {
 		Self { service: Arc::new(service) }
 	}

--- a/core/src/client/async_client/manager.rs
+++ b/core/src/client/async_client/manager.rs
@@ -256,7 +256,7 @@ impl RequestManager {
 		&mut self,
 		request_id: RequestId,
 		subscription_id: SubscriptionId<'static>,
-	) -> Option<(RequestId, SubscriptionSink, UnsubscribeMethod, SubscriptionId)> {
+	) -> Option<(RequestId, SubscriptionSink, UnsubscribeMethod, SubscriptionId<'_>)> {
 		match (self.requests.entry(request_id), self.subscriptions.entry(subscription_id)) {
 			(Entry::Occupied(request), Entry::Occupied(subscription))
 				if matches!(request.get(), Kind::Subscription(_)) =>
@@ -282,7 +282,7 @@ impl RequestManager {
 		&mut self,
 		request_id: RequestId,
 		subscription_id: SubscriptionId<'static>,
-	) -> Option<(RequestId, SubscriptionSink, UnsubscribeMethod, SubscriptionId)> {
+	) -> Option<(RequestId, SubscriptionSink, UnsubscribeMethod, SubscriptionId<'_>)> {
 		match (self.requests.entry(request_id), self.subscriptions.entry(subscription_id)) {
 			(Entry::Occupied(mut request), Entry::Occupied(subscription))
 				if matches!(request.get(), Kind::Subscription(_)) =>

--- a/core/src/client/async_client/mod.rs
+++ b/core/src/client/async_client/mod.rs
@@ -149,7 +149,7 @@ impl ThreadSafeRequestManager {
 		Self::default()
 	}
 
-	pub(crate) fn lock(&self) -> std::sync::MutexGuard<RequestManager> {
+	pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, RequestManager> {
 		self.0.lock().expect(NOT_POISONED)
 	}
 }

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -429,7 +429,7 @@ impl Subscription {
 	}
 
 	/// Get the subscription ID
-	pub fn subscription_id(&self) -> &SubscriptionId {
+	pub fn subscription_id(&self) -> &SubscriptionId<'static> {
 		&self.sub_id
 	}
 

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -91,6 +91,10 @@ macro_rules! to_rpc_params_impl {
 	};
 }
 
+impl ToRpcParams for serde_json::Map<String, serde_json::Value> {
+	to_rpc_params_impl!();
+}
+
 impl<P: Serialize> ToRpcParams for &[P] {
 	to_rpc_params_impl!();
 }

--- a/proc-macros/src/attributes.rs
+++ b/proc-macros/src/attributes.rs
@@ -136,7 +136,7 @@ impl AttributeMeta {
 	/// Attempt to get a list of `Argument`s from a list of names in order.
 	///
 	/// Errors if there is an argument with a name that's not on the list, or if there is a duplicate definition.
-	pub fn retain<const N: usize>(self, allowed: [&str; N]) -> syn::Result<[Result<Argument, MissingArgument>; N]> {
+	pub fn retain<const N: usize>(self, allowed: [&str; N]) -> syn::Result<[Result<Argument, MissingArgument<'_>>; N]> {
 		assert!(
 			N != 0,
 			"Calling `AttributeMeta::retain` with an empty `allowed` list, this is a bug, please report it"

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -696,13 +696,13 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 	///
 	/// impl<S> RpcServiceT for MyMiddleware<S>
 	/// where
-	/// 	S: RpcServiceT + Clone + Send + Sync + 'static,
+	///     S: RpcServiceT + Clone + Send + Sync + 'static,
 	/// {
-	///    type MethodResponse = S::MethodResponse;
-	///    type NotificationResponse = S::NotificationResponse;
-	///    type BatchResponse = S::BatchResponse;
+	///     type MethodResponse = S::MethodResponse;
+	///     type NotificationResponse = S::NotificationResponse;
+	///     type BatchResponse = S::BatchResponse;
 	///
-	///    fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+	///     fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
 	///         tracing::info!("MyMiddleware processed call {}", req.method);
 	///         let count = self.count.clone();
 	///         let service = self.service.clone();
@@ -713,15 +713,15 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 	///             count.fetch_add(1, Ordering::Relaxed);
 	///             rp
 	///         }
-	///    }
+	///     }
 	///
-	///    fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+	///     fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
 	///          self.service.batch(batch)
-	///    }
+	///     }
 	///
-	///    fn notification<'a>(&self, notif: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+	///     fn notification<'a>(&self, notif: Notification<'a>) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
 	///          self.service.notification(notif)
-	///    }
+	///     }
 	/// }
 	///
 	/// // Create a state per connection

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -107,7 +107,7 @@ impl<'a> Params<'a> {
 	///
 	/// This allows sequential parsing of the incoming params, using an `Iterator`-style API and is useful when the RPC
 	/// request has optional parameters at the tail that may or may not be present.
-	pub fn sequence(&self) -> ParamsSequence {
+	pub fn sequence(&self) -> ParamsSequence<'_> {
 		let json = match self.0.as_ref() {
 			// It's assumed that params is `[a,b,c]`, if empty regard as no params.
 			Some(json) if json == "[]" => "",

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -91,7 +91,7 @@ impl<'a> Request<'a> {
 	}
 
 	/// Get the params of the request.
-	pub fn params(&self) -> Params {
+	pub fn params(&self) -> Params<'_> {
 		Params::new(self.params.as_ref().map(|p| RawValue::get(p)))
 	}
 


### PR DESCRIPTION
Also bump serde_json to a version which actually has a required `RawValue::NULL` constant added.