### PR TITLE
Fix tracing enabled check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
-version = "0.24.9"
+version = "0.24.10"
 edition = "2021"
 rust-version = "1.74.0"
 license = "MIT"
@@ -31,14 +31,14 @@ keywords = ["jsonrpc", "json", "http", "websocket", "WASM"]
 readme = "README.md"
 
 [workspace.dependencies]
-jsonrpsee-types = { path = "types", version = "0.24.9" }
-jsonrpsee-core = { path = "core", version = "0.24.9" }
-jsonrpsee-server = { path = "server", version = "0.24.9" }
-jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.9" }
-jsonrpsee-http-client = { path = "client/http-client", version = "0.24.9" }
-jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.9" }
-jsonrpsee-client-transport = { path = "client/transport", version = "0.24.9" }
-jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.9" }
+jsonrpsee-types = { path = "types", version = "0.24.10" }
+jsonrpsee-core = { path = "core", version = "0.24.10" }
+jsonrpsee-server = { path = "server", version = "0.24.10" }
+jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.10" }
+jsonrpsee-http-client = { path = "client/http-client", version = "0.24.10" }
+jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.10" }
+jsonrpsee-client-transport = { path = "client/transport", version = "0.24.10" }
+jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.10" }
 
 tower = "0.4"
 tower-http = "0.5"

--- a/core/src/tracing.rs
+++ b/core/src/tracing.rs
@@ -10,7 +10,7 @@ pub mod client {
 
 	/// Helper for writing trace logs from str.
 	pub fn tx_log_from_str(s: impl AsRef<str>, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: CLIENT, Level::TRACE) {
 			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
 			tracing::trace!(target: CLIENT, send = msg);
 		}
@@ -18,7 +18,7 @@ pub mod client {
 
 	/// Helper for writing trace logs from JSON.
 	pub fn tx_log_from_json(s: &impl Serialize, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: CLIENT, Level::TRACE) {
 			let json = serde_json::to_string(s).unwrap_or_default();
 			let msg = truncate_at_char_boundary(&json, max as usize);
 			tracing::trace!(target: CLIENT, send = msg);
@@ -27,7 +27,7 @@ pub mod client {
 
 	/// Helper for writing trace logs from str.
 	pub fn rx_log_from_str(s: impl AsRef<str>, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: CLIENT, Level::TRACE) {
 			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
 			tracing::trace!(target: CLIENT, recv = msg);
 		}
@@ -35,7 +35,7 @@ pub mod client {
 
 	/// Helper for writing trace logs from JSON.
 	pub fn rx_log_from_json(s: &impl Serialize, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: CLIENT, Level::TRACE) {
 			let res = serde_json::to_string(s).unwrap_or_default();
 			let msg = truncate_at_char_boundary(res.as_str(), max as usize);
 			tracing::trace!(target: CLIENT, recv = msg);
@@ -44,7 +44,7 @@ pub mod client {
 
 	/// Helper for writing trace logs from bytes.
 	pub fn rx_log_from_bytes(bytes: &[u8], max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: CLIENT, Level::TRACE) {
 			let res = serde_json::from_slice::<serde_json::Value>(bytes).unwrap_or_default();
 			rx_log_from_json(&res, max);
 		}
@@ -57,7 +57,7 @@ pub mod server {
 
 	/// Helper for writing trace logs from str.
 	pub fn tx_log_from_str(s: impl AsRef<str>, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: SERVER, Level::TRACE) {
 			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
 			tracing::trace!(target: SERVER, send = msg);
 		}
@@ -65,7 +65,7 @@ pub mod server {
 
 	/// Helper for writing trace logs from JSON.
 	pub fn tx_log_from_json(s: &impl Serialize, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: SERVER, Level::TRACE) {
 			let json = serde_json::to_string(s).unwrap_or_default();
 			let msg = truncate_at_char_boundary(&json, max as usize);
 			tracing::trace!(target: SERVER, send = msg);
@@ -74,7 +74,7 @@ pub mod server {
 
 	/// Helper for writing trace logs from str.
 	pub fn rx_log_from_str(s: impl AsRef<str>, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: SERVER, Level::TRACE) {
 			let msg = truncate_at_char_boundary(s.as_ref(), max as usize);
 			tracing::trace!(target: SERVER, recv = msg);
 		}
@@ -82,7 +82,7 @@ pub mod server {
 
 	/// Helper for writing trace logs from JSON.
 	pub fn rx_log_from_json(s: &impl Serialize, max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: SERVER, Level::TRACE) {
 			let res = serde_json::to_string(s).unwrap_or_default();
 			let msg = truncate_at_char_boundary(res.as_str(), max as usize);
 			tracing::trace!(target: SERVER, recv = msg);
@@ -91,7 +91,7 @@ pub mod server {
 
 	/// Helper for writing trace logs from bytes.
 	pub fn rx_log_from_bytes(bytes: &[u8], max: u32) {
-		if tracing::enabled!(Level::TRACE) {
+		if tracing::enabled!(target: SERVER, Level::TRACE) {
 			let res = serde_json::from_slice::<serde_json::Value>(bytes).unwrap_or_default();
 			rx_log_from_json(&res, max);
 		}


### PR DESCRIPTION
Fix tracing::enabled check
without that fix you need to enable trace globally, and can't just scope to the desired (jsonrpsee-server or jsonrpsee-client) target