### PR TITLE
Prepare to release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is just a small release; the only breaking change is the addition of `max_f
 
 The other changes are as follows:
 
-## Changed
+### [Changed]
 
 - Fix new Rust 1.89 lifetime warnings and impl ToRpcParams on serde_json::Map ([#1594](https://github.com/paritytech/jsonrpsee/pull/1594))
 - feat(keepalive): expose tcp keep-alive options ([#1583](https://github.com/paritytech/jsonrpsee/pull/1583))
@@ -20,7 +20,7 @@ The other changes are as follows:
 - chore(deps): update pprof requirement from 0.14 to 0.15 ([#1577](https://github.com/paritytech/jsonrpsee/pull/1577))
 - Expose `jsonrpsee_http_client::RpcService` ([#1574](https://github.com/paritytech/jsonrpsee/pull/1574))
 
-## Fixed
+### [Fixed]
 
 - fix: Remove username and password from URL after building Authorization header ([#1581](https://github.com/paritytech/jsonrpsee/pull/1581))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.26.0] - 2025-08-11
+
+This is just a small release; the only breaking change is the addition of `max_frame_size` to `WsTransportClientBuilder`, which necessitates a minor version bump.
+
+The other changes are as follows:
+
+## Changed
+
+- Fix new Rust 1.89 lifetime warnings and impl ToRpcParams on serde_json::Map ([#1594](https://github.com/paritytech/jsonrpsee/pull/1594))
+- feat(keepalive): expose tcp keep-alive options ([#1583](https://github.com/paritytech/jsonrpsee/pull/1583))
+- chore: expose `TowerServiceNoHttp` type ([#1588](https://github.com/paritytech/jsonrpsee/pull/1588))
+- chore(deps): update socket2 requirement from 0.5.1 to 0.6.0 ([#1587](https://github.com/paritytech/jsonrpsee/pull/1587))
+- Allow max websocket frame size to be set ([#1585](https://github.com/paritytech/jsonrpsee/pull/1585))
+- chore(deps): update pprof requirement from 0.14 to 0.15 ([#1577](https://github.com/paritytech/jsonrpsee/pull/1577))
+- Expose `jsonrpsee_http_client::RpcService` ([#1574](https://github.com/paritytech/jsonrpsee/pull/1574))
+
+## Fixed
+
+- fix: Remove username and password from URL after building Authorization header ([#1581](https://github.com/paritytech/jsonrpsee/pull/1581))
+
 ## [v0.25.1] - 2025-04-24
 
 A small follow-up patch release that adds a `Clone impl` for the middleware RpcLogger which was missing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "3"
 
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
-version = "0.25.1"
+version = "0.26.0"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
@@ -32,14 +32,14 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal jsonrpsee crates
-jsonrpsee-client-transport = { path = "client/transport", version = "0.25.1" }
-jsonrpsee-core = { path = "core", version = "0.25.1" }
-jsonrpsee-http-client = { path = "client/http-client", version = "0.25.1" }
-jsonrpsee-proc-macros = { path = "proc-macros", version = "0.25.1" }
-jsonrpsee-server = { path = "server", version = "0.25.1" }
-jsonrpsee-types = { path = "types", version = "0.25.1" }
-jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.25.1" }
-jsonrpsee-ws-client = { path = "client/ws-client", version = "0.25.1" }
+jsonrpsee-client-transport = { path = "client/transport", version = "0.26.0" }
+jsonrpsee-core = { path = "core", version = "0.26.0" }
+jsonrpsee-http-client = { path = "client/http-client", version = "0.26.0" }
+jsonrpsee-proc-macros = { path = "proc-macros", version = "0.26.0" }
+jsonrpsee-server = { path = "server", version = "0.26.0" }
+jsonrpsee-types = { path = "types", version = "0.26.0" }
+jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.26.0" }
+jsonrpsee-ws-client = { path = "client/ws-client", version = "0.26.0" }
 
 # Deps used by the jsonrpsee crates.
 async-trait = "0.1"


### PR DESCRIPTION
This is just a small release; the only breaking change is the addition of `max_frame_size` to `WsTransportClientBuilder`, which necessitates a minor version bump.

The other changes are as follows:

### [Changed]

- Fix new Rust 1.89 lifetime warnings and impl ToRpcParams on serde_json::Map ([#1594](https://github.com/paritytech/jsonrpsee/pull/1594))
- feat(keepalive): expose tcp keep-alive options ([#1583](https://github.com/paritytech/jsonrpsee/pull/1583))
- chore: expose `TowerServiceNoHttp` type ([#1588](https://github.com/paritytech/jsonrpsee/pull/1588))
- chore(deps): update socket2 requirement from 0.5.1 to 0.6.0 ([#1587](https://github.com/paritytech/jsonrpsee/pull/1587))
- Allow max websocket frame size to be set ([#1585](https://github.com/paritytech/jsonrpsee/pull/1585))
- chore(deps): update pprof requirement from 0.14 to 0.15 ([#1577](https://github.com/paritytech/jsonrpsee/pull/1577))
- Expose `jsonrpsee_http_client::RpcService` ([#1574](https://github.com/paritytech/jsonrpsee/pull/1574))

### [Fixed]

- fix: Remove username and password from URL after building Authorization header ([#1581](https://github.com/paritytech/jsonrpsee/pull/1581))