### PR TITLE
server: expose pending subscription id (backport #1634)

### DIFF
--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -301,6 +301,11 @@ impl PendingSubscriptionSink {
 		}
 	}
 
+	/// Get the subscription ID.
+	pub fn subscription_id(&self) -> SubscriptionId<'static> {
+		self.uniq_sub.sub_id.clone()
+	}
+
 	/// Returns connection identifier, which was used to perform pending subscription request
 	pub fn connection_id(&self) -> ConnectionId {
 		self.uniq_sub.conn_id

--- a/server/src/tests/ws.rs
+++ b/server/src/tests/ws.rs
@@ -574,6 +574,8 @@ async fn custom_subscription_id_works() {
 			"subscribe_hello",
 			"unsubscribe_hello",
 			|_, sink, _, _| async {
+				assert!(matches!(sink.subscription_id(), SubscriptionId::Str(id) if id == "0xdeadbeef"));
+
 				let sink = sink.accept().await.unwrap();
 				assert!(matches!(sink.subscription_id(), SubscriptionId::Str(id) if id == "0xdeadbeef"));
 				// Keep idle until it's unsubscribed.


### PR DESCRIPTION
Backport of #1634 to v0.24.x for the v0.24.11 release.