### PR TITLE
feat: enable WS deflate in soketto

### DIFF
--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -60,6 +60,7 @@ ws = [
     "tracing",
     "url",
 ]
+ws-deflate = ["ws", "soketto/deflate"]
 web = [
     "gloo-net",
     "futures-channel",

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -38,6 +38,8 @@ use jsonrpsee_core::client::{ReceivedMessage, TransportReceiverT, TransportSende
 use soketto::connection::CloseReason;
 use soketto::connection::Error::Utf8;
 use soketto::data::ByteSlice125;
+#[cfg(feature = "ws-deflate")]
+use soketto::extension::deflate::Deflate;
 use soketto::handshake::client::{Client as WsHandshakeClient, ServerResponse};
 use soketto::{Data, Incoming, connection};
 use thiserror::Error;
@@ -101,6 +103,9 @@ pub struct WsTransportClientBuilder {
 	pub max_redirections: usize,
 	/// TCP no delay.
 	pub tcp_no_delay: bool,
+	/// Enable per-message deflate compression.
+	#[cfg(feature = "ws-deflate")]
+	pub ws_compression: bool,
 }
 
 impl Default for WsTransportClientBuilder {
@@ -115,6 +120,8 @@ impl Default for WsTransportClientBuilder {
 			headers: http::HeaderMap::new(),
 			max_redirections: 5,
 			tcp_no_delay: true,
+			#[cfg(feature = "ws-deflate")]
+			ws_compression: false,
 		}
 	}
 }
@@ -167,6 +174,26 @@ impl WsTransportClientBuilder {
 	/// (default is 5).
 	pub fn max_redirections(mut self, redirect: usize) -> Self {
 		self.max_redirections = redirect;
+		self
+	}
+
+	/// Enable per-message deflate compression for the WebSocket connection.
+	///
+	/// This uses the `permessage-deflate` WebSocket extension (RFC 7692).
+	///
+	/// Default: compression is disabled.
+	#[cfg(feature = "ws-deflate")]
+	pub fn enable_ws_compression(mut self) -> Self {
+		self.ws_compression = true;
+		self
+	}
+
+	/// Disable per-message deflate compression for the WebSocket connection.
+	///
+	/// Default: compression is disabled.
+	#[cfg(feature = "ws-deflate")]
+	pub fn disable_ws_compression(mut self) -> Self {
+		self.ws_compression = false;
 		self
 	}
 }
@@ -482,6 +509,11 @@ impl WsTransportClientBuilder {
 			&target.host_header,
 			&target.path_and_query,
 		);
+
+		#[cfg(feature = "ws-deflate")]
+		if self.ws_compression {
+			client.add_extension(Box::new(Deflate::new(soketto::Mode::Client)));
+		}
 
 		let headers: Vec<_> = match &target.basic_auth {
 			Some(basic_auth) if !self.headers.contains_key(http::header::AUTHORIZATION) => {

--- a/client/ws-client/Cargo.toml
+++ b/client/ws-client/Cargo.toml
@@ -35,6 +35,7 @@ rustls = { workspace = true, features = ["logging", "std", "tls12", "ring"] }
 [features]
 tls = ["jsonrpsee-client-transport/tls"]
 tls-rustls-platform-verifier = ["jsonrpsee-client-transport/tls-rustls-platform-verifier", "tls"]
+ws-deflate = ["jsonrpsee-client-transport/ws-deflate"]
 default = ["tls-rustls-platform-verifier"]
 
 [package.metadata.docs.rs]

--- a/client/ws-client/src/lib.rs
+++ b/client/ws-client/src/lib.rs
@@ -102,6 +102,9 @@ pub struct WsClientBuilder<RpcMiddleware = Logger> {
 	id_kind: IdKind,
 	tcp_no_delay: bool,
 	service_builder: RpcServiceBuilder<RpcMiddleware>,
+	/// Enable per-message deflate compression.
+	#[cfg(feature = "ws-deflate")]
+	ws_compression: bool,
 }
 
 impl Default for WsClientBuilder {
@@ -122,6 +125,8 @@ impl Default for WsClientBuilder {
 			id_kind: IdKind::Number,
 			tcp_no_delay: true,
 			service_builder: RpcServiceBuilder::default().rpc_logger(1024),
+			#[cfg(feature = "ws-deflate")]
+			ws_compression: false,
 		}
 	}
 }
@@ -244,6 +249,26 @@ impl<RpcMiddleware> WsClientBuilder<RpcMiddleware> {
 		self
 	}
 
+	/// Enable per-message deflate compression for the WebSocket connection.
+	///
+	/// This uses the `permessage-deflate` WebSocket extension (RFC 7692).
+	///
+	/// Default: compression is disabled.
+	#[cfg(feature = "ws-deflate")]
+	pub fn enable_ws_compression(mut self) -> Self {
+		self.ws_compression = true;
+		self
+	}
+
+	/// Disable per-message deflate compression for the WebSocket connection.
+	///
+	/// Default: compression is disabled.
+	#[cfg(feature = "ws-deflate")]
+	pub fn disable_ws_compression(mut self) -> Self {
+		self.ws_compression = false;
+		self
+	}
+
 	/// See documentation [`WsTransportClientBuilder::set_headers`] (default is none).
 	pub fn set_headers(mut self, headers: http::HeaderMap) -> Self {
 		self.headers = headers;
@@ -298,6 +323,8 @@ impl<RpcMiddleware> WsClientBuilder<RpcMiddleware> {
 			id_kind: self.id_kind,
 			tcp_no_delay: self.tcp_no_delay,
 			service_builder,
+			#[cfg(feature = "ws-deflate")]
+			ws_compression: self.ws_compression,
 		}
 	}
 
@@ -358,6 +385,8 @@ impl<RpcMiddleware> WsClientBuilder<RpcMiddleware> {
 			max_frame_size: self.max_frame_size,
 			max_redirections: self.max_redirections,
 			tcp_no_delay: self.tcp_no_delay,
+			#[cfg(feature = "ws-deflate")]
+			ws_compression: self.ws_compression,
 		};
 
 		let uri = Url::parse(url.as_ref()).map_err(|e| Error::Transport(e.into()))?;
@@ -388,6 +417,8 @@ impl<RpcMiddleware> WsClientBuilder<RpcMiddleware> {
 			max_frame_size: self.max_frame_size,
 			max_redirections: self.max_redirections,
 			tcp_no_delay: self.tcp_no_delay,
+			#[cfg(feature = "ws-deflate")]
+			ws_compression: self.ws_compression,
 		};
 
 		let uri = Url::parse(url.as_ref()).map_err(|e| Error::Transport(e.into()))?;

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -39,6 +39,7 @@ async-wasm-client = ["jsonrpsee-core/async-wasm-client"]
 http-client = ["jsonrpsee-http-client", "jsonrpsee-types", "jsonrpsee-core/client"]
 wasm-client = ["jsonrpsee-wasm-client", "jsonrpsee-types", "jsonrpsee-core/client"]
 ws-client = ["jsonrpsee-ws-client", "jsonrpsee-types", "jsonrpsee-core/client"]
+ws-deflate = ["jsonrpsee-server/ws-deflate", "jsonrpsee-ws-client/ws-deflate"]
 macros = ["jsonrpsee-proc-macros", "jsonrpsee-types", "tracing"]
 
 client = ["http-client", "ws-client", "wasm-client", "client-ws-transport-tls", "client-web-transport", "async-client", "async-wasm-client", "client-core"]

--- a/jsonrpsee/src/lib.rs
+++ b/jsonrpsee/src/lib.rs
@@ -48,6 +48,7 @@
 //! - **`client-ws-transport`** - Enables `ws` transport with TLS.
 //! - **`client-ws-transport-no-tls`** - Enables `ws` transport without TLS.
 //! - **`client-web-transport`** - Enables `websys` transport.
+//! - **`ws-deflate`** - Enables per-message deflate compression for WebSocket connections (RFC 7692).
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,9 @@ publish = true
 [lints]
 workspace = true
 
+[features]
+ws-deflate = ["soketto/deflate"]
+
 [dependencies]
 futures-util = { workspace = true, features = ["io", "async-await-macro"] }
 http = { workspace = true }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -53,6 +53,8 @@ use jsonrpsee_types::error::{
 	BATCHES_NOT_SUPPORTED_CODE, BATCHES_NOT_SUPPORTED_MSG, ErrorCode, reject_too_big_batch_request,
 };
 use jsonrpsee_types::{ErrorObject, Id};
+#[cfg(feature = "ws-deflate")]
+use soketto::extension::deflate::Deflate;
 use soketto::handshake::http::is_upgrade_request;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 use tokio::sync::{OwnedSemaphorePermit, mpsc, watch};
@@ -200,6 +202,9 @@ pub struct ServerConfig {
 	pub(crate) keep_alive: Option<std::time::Duration>,
 	/// `KEEP_ALIVE_TIMEOUT` duration.
 	pub(crate) keep_alive_timeout: Duration,
+	/// Enable WebSocket per-message deflate compression.
+	#[cfg(feature = "ws-deflate")]
+	pub(crate) ws_compression: bool,
 }
 
 /// The builder to configure and create a JSON-RPC server configuration.
@@ -233,6 +238,9 @@ pub struct ServerConfigBuilder {
 	keep_alive: Option<std::time::Duration>,
 	/// `KEEP_ALIVE_TIMEOUT` duration.
 	keep_alive_timeout: std::time::Duration,
+	/// Enable WebSocket per-message deflate compression.
+	#[cfg(feature = "ws-deflate")]
+	ws_compression: bool,
 }
 
 /// Builder for [`TowerService`].
@@ -374,6 +382,8 @@ impl Default for ServerConfigBuilder {
 			keep_alive: None,
 			//same as `hyper` default
 			keep_alive_timeout: Duration::from_secs(20),
+			#[cfg(feature = "ws-deflate")]
+			ws_compression: false,
 		}
 	}
 }
