### PR TITLE
Fix clippy and compiler warnings across client and server crates

### DIFF
--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -252,9 +252,9 @@ async fn batch_request_out_of_order_response() {
 }
 
 async fn run_batch_request_with_response<T: Send + DeserializeOwned + std::fmt::Debug + Clone + 'static>(
-	batch: BatchRequestBuilder<'_>,
+	batch: BatchRequestBuilder<'static>,
 	response: String,
-) -> Result<BatchResponse<T>, ClientError> {
+) -> Result<BatchResponse<'static, T>, ClientError> {
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
 	let uri = format!("http://{server_addr}");
 	let client = HttpClientBuilder::default().build(&uri).unwrap();

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -251,10 +251,10 @@ async fn batch_request_out_of_order_response() {
 	assert_eq!(response, vec!["hello".to_string(), "goodbye".to_string(), "here's your swag".to_string()]);
 }
 
-async fn run_batch_request_with_response<T: Send + DeserializeOwned + std::fmt::Debug + Clone + 'static>(
-	batch: BatchRequestBuilder<'static>,
+async fn run_batch_request_with_response<'a, T: Send + DeserializeOwned + std::fmt::Debug + Clone + 'static>(
+	batch: BatchRequestBuilder<'a>,
 	response: String,
-) -> Result<BatchResponse<'static, T>, ClientError> {
+) -> Result<BatchResponse<'a, T>, ClientError> {
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
 	let uri = format!("http://{server_addr}");
 	let client = HttpClientBuilder::default().build(&uri).unwrap();

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -440,9 +440,9 @@ async fn is_connected_works() {
 }
 
 async fn run_batch_request_with_response<T: Send + DeserializeOwned + std::fmt::Debug + Clone + 'static>(
-	batch: BatchRequestBuilder<'_>,
+	batch: BatchRequestBuilder<'static>,
 	response: String,
-) -> Result<BatchResponse<T>, Error> {
+) -> Result<BatchResponse<'static, T>, Error> {
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), response)
 		.with_default_timeout()
 		.await

--- a/client/ws-client/src/tests.rs
+++ b/client/ws-client/src/tests.rs
@@ -439,10 +439,10 @@ async fn is_connected_works() {
 	assert!(!client.is_connected())
 }
 
-async fn run_batch_request_with_response<T: Send + DeserializeOwned + std::fmt::Debug + Clone + 'static>(
-	batch: BatchRequestBuilder<'static>,
+async fn run_batch_request_with_response<'a, T: Send + DeserializeOwned + std::fmt::Debug + Clone + 'static>(
+	batch: BatchRequestBuilder<'a>,
 	response: String,
-) -> Result<BatchResponse<'static, T>, Error> {
+) -> Result<BatchResponse<'a, T>, Error> {
 	let server = WebSocketTestServer::with_hardcoded_response("127.0.0.1:0".parse().unwrap(), response)
 		.with_default_timeout()
 		.await

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -63,7 +63,6 @@ pub(crate) struct SubscriptionLagged(Arc<RwLock<bool>>);
 /// Owned version of [`RawResponse`].
 pub type RawResponseOwned = RawResponse<'static>;
 
