### PR TITLE
fix(http-client): expose types to allow naming HttpClient with middleware

### DIFF
--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -26,7 +26,7 @@ jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["client", "http-helpers"] }
 rustls = { workspace = true, optional = true, features = ["logging", "std", "tls12", "ring"] }
 rustls-platform-verifier = { workspace = true, optional = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/client/http-client/src/lib.rs
+++ b/client/http-client/src/lib.rs
@@ -57,6 +57,10 @@ pub type HttpRequest<T = HttpBody> = jsonrpsee_core::http_helpers::Request<T>;
 /// HTTP response with default body.
 pub type HttpResponse<T = HttpBody> = jsonrpsee_core::http_helpers::Response<T>;
 
+pub use jsonrpsee_core::middleware::layer::{RpcLogger, RpcLoggerLayer};
+pub use jsonrpsee_core::middleware::{RpcServiceBuilder, RpcServiceT};
+pub use transport::{HttpBackend, HttpTransportClient};
+
 /// Custom TLS configuration.
 #[cfg(feature = "tls")]
 pub type CustomCertStore = rustls::ClientConfig;

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { workspace = true }
 jsonrpsee-test-utils = { path = "../../test-utils" }
 tokio = { workspace = true, features = ["macros"] }
 serde_json = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 rustls = { workspace = true, features = ["logging", "std", "tls12", "ring"] }
 
 [features]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 async-trait = { workspace = true }
 jsonrpsee-types = { workspace = true }
 thiserror = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 tracing = { workspace = true }
 

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -33,7 +33,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy"]}
 futures-channel = { workspace = true }
 futures-util = { workspace = true }
 serde_json = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 trybuild = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tower = { workspace = true }

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_deprecated_method.stderr
@@ -1,12 +1,12 @@
 error: use of deprecated method `DeprecatedClient::async_method`: please use `new_method` instead
-  --> $DIR/rpc_deprecated_method.rs:63:20
+  --> tests/ui/incorrect/rpc/rpc_deprecated_method.rs:63:20
    |
 63 |     assert_eq!(client.async_method().await.unwrap(), 16);
    |                       ^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/rpc_deprecated_method.rs:4:9
+  --> tests/ui/incorrect/rpc/rpc_deprecated_method.rs:4:9
    |
-4  | #![deny(warnings)]
+ 4 | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`

--- a/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
+++ b/proc-macros/tests/ui/incorrect/rpc/rpc_empty_bounds.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `<Conf as Config>::Hash: DeserializeOwned` is not satisfied
+error[E0277]: the trait bound `<Conf as Config>::Hash: serde::de::DeserializeOwned` is not satisfied
  --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
   |
 9 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]
@@ -15,7 +15,7 @@ note: required by a bound in `request`
   |            ^^^^^^^^^^^^^^^^ required by this bound in `ClientT::request`
   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `<Conf as Config>::Hash: Serialize` is not satisfied
+error[E0277]: the trait bound `<Conf as Config>::Hash: serde::Serialize` is not satisfied
  --> tests/ui/incorrect/rpc/rpc_empty_bounds.rs:9:1
   |
 9 | #[rpc(server, client, namespace = "foo", client_bounds(), server_bounds())]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["server-auto", "tokio", "client-legacy"] }
 http-body-util = { workspace = true }
 tracing = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "alloc"] }
 serde_json = { workspace = true }
 soketto = { workspace = true, features = ["http"] }
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "time"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,7 +20,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["http1", "client", "client-legacy"] }
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "client-core", "http-client", "ws-client", "macros"] }
 jsonrpsee-test-utils = { path = "../test-utils" }
-serde = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 tokio-stream = { workspace = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,6 +18,6 @@ workspace = true
 
 [dependencies]
 http = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
### **Summary**
This PR addresses #1590 by re-exporting the internal types that compose the `HttpClient` generic stack. 

Currently, when a user applies middleware using `HttpClientBuilder`, the resulting type becomes a complex chain, such as `HttpClient<MyMiddleware<RpcService<HttpBackend>>>`. While some of these structs were marked `pub`, they were located in private modules, making it impossible for users to explicitly name the type in function signatures or struct definitions.


### **Example Usage**
Before this change, the following code would fail to compile because `RpcLogger`, `RpcService`, and `HttpBackend` were not reachable:

```rust
use jsonrpsee::http_client::{HttpClient, RpcService, HttpBackend, RpcLogger, RpcServiceBuilder};

// Explicitly naming the default client type
fn get_client() -> HttpClient<RpcLogger<RpcService<HttpBackend>>> {
    HttpClient::builder()
        .build("http://localhost:9933")
        .unwrap()
}

// Naming a client with stripped/custom middleware
fn get_custom_client() -> HttpClient<RpcService<HttpBackend>> {
    HttpClient::builder()
        .set_rpc_middleware(RpcServiceBuilder::new())
        .build("http://localhost:9933")
        .unwrap()
}
```

### **Fixes**
Closes #1590