@@ -496,6 +506,27 @@ impl ServerConfigBuilder {
 		self
 	}
 
+	/// Enable per-message deflate compression for WebSocket connections.
+	///
+	/// This uses the `permessage-deflate` WebSocket extension (RFC 7692)
+	/// to compress individual messages.
+	///
+	/// Default: compression is disabled.
+	#[cfg(feature = "ws-deflate")]
+	pub fn enable_ws_compression(mut self) -> Self {
+		self.ws_compression = true;
+		self
+	}
+
+	/// Disable per-message deflate compression for WebSocket connections.
+	///
+	/// Default: compression is disabled.
+	#[cfg(feature = "ws-deflate")]
+	pub fn disable_ws_compression(mut self) -> Self {
+		self.ws_compression = false;
+		self
+	}
+
 	/// Configure custom `subscription ID` provider for the server to use
 	/// to when getting new subscription calls.
 	///
@@ -558,6 +589,8 @@ impl ServerConfigBuilder {
 			tcp_no_delay: self.tcp_no_delay,
 			keep_alive: self.keep_alive,
 			keep_alive_timeout: self.keep_alive_timeout,
+			#[cfg(feature = "ws-deflate")]
+			ws_compression: self.ws_compression,
 		}
 	}
 }
@@ -1045,6 +1078,11 @@ where
 			let this = self.inner.clone();
 
 			let mut server = soketto::handshake::http::Server::new();
