### PR TITLE
fix(server): install timer for HTTP/2 connections

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -42,7 +42,7 @@ use crate::{Extensions, HttpBody, HttpRequest, HttpResponse, LOG_TARGET};
 use futures_util::future::{self, Either, FutureExt};
 use futures_util::io::{BufReader, BufWriter};
 use hyper::body::Bytes;
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use jsonrpsee_core::id_providers::RandomIntegerIdProvider;
 use jsonrpsee_core::middleware::{Batch, BatchEntry, BatchEntryErr, RpcServiceBuilder, RpcServiceT};
 use jsonrpsee_core::server::helpers::prepare_error;
@@ -1215,7 +1215,7 @@ where
 		let mut builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
 
 		//default is true for http1, if set to false then websocket connections will not be upgraded.
-		builder.http2().keep_alive_interval(keep_alive).keep_alive_timeout(keep_alive_timeout);
+		builder.http2().timer(TokioTimer::new()).keep_alive_interval(keep_alive).keep_alive_timeout(keep_alive_timeout);
 
 		let conn = builder.serve_connection_with_upgrades(io, service);
 		let stopped = stop_handle.shutdown();

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -31,7 +31,7 @@ use std::task::{Context, Poll};
 use crate::{HttpBody, HttpRequest};
 
 use futures_util::future::{self, Either};
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use jsonrpsee_core::BoxError;
 use pin_project::pin_project;
 use tower::ServiceExt;
@@ -100,7 +100,8 @@ where
 	let service = hyper_util::service::TowerToHyperService::new(service);
 	let io = TokioIo::new(io);
 
-	let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+	let mut builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+	builder.http2().timer(TokioTimer::new());
 	let conn = builder.serve_connection_with_upgrades(io, service);
 	conn.await
 }
@@ -124,7 +125,8 @@ where
 	let service = hyper_util::service::TowerToHyperService::new(service);
 	let io = TokioIo::new(io);
 
-	let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+	let mut builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+	builder.http2().timer(TokioTimer::new());
 	let conn = builder.serve_connection_with_upgrades(io, service);
 
 	tokio::pin!(stopped, conn);


### PR DESCRIPTION
## Summary
- Install `TokioTimer` on the server HTTP/2 builder used by accepted connections.
- Install `TokioTimer` on the low-level `serve` and `serve_with_graceful_shutdown` helpers.

## Context
Hyper 1.x requires an explicit timer for HTTP/2 keep-alive / timeout handling. jsonrpsee exposes server keep-alive configuration via `ServerConfigBuilder::set_keep_alive`, but the underlying `hyper_util::server::conn::auto::Builder` is currently created with only `TokioExecutor`.

That means a server configured with HTTP/2 keep-alive can panic at runtime when an HTTP/2 connection constructs hyper's ping channel:

`You must supply a timer.`

This mirrors the timer setup tonic added for its hyper-backed server path.