### PR TITLE
WIP: Add support for generating `rpc.discover` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ tower-http = "0.6"
 tracing = "0.1.34"
 url = "2.4"
 wasm-bindgen-futures = "0.4.19"
+open-rpc = { git = "https://github.com/Velnbur/open-rpc", branch = "feature/utoipa-integration" }
 
 # Dev dependencies
 anyhow = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ futures = { workspace = true }
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-tls"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "time", "signal"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 serde_json = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "compression-full", "sensitive-headers", "trace", "timeout"] }
@@ -23,3 +23,4 @@ tower = { workspace = true, features = ["timeout"] }
 hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy"]}
 console-subscriber = { workspace = true }
+serde = { workspace = true }

--- a/examples/examples/rpc_discover.rs
+++ b/examples/examples/rpc_discover.rs
@@ -1,0 +1,74 @@
+use std::net::SocketAddr;
+
+use jsonrpsee::core::{RpcResult, async_trait};
+use jsonrpsee::open_rpc::utoipa;
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::server::ServerBuilder;
+
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+pub struct AddRequest {
+	pub a: u8,
+	pub b: u8,
+}
+
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize, Clone)]
+pub struct AddResponse {
+	pub sum: u16,
+}
+
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum Operation {
+	Add,
+	Mul,
+	Sub,
+}
+
+#[rpc(server, discover)]
+pub trait Rpc {
+	#[method(name = "foo")]
+	async fn async_method(&self, param_a: u8, param_b: String) -> RpcResult<u16>;
+
+	#[method(name = "add")]
+	async fn add(&self, request: AddRequest) -> RpcResult<AddResponse>;
+
+	#[method(name = "calculate")]
+	async fn calculate(&self, args: Vec<i64>, operation: Operation) -> RpcResult<i64>;
+}
+
+pub struct RpcServerImpl;
+
+#[async_trait]
+impl RpcServer for RpcServerImpl {
+	async fn async_method(&self, _param_a: u8, _param_b: String) -> RpcResult<u16> {
+		Ok(42u16)
+	}
+
+	async fn add(&self, request: AddRequest) -> RpcResult<AddResponse> {
+		Ok(AddResponse { sum: request.a as u16 + request.b as u16 })
+	}
+
+	async fn calculate(&self, args: Vec<i64>, operation: Operation) -> RpcResult<i64> {
+		match operation {
+			Operation::Add => Ok(args.iter().sum()),
+			Operation::Mul => Ok(args.iter().product()),
+			Operation::Sub => Ok(args.iter().skip(1).fold(args[0], |acc, x| acc - x)),
+		}
+	}
+}
+
+pub async fn server() -> SocketAddr {
+	let server = ServerBuilder::default().build("127.0.0.1:8080").await.unwrap();
+	let addr = server.local_addr().unwrap();
+	let server_handle = server.start(RpcServerImpl.into_rpc());
+
+	tokio::spawn(server_handle.stopped());
+
+	tokio::signal::ctrl_c().await.unwrap();
+	addr
+}
+
+#[tokio::main]
+async fn main() {
+	let _server_addr = server().await;
+}

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -27,6 +27,7 @@ jsonrpsee-server = { workspace = true, optional = true }
 jsonrpsee-proc-macros = { workspace = true, optional = true }
 jsonrpsee-core = { workspace = true, optional = true }
 jsonrpsee-types = { workspace = true, optional = true }
+open-rpc = { workspace = true, features = ["utoipa"] }
 tracing = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -101,3 +101,5 @@ cfg_client_or_server! {
 cfg_client! {
 	pub use jsonrpsee_core::rpc_params;
 }
+
+pub use open_rpc;


### PR DESCRIPTION
# Description

This PR implements optional generation of `rpc.discover` method which returns [OpenRPC](https://open-rpc.org) specification from trait definition. For that [`open-rpc`](https://docs.rs/open-rpc/latest/open_rpc/) crate was forked to fix compatibility issues with official [examples](https://github.com/open-rpc/examples) and to add some useful conversion functions (about that a little bit later).

This works by using [`utoipa::schema!`](https://docs.rs/utoipa/latest/utoipa/macro.schema.html) and [`utoipa::ToSchema`](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) crate macros, that generate [`utoipa::openapi::Schema`](https://docs.rs/utoipa/latest/utoipa/openapi/schema/enum.Schema.html) structure at runtime, which later converted to `open_rpc::Schema` and, with information from server trait definition, to `open_rpc::ContentDescriptor`.

With these information about each trait method, `open_rpc::OpenRpc` structure is constructed inside `rpc.discover` method at runtime. For now it's constructed on each `rpc.discover` call, but this can be improved by adding some lazy static variable.

# Functionality

For example, you can take a look at `examples/examples/rpc_discover.rs`, run it:

```shell
cd examples && cargo run --example rpc_discover
```

then send request to server:

```shell
curl -X POST -H "Content-Type: application/json" http://127.0.0.1:8080 -d '{"jsonrpc": "2.0","id":"id", "method": "rpc.discover"}' | jq .result
```

<details>
<summary>Response</summary>

```json
{
  "openrpc": "1.0.0-rc1",
  "info": {
    "title": "Rpc",
    "version": ""
  },
  "servers": [],
  "methods": [
    {
      "name": "foo",
      "description": "",
      "params": [
        {
          "name": "param_a",
          "required": true,
          "schema": {
            "type": "integer",
            "minimum": 0
          }
        },
        {
          "name": "param_b",
          "required": true,
          "schema": {
            "type": "string"
          }
        }
      ],
      "result": {
        "name": "return",
        "required": true,
        "schema": {
          "type": "integer",
          "minimum": 0
        }
      }
    },
    {
      "name": "add",
      "description": "",
      "params": [
        {
          "name": "request",
          "required": true,
          "schema": {
            "type": "object",
            "properties": {
              "a": {
                "type": "integer",
                "minimum": 0
              },
              "b": {
                "type": "integer",
                "minimum": 0
              }
            },
            "required": [
              "a",
              "b"
            ]
          }
        }
      ],
      "result": {
        "name": "return",
        "required": true,
        "schema": {
          "type": "object",
          "properties": {
            "sum": {
              "type": "integer",
              "minimum": 0
            }
          },
          "required": [
            "sum"
          ]
        }
      }
    },
    {
      "name": "calculate",
      "description": "",
      "params": [
        {
          "name": "args",
          "required": true,
          "schema": {
            "type": "array",
            "items": {
              "type": "integer"
            }
          }
        },
        {
          "name": "operation",
          "required": true,
          "schema": {
            "type": "string",
            "enum": [
              "add",
              "mul",
              "sub"
            ]
          }
        }
      ],
      "result": {
        "name": "return",
        "required": true,
        "schema": {
          "type": "integer"
        }
      }
    }
  ]
}
```

</details>

copy response, and introspect it, for example, using [OpenRPC Playground](https://playground.open-rpc.org).