### PR TITLE
refactor: replace soketto with yawc for per-message deflate support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,13 +69,12 @@ rustls-pki-types = "1"
 rustls-platform-verifier = "0.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.142", default-features = false, features = ["alloc", "raw_value"] }
-soketto = "0.8.1"
+yawc = { version = "0.3.3", default-features = false, features = ["rustls-ring"] }
 syn = { version = "2", default-features = false }
 thiserror = "2"
 tokio = "1.42"
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-stream = "0.1.7"
-tokio-util = "0.7"
 tower = "0.5"
 tower-http = "0.6"
 tracing = "0.1.34"

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = { workspace = true, optional = true }
 futures-util = { workspace = true, features = ["alloc"], optional = true }
 http = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-tokio-util = { workspace = true, features = ["compat"], optional = true }
 tokio = { workspace = true, features = ["net", "time", "macros"], optional = true }
 pin-project = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
@@ -37,7 +36,7 @@ rustls-platform-verifier = { workspace = true, optional = true }
 rustls = { workspace = true, default-features = false, optional = true }
 
 # ws
-soketto = { workspace = true, optional = true }
+yawc = { workspace = true, optional = true }
 
 # web-sys
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -53,8 +52,7 @@ ws = [
     "futures-util",
     "http",
     "tokio",
-    "tokio-util",
-    "soketto",
+    "yawc",
     "pin-project",
     "thiserror",
     "tracing",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 workspace = true
 
 [dependencies]
-futures-util = { workspace = true, features = ["io", "async-await-macro"] }
+futures-util = { workspace = true, features = ["async-await-macro"] }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
@@ -29,10 +29,9 @@ pin-project = "1.1.3"
 route-recognizer = "0.3.1"
 serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
-soketto = { version = "0.8.1", features = ["http"] }
+yawc = { workspace = true }
 thiserror = "2"
 tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
-tokio-util = { version = "0.7", features = ["compat"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -51,6 +51,7 @@ pub use server::{
 	ServerConfigBuilder, TowerService, TowerServiceBuilder, TowerServiceNoHttp,
 };
 pub use tracing;
+pub use yawc::{DeflateOptions, Options as WsOptions};
 
 pub use jsonrpsee_core::http_helpers::{Body as HttpBody, Request as HttpRequest, Response as HttpResponse};
 pub use transport::http;

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -15,6 +15,6 @@ http-body-util = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc"] }
 serde_json = { workspace = true }
-soketto = { workspace = true, features = ["http"] }
+url = { workspace = true }
+yawc = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "time"] }
-tokio-util = { workspace = true, features = ["compat"] }

--- a/test-utils/src/mocks.rs
+++ b/test-utils/src/mocks.rs
@@ -32,15 +32,14 @@ use std::time::Duration;
 use futures_channel::mpsc;
 use futures_channel::oneshot;
 use futures_util::future::FutureExt;
-use futures_util::io::{BufReader, BufWriter};
 use futures_util::sink::SinkExt;
-use futures_util::stream::{self, StreamExt};
+use futures_util::stream::StreamExt;
 use futures_util::{pin_mut, select};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use serde::{Deserialize, Serialize};
-use soketto::handshake::{self, Error as SokettoError, Server, http::is_upgrade_request, server::Response};
 use tokio::net::TcpStream;
-use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
+use yawc::frame::{Frame, OpCode};
+use yawc::{Options, WebSocket, WebSocketError};
 
 pub use hyper::{HeaderMap, StatusCode, Uri};
 
@@ -69,8 +68,8 @@ pub struct HttpResponse {
 
 /// WebSocket client to construct with arbitrary payload to construct bad payloads.
 pub struct WebSocketTestClient {
-	tx: soketto::Sender<BufReader<BufWriter<Compat<TcpStream>>>>,
-	rx: soketto::Receiver<BufReader<BufWriter<Compat<TcpStream>>>>,
+	tx: futures_util::stream::SplitSink<WebSocket<TcpStream>, Frame>,
+	rx: futures_util::stream::SplitStream<WebSocket<TcpStream>>,
 }
 
 impl std::fmt::Debug for WebSocketTestClient {
@@ -83,54 +82,60 @@ impl std::fmt::Debug for WebSocketTestClient {
 pub enum WebSocketTestError {
 	Redirect,
 	RejectedWithStatusCode(u16),
-	Soketto(SokettoError),
+	Yawc(WebSocketError),
 }
 
 impl From<io::Error> for WebSocketTestError {
 	fn from(err: io::Error) -> Self {
-		WebSocketTestError::Soketto(SokettoError::Io(err))
+		WebSocketTestError::Yawc(WebSocketError::IoError(err))
 	}
 }
 
 impl WebSocketTestClient {
 	pub async fn new(url: SocketAddr) -> Result<Self, WebSocketTestError> {
 		let socket = TcpStream::connect(url).await?;
-		let mut client = handshake::Client::new(BufReader::new(BufWriter::new(socket.compat())), "test-client", "/");
-		match client.handshake().await {
-			Ok(handshake::ServerResponse::Accepted { .. }) => {
-				let (tx, rx) = client.into_builder().finish();
+		let ws_url: url::Url = format!("ws://{url}/").parse().expect("valid url");
+		match WebSocket::handshake(ws_url, socket, Options::default()).await {
+			Ok(ws) => {
+				let (tx, rx) = ws.split();
 				Ok(Self { tx, rx })
 			}
-			Ok(handshake::ServerResponse::Redirect { .. }) => Err(WebSocketTestError::Redirect),
-			Ok(handshake::ServerResponse::Rejected { status_code }) => {
+			Err(WebSocketError::Redirected { .. }) => Err(WebSocketTestError::Redirect),
+			Err(WebSocketError::InvalidStatusCode(status_code)) => {
 				Err(WebSocketTestError::RejectedWithStatusCode(status_code))
 			}
-			Err(err) => Err(WebSocketTestError::Soketto(err)),
+			Err(err) => Err(WebSocketTestError::Yawc(err)),
 		}
 	}
 
 	pub async fn send_request_text(&mut self, msg: impl AsRef<str>) -> Result<String, Error> {
 		self.send(msg).await?;
-		let mut data = Vec::new();
-		self.rx.receive_data(&mut data).await?;
-		String::from_utf8(data).map_err(Into::into)
+		self.receive().await
 	}
 
 	pub async fn send(&mut self, msg: impl AsRef<str>) -> Result<(), Error> {
-		self.tx.send_text(msg).await?;
-		self.tx.flush().await.map_err(Into::into)
+		self.tx.send(Frame::text(msg.as_ref().to_string())).await.map_err(Into::into)
 	}
 
 	pub async fn send_request_binary(&mut self, msg: &[u8]) -> Result<String, Error> {
-		self.tx.send_binary(msg).await?;
-		self.tx.flush().await?;
+		self.tx.send(Frame::binary(msg.to_vec())).await?;
 		self.receive().await
 	}
 
 	pub async fn receive(&mut self) -> Result<String, Error> {
-		let mut data = Vec::new();
-		self.rx.receive_data(&mut data).await?;
-		String::from_utf8(data).map_err(Into::into)
+		loop {
+			match self.rx.next().await {
+				Some(frame) => match frame.opcode() {
+					OpCode::Text | OpCode::Binary => {
+						return String::from_utf8(frame.into_payload().to_vec()).map_err(Into::into);
+					}
+					OpCode::Close => return Err("Connection closed".into()),
+					// Skip ping/pong frames
+					_ => continue,
+				},
+				None => return Err("Connection closed".into()),
+			}
+		}
 	}
 
 	pub async fn close(&mut self) -> Result<(), Error> {
@@ -241,28 +246,50 @@ async fn server_backend(listener: tokio::net::TcpListener, mut exit: mpsc::Unbou
 }
 
 async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut exit: mpsc::UnboundedReceiver<()>) {
-	let mut server = Server::new(socket.compat());
+	let io = TokioIo::new(socket);
 
-	let key = match server.receive_request().await {
-		Ok(req) => req.key(),
-		Err(_) => return,
+	// Use a oneshot channel to send the established WebSocket to the main task.
+	let (ws_tx, ws_rx) = tokio::sync::oneshot::channel::<hyper::Result<yawc::HttpWebSocket>>();
+	let ws_tx = std::sync::Arc::new(std::sync::Mutex::new(Some(ws_tx)));
+
+	let mode_clone = mode.clone();
+
+	let service = hyper::service::service_fn(move |mut req: hyper::Request<hyper::body::Incoming>| {
+		let ws_tx = ws_tx.lock().unwrap().take().expect("service_fn called only once for HTTP upgrade");
+		async move {
+			let (response, upgrade_fut) = yawc::WebSocket::upgrade(&mut req)?;
+
+			tokio::spawn(async move {
+				let _ = ws_tx.send(upgrade_fut.await);
+			});
+
+			Ok::<_, yawc::WebSocketError>(response)
+		}
+	});
+
+	// We need to use hyper to handle the HTTP upgrade, then get the WebSocket.
+	// But since service_fn requires FnMut and we need to move ws_tx out,
+	// let's use a simpler approach: accept the TCP connection with hyper for the upgrade.
+	let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+	let conn = builder.serve_connection_with_upgrades(io, service);
+
+	// Drive the HTTP connection to complete the upgrade
+	let _ = conn.await;
+
+	// Now get the WebSocket
+	let ws = match ws_rx.await {
+		Ok(Ok(ws)) => ws,
+		_ => return,
 	};
 
-	let accept = server.send_response(&Response::Accept { key, protocol: None }).await;
+	let (mut sender, receiver) = ws.split();
 
-	if accept.is_err() {
-		return;
-	}
-
-	let (mut sender, receiver) = server.into_builder().finish();
-
-	let ws_stream = stream::unfold(receiver, move |mut receiver| async {
-		let mut buf = Vec::new();
-		let ret = match receiver.receive_data(&mut buf).await {
-			Ok(_) => Ok(buf),
-			Err(err) => Err(err),
-		};
-		Some((ret, receiver))
+	let ws_stream = receiver.filter_map(|frame| async move {
+		match frame.opcode() {
+			OpCode::Text | OpCode::Binary => Some(frame.into_payload().to_vec()),
+			OpCode::Close => None,
+			_ => None, // skip pings/pongs
+		}
 	});
 	pin_mut!(ws_stream);
 
@@ -275,15 +302,15 @@ async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut ex
 
 		select! {
 			_ = time_out => {
-				 match &mode {
+				 match &mode_clone {
 					ServerMode::Subscription { subscription_response, .. } => {
-						if let Err(e) = sender.send_text(&subscription_response).await {
+						if let Err(e) = sender.send(Frame::text(subscription_response.clone())).await {
 							tracing::warn!("send response to subscription: {:?}", e);
 							break;
 						}
 					},
 					ServerMode::Notification(n) => {
-						if let Err(e) = sender.send_text(&n).await {
+						if let Err(e) = sender.send(Frame::text(n.clone())).await {
 							tracing::warn!("send notification: {:?}", e);
 							break;
 						}
@@ -294,16 +321,16 @@ async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut ex
 			ws = next_ws => {
 				// Got a request on the connection but don't care about the contents.
 				// Just send out the pre-configured hardcoded responses.
-				if let Some(Ok(_)) = ws {
-					match &mode {
+				if let Some(_) = ws {
+					match &mode_clone {
 						ServerMode::Response(r) => {
-							if let Err(e) = sender.send_text(&r).await {
+							if let Err(e) = sender.send(Frame::text(r.clone())).await {
 								tracing::warn!("send response to request error: {:?}", e);
 								break;
 							}
 						},
 						ServerMode::Subscription { subscription_id, .. } => {
-							if let Err(e) = sender.send_text(&subscription_id).await {
+							if let Err(e) = sender.send(Frame::text(subscription_id.clone())).await {
 								tracing::warn!("send subscription id error: {:?}", e);
 								break;
 							}
@@ -317,6 +344,23 @@ async fn connection_task(socket: tokio::net::TcpStream, mode: ServerMode, mut ex
 			_ = next_exit => break,
 		}
 	}
+}
+
+/// Checks whether the incoming request is a WebSocket upgrade request.
+fn is_upgrade_request<B>(req: &hyper::Request<B>) -> bool {
+	let dominated_upgrade = req
+		.headers()
+		.get(hyper::header::UPGRADE)
+		.and_then(|v| v.to_str().ok())
+		.map(|v| v.eq_ignore_ascii_case("websocket"))
+		.unwrap_or(false);
+	let has_connection_upgrade = req
+		.headers()
+		.get(hyper::header::CONNECTION)
+		.and_then(|v| v.to_str().ok())
+		.map(|v| v.to_lowercase().contains("upgrade"))
+		.unwrap_or(false);
+	dominated_upgrade && has_connection_upgrade
 }
 
 // Run a WebSocket server running on localhost that redirects requests for testing.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,7 +24,6 @@ serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 tokio-stream = { workspace = true }
-tokio-util = { workspace = true, features = ["compat"]}
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }


### PR DESCRIPTION
Migrate from soketto to yawc across the entire codebase (server, client transport, ws-client, test-utils). yawc provides RFC 7692 permessage-deflate compression with balanced compression enabled by default, near-zero-copy frame processing, and SIMD-optimized masking.

Key changes:
- Replace soketto handshake/connection with yawc WebSocket::upgrade (server) and WebSocket::handshake_with_request (client)
- Remove tokio-util compat layer (yawc uses tokio I/O natively)
- Add configurable WsOptions (compression level, payload limits) to ServerConfigBuilder, WsTransportClientBuilder, and WsClientBuilder
- Re-export DeflateOptions and WsOptions from server and client crates
- Update test mocks to use yawc with safe Arc<Mutex<Option>> pattern
- Adapt max request body size test for yawc's connection-terminating behavior on oversized payloads