### PR TITLE
server: expose subscription id on PendingSubscriptionSink

### DIFF
--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -266,6 +266,11 @@ impl PendingSubscriptionSink {
 		}
 	}
 
+	/// Get the subscription ID.
+	pub fn subscription_id(&self) -> SubscriptionId<'static> {
+		self.uniq_sub.sub_id.clone()
+	}
+
 	/// Returns connection identifier, which was used to perform pending subscription request
 	pub fn connection_id(&self) -> ConnectionId {
 		self.uniq_sub.conn_id

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -579,6 +579,8 @@ async fn custom_subscription_id_works() {
 			"subscribe_hello",
 			"unsubscribe_hello",
 			|_, sink, _, _| async {
+				assert!(matches!(sink.subscription_id(), SubscriptionId::Str(id) if id == "0xdeadbeef"));
+
 				let sink = sink.accept().await.unwrap();
 				assert!(matches!(sink.subscription_id(), SubscriptionId::Str(id) if id == "0xdeadbeef"));
 				// Keep idle until it's unsubscribed.


### PR DESCRIPTION
## Summary

Expose the generated subscription id on `PendingSubscriptionSink`.

The subscription id is generated before the subscription callback is invoked and is already used by `accept()` to build the subscription response. However, it is currently only publicly accessible after accepting the subscription through `SubscriptionSink::subscription_id()`.

Some servers need to register per-subscription state before accepting the subscription. Otherwise, follow-up RPC calls using the subscription id can race with server-side registration.

This adds a small getter mirroring the existing `SubscriptionSink::subscription_id()` API.