### PR TITLE
Fix serde deps for jsonrpsee-types

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 publish = true
 
 [dependencies]
-serde = { version = "1", default-features = false, features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"] }
 thiserror = "1.0"
 http = "1"


### PR DESCRIPTION
without that change building this crate in isolation (cargo build -p jsonrpsee-types) doesn't work 
