### PR TITLE
chore: improve jsonrpsee maintenance path

### DIFF
--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -358,4 +358,49 @@ mod tests {
 		let ser = serde_json::to_string(&ErrorObject::owned(-32699, "food", Some(data))).unwrap();
 		assert_eq!(exp, ser);
 	}
+
+	#[test]
+	fn deserialize_fails_with_extra_field() {
+		let ser = r#"{"code":-32700,"message":"Parse error","extra":1}"#;
+		assert!(serde_json::from_str::<ErrorObject>(ser).is_err());
+	}
+
+	#[test]
+	fn deserialize_fails_with_missing_code() {
+		let ser = r#"{"message":"Parse error"}"#;
+		assert!(serde_json::from_str::<ErrorObject>(ser).is_err());
+	}
+
+	#[test]
+	fn deserialize_fails_with_missing_message() {
+		let ser = r#"{"code":-32700}"#;
+		assert!(serde_json::from_str::<ErrorObject>(ser).is_err());
+	}
+
+	#[test]
+	fn deserialize_with_data_object() {
+		let ser = r#"{"code":-32602,"message":"Invalid params","data":{"key":"value"}}"#;
+		let err: ErrorObject = serde_json::from_str(ser).unwrap();
+		assert_eq!(err.code(), -32602);
+		assert_eq!(err.message(), "Invalid params");
+		assert_eq!(err.data().unwrap().get(), r#"{"key":"value"}"#);
+	}
+
+	#[test]
+	fn deserialize_with_data_array() {
+		let ser = r#"{"code":-32602,"message":"Invalid params","data":[1,2,3]}"#;
+		let err: ErrorObject = serde_json::from_str(ser).unwrap();
+		assert_eq!(err.code(), -32602);
+		assert_eq!(err.message(), "Invalid params");
+		assert_eq!(err.data().unwrap().get(), "[1,2,3]");
+	}
+
+	#[test]
+	fn deserialize_with_data_null() {
+		let ser = r#"{"code":-32602,"message":"Invalid params","data":null}"#;
+		let err: ErrorObject = serde_json::from_str(ser).unwrap();
+		assert_eq!(err.code(), -32602);
+		assert_eq!(err.message(), "Invalid params");
+		assert!(err.data().is_none());
+	}
 }

--- a/types/src/params.rs
+++ b/types/src/params.rs
@@ -585,4 +585,47 @@ mod test {
 		assert_eq!(seq.optional_next::<Vec<Vec<u32>>>().unwrap(), Some(vec![vec![5], vec![6, 7], vec![]]));
 		assert_eq!(seq.optional_next::<serde_json::Value>().unwrap(), Some(serde_json::json!({"named":7})));
 	}
+
+	#[test]
+	fn params_sequence_out_of_range() {
+		let params = Params::new(Some("[1, 2]"));
+		let mut seq = params.sequence();
+		assert_eq!(seq.next::<u64>().unwrap(), 1);
+		assert_eq!(seq.next::<u64>().unwrap(), 2);
+		assert!(seq.next::<u64>().is_err());
+		// subsequent calls stay err
+		assert!(seq.next::<u64>().is_err());
+	}
+
+	#[test]
+	fn params_parse_by_name_vs_position() {
+		#[derive(serde::Deserialize, Debug, PartialEq)]
+		struct Named {
+			a: u32,
+			b: String,
+		}
+
+		let by_name = Params::new(Some(r#"{"a":1,"b":"hello"}"#));
+		let parsed: Named = by_name.parse().unwrap();
+		assert_eq!(parsed, Named { a: 1, b: "hello".into() });
+
+		let by_pos = Params::new(Some(r#"[1, "hello"]"#));
+		let parsed: (u32, String) = by_pos.parse().unwrap();
+		assert_eq!(parsed, (1, "hello".into()));
+	}
+
+	#[test]
+	fn params_empty_none_and_array() {
+		let none = Params::new(None);
+		assert_eq!(none.len_bytes(), 0);
+		assert!(none.as_str().is_none());
+		assert!(!none.is_object());
+		let mut seq = none.sequence();
+		assert!(seq.next::<u64>().is_err());
+
+		let empty = Params::new(Some("[]"));
+		assert_eq!(empty.len_bytes(), 2);
+		let mut seq = empty.sequence();
+		assert!(seq.next::<u64>().is_err());
+	}
 }


### PR DESCRIPTION
Summary:
- Add focused unit tests for edge cases in the JSON-RPC types: e.g., parsing of error objects with `data` payloads and missing/extra fields in `ErrorObject`, plus tests for `Params` covering empty params, by-name vs by-position parsing, and out-of-range index access via `Params::sequence()`/`Params::parse()`. Pure additive tests, no behavior change.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.