### PR TITLE
chore: release v0.24.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
-version = "0.24.10"
+version = "0.24.11"
 edition = "2021"
 rust-version = "1.74.0"
 license = "MIT"
@@ -31,14 +31,14 @@ keywords = ["jsonrpc", "json", "http", "websocket", "WASM"]
 readme = "README.md"
 
 [workspace.dependencies]
-jsonrpsee-types = { path = "types", version = "0.24.10" }
-jsonrpsee-core = { path = "core", version = "0.24.10" }
-jsonrpsee-server = { path = "server", version = "0.24.10" }
-jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.10" }
-jsonrpsee-http-client = { path = "client/http-client", version = "0.24.10" }
-jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.10" }
-jsonrpsee-client-transport = { path = "client/transport", version = "0.24.10" }
-jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.10" }
+jsonrpsee-types = { path = "types", version = "0.24.11" }
+jsonrpsee-core = { path = "core", version = "0.24.11" }
+jsonrpsee-server = { path = "server", version = "0.24.11" }
+jsonrpsee-ws-client = { path = "client/ws-client", version = "0.24.11" }
+jsonrpsee-http-client = { path = "client/http-client", version = "0.24.11" }
+jsonrpsee-wasm-client = { path = "client/wasm-client", version = "0.24.11" }
+jsonrpsee-client-transport = { path = "client/transport", version = "0.24.11" }
+jsonrpsee-proc-macros = { path = "proc-macros", version = "0.24.11" }
 
 tower = "0.4"
 tower-http = "0.5"


### PR DESCRIPTION
Bump workspace version 0.24.10 → 0.24.11. Includes #1637 (backport of #1634 — expose pending subscription id).