+
+			#[cfg(feature = "ws-deflate")]
+			if this.server_cfg.ws_compression {
+				server.add_extension(Box::new(Deflate::new(soketto::Mode::Server)));
+			}
 
 			let response = match server.receive_request(&request) {
 				Ok(response) => {

--- a/server/src/transport/ws.rs
+++ b/server/src/transport/ws.rs
@@ -18,6 +18,8 @@ use jsonrpsee_types::error::{ErrorCode, reject_too_big_request};
 use serde_json::value::RawValue;
 use soketto::connection::Error as SokettoError;
 use soketto::data::ByteSlice125;
+#[cfg(feature = "ws-deflate")]
+use soketto::extension::deflate::Deflate;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{interval, interval_at};
 use tokio_stream::wrappers::ReceiverStream;
@@ -436,6 +438,11 @@ where
 		+ 'static,
 {
 	let mut server = soketto::handshake::http::Server::new();
+
+	#[cfg(feature = "ws-deflate")]
+	if server_cfg.ws_compression {
+		server.add_extension(Box::new(Deflate::new(soketto::Mode::Server)));
+	}
 
 	match server.receive_request(&req) {
 		Ok(response) => {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,7 @@ futures-util = { workspace = true, features = ["alloc"]}
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["http1", "client", "client-legacy"] }
-jsonrpsee = { path = "../jsonrpsee", features = ["server", "client-core", "http-client", "ws-client", "macros"] }
+jsonrpsee = { path = "../jsonrpsee", features = ["server", "client-core", "http-client", "ws-client", "macros", "ws-deflate"] }
 jsonrpsee-test-utils = { path = "../test-utils" }
 serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true }

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -1600,3 +1600,100 @@ async fn http_connection_guard_works() {
 		assert_eq!(conn_count, 1);
 	}
 }
+
+/// Checks permessage-deflate compression when both server and client enable it.
+///
+/// We use a raw TCP proxy between the client and server to capture the bytes
+/// and actually verify that the compressed bytes are flowing on the wire.
+#[tokio::test]
+async fn ws_deflate_wire_level_proxy() {
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+	use tokio::net::{
+		TcpListener, TcpStream,
+		tcp::{OwnedReadHalf, OwnedWriteHalf},
+	};
+
+	// The real RPC server.
+
+	let server = ServerBuilder::with_config(ServerConfig::builder().enable_ws_compression().build())
+		.build("127.0.0.1:0")
+		.await
+		.unwrap();
+	let server_addr = server.local_addr().unwrap();
+
+	let mut module = RpcModule::new(());
+	module
+		.register_method("echo_big", |params, _, _| {
+			let s: String = params.one().unwrap();
+			s
+		})
+		.unwrap();
+	let handle = server.start(module);
+
+	// Transparent TCP proxy.
+
+	let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let proxy_addr = proxy_listener.local_addr().unwrap();
+
+	let proxy_task = tokio::spawn(async move {
+		let (client_conn, _) = proxy_listener.accept().await.unwrap();
+		let server_conn = TcpStream::connect(server_addr).await.unwrap();
+
+		let (cr, cw) = client_conn.into_split();
+		let (sr, sw) = server_conn.into_split();
+
+		let propagate_and_capture = |mut rd: OwnedReadHalf, mut wr: OwnedWriteHalf| {
+			tokio::spawn(async move {
+				let mut buf = [0u8; 4096];
+				let mut captured = Vec::new();
+				loop {
+					let n = match rd.read(&mut buf).await {
+						Ok(0) => break,
+						Ok(n) => n,
+						Err(e) => panic!("proxy client->server read error: {e}"),
+					};
+					captured.extend_from_slice(&buf[..n]);
+					wr.write_all(&buf[..n]).await.expect("proxy client->server write error");
+				}
+				captured
+			})
+		};
+
+		let t1 = propagate_and_capture(cr, sw);
+		let t2 = propagate_and_capture(sr, cw);
+
+		let (c2s, s2c) = tokio::join!(t1, t2);
+		(c2s.unwrap(), s2c.unwrap())
+	});
+
+	// The real RPC client.
+
+	let big_string = "a".repeat(200);
+
+	let url = format!("ws://{proxy_addr}");
+	let client = jsonrpsee::ws_client::WsClientBuilder::default().enable_ws_compression().build(&url).await.unwrap();
+
+	let response: String = client.request("echo_big", rpc_params![big_string.clone()]).await.unwrap();
+	assert_eq!(response, big_string);
+
+	// Drop the client to close the WebSocket connection so the proxy tasks reach EOF and finish.
+	drop(client);
+	let (c2s, s2c) = proxy_task.await.unwrap();
+
+	// Assertions.
+
+	let needle = big_string.as_bytes();
+
+	assert!(
+		!c2s.windows(needle.len()).any(|w| w == needle),
+		"client->server bytes contain plaintext payload – compression is NOT active on the client side"
+	);
+
+	assert!(
+		!s2c.windows(needle.len()).any(|w| w == needle),
+		"server->client bytes contain plaintext payload – compression is NOT active on the server side"
+	);
+
+	handle.stop().unwrap();
+	handle.stopped().await;
+}


### PR DESCRIPTION
This PR introduces the new feature `ws-deflate` and extends server/client configs with `ws_compression: bool`. It doesn't replace soketto with yawc, only enables existing extension in soketto if the corresponding feature is enabled.

Alternative to https://github.com/paritytech/jsonrpsee/pull/1627

cc @jsdw