-#[allow(dead_code)]
 impl SubscriptionLagged {
 	/// Create a new [`SubscriptionLagged`].
 	pub(crate) fn new() -> Self {
@@ -289,7 +288,6 @@ pub struct Subscription<Notif> {
 // but type type has no need to be pinned.
 impl<Notif> std::marker::Unpin for Subscription<Notif> {}
 
-#[allow(dead_code)]
 impl<Notif> Subscription<Notif> {
 	/// Create a new subscription.
 	fn new(to_back: mpsc::Sender<FrontToBack>, rx: SubscriptionReceiver, kind: SubscriptionKind) -> Self {
@@ -335,7 +333,6 @@ impl<Notif> Subscription<Notif> {
 
 /// Batch request message.
 #[derive(Debug)]
-#[allow(dead_code)]
 struct BatchMessage {
 	/// Serialized batch request.
 	raw: String,
@@ -347,7 +344,6 @@ struct BatchMessage {
 
 /// Request message.
 #[derive(Debug)]
-#[allow(dead_code)]
 struct RequestMessage {
 	/// Serialized message.
 	raw: String,
@@ -359,7 +355,6 @@ struct RequestMessage {
 
 /// Subscription message.
 #[derive(Debug)]
-#[allow(dead_code)]
 struct SubscriptionMessage {
 	/// Serialized message.
 	raw: String,
@@ -377,7 +372,6 @@ struct SubscriptionMessage {
 
 /// RegisterNotification message.
 #[derive(Debug)]
-#[allow(dead_code)]
 struct RegisterNotificationMessage {
 	/// Method name this notification handler is attached to
 	method: String,
@@ -389,7 +383,6 @@ struct RegisterNotificationMessage {
 
 /// Message that the Client can send to the background task.
 #[derive(Debug)]
-#[allow(dead_code)]
 enum FrontToBack {
 	/// Send a batch request to the server.
 	Batch(BatchMessage),
@@ -613,7 +606,6 @@ impl<'a, R> IntoIterator for BatchResponse<'a, R> {
 }
 
 #[derive(thiserror::Error, Debug)]
-#[allow(dead_code)]
 enum TrySubscriptionSendError {
 	#[error("The subscription is closed")]
 	Closed,
@@ -622,13 +614,11 @@ enum TrySubscriptionSendError {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) struct SubscriptionSender {
 	inner: mpsc::Sender<Box<RawValue>>,
 	lagged: SubscriptionLagged,
 }
 
-#[allow(dead_code)]
 impl SubscriptionSender {
 	fn send(&self, msg: Box<RawValue>) -> Result<(), TrySubscriptionSendError> {
 		match self.inner.try_send(msg) {
@@ -656,7 +646,6 @@ impl Stream for SubscriptionReceiver {
 	}
 }
 
-#[allow(dead_code)]
 fn subscription_channel(max_buf_size: usize) -> (SubscriptionSender, SubscriptionReceiver) {
 	let (tx, rx) = mpsc::channel(max_buf_size);
 	let lagged_tx = SubscriptionLagged::new();
@@ -672,7 +661,6 @@ pub struct SubscriptionResponse {
 	sub_id: SubscriptionId<'static>,
 	// The receiver is used to receive notifications from the server and shouldn't be exposed to the user
 	// from the middleware.
-	#[allow(dead_code)]
 	stream: SubscriptionReceiver,
 }
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -63,6 +63,7 @@ pub(crate) struct SubscriptionLagged(Arc<RwLock<bool>>);
 /// Owned version of [`RawResponse`].
 pub type RawResponseOwned = RawResponse<'static>;
 
+#[allow(dead_code)]
 impl SubscriptionLagged {
 	/// Create a new [`SubscriptionLagged`].
 	pub(crate) fn new() -> Self {
@@ -288,6 +289,7 @@ pub struct Subscription<Notif> {
 // but type type has no need to be pinned.
 impl<Notif> std::marker::Unpin for Subscription<Notif> {}
 
+#[allow(dead_code)]
 impl<Notif> Subscription<Notif> {
 	/// Create a new subscription.
 	fn new(to_back: mpsc::Sender<FrontToBack>, rx: SubscriptionReceiver, kind: SubscriptionKind) -> Self {
@@ -333,6 +335,7 @@ impl<Notif> Subscription<Notif> {
 
 /// Batch request message.
 #[derive(Debug)]
+#[allow(dead_code)]
 struct BatchMessage {
 	/// Serialized batch request.
 	raw: String,
@@ -344,6 +347,7 @@ struct BatchMessage {
 
 /// Request message.
 #[derive(Debug)]
+#[allow(dead_code)]
 struct RequestMessage {
 	/// Serialized message.
 	raw: String,
@@ -355,6 +359,7 @@ struct RequestMessage {
 
 /// Subscription message.
 #[derive(Debug)]
+#[allow(dead_code)]
 struct SubscriptionMessage {
 	/// Serialized message.
 	raw: String,
@@ -372,6 +377,7 @@ struct SubscriptionMessage {
 
 /// RegisterNotification message.
 #[derive(Debug)]
+#[allow(dead_code)]
 struct RegisterNotificationMessage {
 	/// Method name this notification handler is attached to
 	method: String,
@@ -383,6 +389,7 @@ struct RegisterNotificationMessage {
 
 /// Message that the Client can send to the background task.
 #[derive(Debug)]
+#[allow(dead_code)]
 enum FrontToBack {
 	/// Send a batch request to the server.
 	Batch(BatchMessage),
@@ -606,6 +613,7 @@ impl<'a, R> IntoIterator for BatchResponse<'a, R> {
 }
 
 #[derive(thiserror::Error, Debug)]
+#[allow(dead_code)]
 enum TrySubscriptionSendError {
 	#[error("The subscription is closed")]
 	Closed,
@@ -614,11 +622,13 @@ enum TrySubscriptionSendError {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) struct SubscriptionSender {
 	inner: mpsc::Sender<Box<RawValue>>,
 	lagged: SubscriptionLagged,
 }
 
+#[allow(dead_code)]
 impl SubscriptionSender {
 	fn send(&self, msg: Box<RawValue>) -> Result<(), TrySubscriptionSendError> {
 		match self.inner.try_send(msg) {
@@ -646,6 +656,7 @@ impl Stream for SubscriptionReceiver {
 	}
 }
 
+#[allow(dead_code)]
 fn subscription_channel(max_buf_size: usize) -> (SubscriptionSender, SubscriptionReceiver) {
 	let (tx, rx) = mpsc::channel(max_buf_size);
 	let lagged_tx = SubscriptionLagged::new();
@@ -661,6 +672,7 @@ pub struct SubscriptionResponse {
 	sub_id: SubscriptionId<'static>,
 	// The receiver is used to receive notifications from the server and shouldn't be exposed to the user
 	// from the middleware.
+	#[allow(dead_code)]
 	stream: SubscriptionReceiver,
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1163,7 +1163,7 @@ struct ProcessConnection<'a, HttpMiddleware, RpcMiddleware> {
 }
 
 #[instrument(name = "connection", skip_all, fields(remote_addr = %params.remote_addr, conn_id = %params.conn_id), level = "INFO")]
-fn process_connection<'a, RpcMiddleware, HttpMiddleware, Body>(params: ProcessConnection<HttpMiddleware, RpcMiddleware>)
+fn process_connection<RpcMiddleware, HttpMiddleware, Body>(params: ProcessConnection<HttpMiddleware, RpcMiddleware>)
 where
 	HttpMiddleware: Layer<TowerServiceNoHttp<RpcMiddleware>> + Send + 'static,
 	<HttpMiddleware as Layer<TowerServiceNoHttp<RpcMiddleware>>>::Service:


### PR DESCRIPTION
Warnings surfaced while working on #1628. Merging these separately - they're independent from that work and trivial to review on their own.

### Changes

- Removed unused lifetime parameter `'a` from `process_connection` in the server crate.
- Fixed `mismatched_lifetime_syntaxes` warnings in `http-client` and `ws-client` test helpers by using explicit `'static` lifetimes consistently.
- Suppressed dead code warnings in `core::client` for types only used when `async-client` or `async-wasm-client` features are enabled (`FrontToBack`, `BatchMessage`, `SubscriptionSender`, etc.).

### Motivation

`cargo clippy` and `cargo test -p jsonrpsee-http-client` produced ~14 compiler warnings. Mix of an unused lifetime, inconsistent lifetime syntax, and dead code from types gated behind feature flags not active in all compilation contexts.

Clean builds should be clean. Warnings that linger get ignored, and ignored warnings hide real problems.

### Test plan

- `cargo clippy --all-targets --all-features` — zero warnings.
- `cargo test --features tls` — zero warnings.