### PR TITLE
feat(types): preserve JSON-RPC request extensions

### DIFF
--- a/core/src/middleware/mod.rs
+++ b/core/src/middleware/mod.rs
@@ -19,7 +19,7 @@ use tower::layer::util::{Identity, Stack};
 /// Re-export types from `jsonrpsee_types` crate for convenience.
 pub type Notification<'a> = jsonrpsee_types::Notification<'a, Option<Cow<'a, RawValue>>>;
 /// Re-export types from `jsonrpsee_types` crate for convenience.
-pub use jsonrpsee_types::{Extensions, Request};
+pub use jsonrpsee_types::{Extensions, Request, RequestExtensions};
 
 /// Error response that can used to indicate an error in JSON-RPC request batch request.
 /// This is used in the [`Batch`] type to indicate an error in the batch entry.

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -153,14 +153,14 @@ pub mod deserialize_with_ext {
 			extensions: &'a http::Extensions,
 		) -> Result<Request<'a>, serde_json::Error> {
 			let mut req: Request = serde_json::from_slice(data)?;
-			*req.extensions_mut() = extensions.clone();
+			req.extensions_mut().extend(extensions.clone());
 			Ok(req)
 		}
 
 		/// Wrapper over `serde_json::from_str` that sets the extensions.
 		pub fn from_str<'a>(data: &'a str, extensions: &'a http::Extensions) -> Result<Request<'a>, serde_json::Error> {
 			let mut req: Request = serde_json::from_str(data)?;
-			*req.extensions_mut() = extensions.clone();
+			req.extensions_mut().extend(extensions.clone());
 			Ok(req)
 		}
 	}
@@ -178,7 +178,7 @@ pub mod deserialize_with_ext {
 			T: serde::Deserialize<'a>,
 		{
 			let mut notif: Notification<T> = serde_json::from_slice(data)?;
-			*notif.extensions_mut() = extensions.clone();
+			notif.extensions_mut().extend(extensions.clone());
 			Ok(notif)
 		}
 
@@ -191,8 +191,69 @@ pub mod deserialize_with_ext {
 			T: serde::Deserialize<'a>,
 		{
 			let mut notif: Notification<T> = serde_json::from_str(data)?;
-			*notif.extensions_mut() = extensions.clone();
+			notif.extensions_mut().extend(extensions.clone());
 			Ok(notif)
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::borrow::Cow;
+
+	use jsonrpsee_types::{Notification, Request};
+	use serde_json::{Value, value::RawValue};
+
+	use super::deserialize_with_ext;
+
+	#[derive(Clone, Debug, PartialEq, Eq)]
+	struct TransportExtension(&'static str);
+
+	fn transport_extensions() -> http::Extensions {
+		let mut extensions = http::Extensions::new();
+		extensions.insert(TransportExtension("transport"));
+		extensions
+	}
+
+	fn assert_request_extensions(request: &Request<'_>) {
+		assert_eq!(request.extensions().get::<TransportExtension>(), Some(&TransportExtension("transport")));
+		assert_eq!(
+			request.request_extensions().and_then(|extensions| extensions.get("vendor")).and_then(Value::as_str),
+			Some("wire")
+		);
+	}
+
+	fn assert_notification_extensions(notification: &Notification<'_, Option<Cow<'_, RawValue>>>) {
+		assert_eq!(notification.extensions().get::<TransportExtension>(), Some(&TransportExtension("transport")));
+		assert_eq!(
+			notification.request_extensions().and_then(|extensions| extensions.get("vendor")).and_then(Value::as_str),
+			Some("wire")
+		);
+	}
+
+	#[test]
+	fn call_deserialization_preserves_wire_and_transport_extensions() {
+		let payload = r#"{"jsonrpc":"2.0","method":"say_hello","id":1,"vendor":"wire"}"#;
+		let extensions = transport_extensions();
+
+		let from_slice = deserialize_with_ext::call::from_slice(payload.as_bytes(), &extensions).unwrap();
+		assert_request_extensions(&from_slice);
+
+		let from_str = deserialize_with_ext::call::from_str(payload, &extensions).unwrap();
+		assert_request_extensions(&from_str);
+	}
+
+	#[test]
+	fn notification_deserialization_preserves_wire_and_transport_extensions() {
+		let payload = r#"{"jsonrpc":"2.0","method":"say_hello","params":[],"vendor":"wire"}"#;
+		let extensions = transport_extensions();
+
+		let from_slice: Notification<Option<Cow<'_, RawValue>>> =
+			deserialize_with_ext::notif::from_slice(payload.as_bytes(), &extensions).unwrap();
+		assert_notification_extensions(&from_slice);
+
+		let from_str: Notification<Option<Cow<'_, RawValue>>> =
+			deserialize_with_ext::notif::from_str(payload, &extensions).unwrap();
+		assert_notification_extensions(&from_str);
 	}
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -46,5 +46,5 @@ pub mod error;
 pub use error::{ErrorCode, ErrorObject, ErrorObjectOwned};
 pub use http::Extensions;
 pub use params::{Id, InvalidRequestId, Params, ParamsSequence, SubscriptionId, TwoPointZero};
-pub use request::{InvalidRequest, Notification, Request};
+pub use request::{InvalidRequest, InvalidRequestExtensionName, Notification, Request, RequestExtensions};
 pub use response::{Response, ResponsePayload, SubscriptionPayload, SubscriptionResponse, Success as ResponseSuccess};

--- a/types/src/request.rs
+++ b/types/src/request.rs
@@ -27,33 +27,121 @@
 //! Types to handle JSON-RPC requests according to the [spec](https://www.jsonrpc.org/specification#request-object).
 //! Some types come with a "*Ser" variant that implements [`serde::Serialize`]; these are used in the client.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use crate::{
 	Params,
 	params::{Id, TwoPointZero},
 };
 use http::Extensions;
-use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Value, value::RawValue};
+
+const RESERVED_REQUEST_MEMBERS: &[&str] = &["jsonrpc", "id", "method", "params"];
+
+/// Additional top-level members serialized with a JSON-RPC request or notification.
+///
+/// These members are stored in the request's [`Extensions`] and can be used by RPC middleware
+/// to carry protocol extensions without adding them to the JSON-RPC `params` value. The reserved
+/// JSON-RPC request members `jsonrpc`, `id`, `method`, and `params` cannot be inserted.
+#[derive(Clone, Debug, Default)]
+pub struct RequestExtensions {
+	members: BTreeMap<String, Value>,
+}
+
+impl RequestExtensions {
+	/// Inserts a request extension member.
+	///
+	/// Returns the previous value when the member was already present.
+	pub fn insert(
+		&mut self,
+		name: impl Into<String>,
+		value: Value,
+	) -> Result<Option<Value>, InvalidRequestExtensionName> {
+		let name = name.into();
+		if RESERVED_REQUEST_MEMBERS.contains(&name.as_str()) {
+			return Err(InvalidRequestExtensionName { name });
+		}
+
+		Ok(self.members.insert(name, value))
+	}
+
+	/// Returns a request extension member by name.
+	pub fn get(&self, name: &str) -> Option<&Value> {
+		self.members.get(name)
+	}
+
+	/// Removes and returns a request extension member by name.
+	pub fn remove(&mut self, name: &str) -> Option<Value> {
+		self.members.remove(name)
+	}
+
+	/// Returns an iterator over the request extension members.
+	pub fn iter(&self) -> impl Iterator<Item = (&str, &Value)> {
+		self.members.iter().map(|(name, value)| (name.as_str(), value))
+	}
+
+	/// Returns the number of request extension members.
+	pub fn len(&self) -> usize {
+		self.members.len()
+	}
+
+	/// Returns whether there are no request extension members.
+	pub fn is_empty(&self) -> bool {
+		self.members.is_empty()
+	}
+}
+
+/// Error returned when a JSON-RPC request extension uses a reserved member name.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("`{name}` is a reserved JSON-RPC request member")]
+pub struct InvalidRequestExtensionName {
+	name: String,
+}
+
+impl InvalidRequestExtensionName {
+	/// Returns the reserved member name.
+	pub fn name(&self) -> &str {
+		&self.name
+	}
+}
+
+#[derive(Serialize)]
+struct RequestRef<'a, 'request> {
+	jsonrpc: &'a TwoPointZero,
+	id: &'a Id<'request>,
+	method: &'a Cow<'request, str>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	params: Option<&'a RawValue>,
+	#[serde(flatten)]
+	request_extensions: Option<&'a BTreeMap<String, Value>>,
+}
+
+#[derive(Deserialize)]
+struct RequestDe<'a> {
+	jsonrpc: TwoPointZero,
+	#[serde(borrow)]
+	id: Id<'a>,
+	#[serde(borrow)]
+	method: Cow<'a, str>,
+	#[serde(borrow)]
+	params: Option<Cow<'a, RawValue>>,
+	#[serde(flatten)]
+	request_extensions: BTreeMap<String, Value>,
+}
 
 /// JSON-RPC request object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Request<'a> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Request ID
-	#[serde(borrow)]
 	pub id: Id<'a>,
 	/// Name of the method to be invoked.
-	#[serde(borrow)]
 	pub method: Cow<'a, str>,
 	/// Parameter values of the request.
-	#[serde(borrow)]
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub params: Option<Cow<'a, RawValue>>,
 	/// The request's extensions.
-	#[serde(skip)]
 	pub extensions: Extensions,
 }
 
@@ -104,6 +192,53 @@ impl<'a> Request<'a> {
 	pub fn extensions_mut(&mut self) -> &mut Extensions {
 		&mut self.extensions
 	}
+
+	/// Returns the additional top-level JSON-RPC request members, when present.
+	pub fn request_extensions(&self) -> Option<&RequestExtensions> {
+		self.extensions.get()
+	}
+
+	/// Returns the additional top-level JSON-RPC request members for mutation.
+	pub fn request_extensions_mut(&mut self) -> &mut RequestExtensions {
+		self.extensions.get_or_insert_default()
+	}
+}
+
+impl Serialize for Request<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		RequestRef {
+			jsonrpc: &self.jsonrpc,
+			id: &self.id,
+			method: &self.method,
+			params: self.params.as_deref(),
+			request_extensions: self.request_extensions().map(|extensions| &extensions.members),
+		}
+		.serialize(serializer)
+	}
+}
+
+impl<'de: 'a, 'a> Deserialize<'de> for Request<'a> {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let request = RequestDe::deserialize(deserializer)?;
+		let mut extensions = Extensions::new();
+		if !request.request_extensions.is_empty() {
+			extensions.insert(RequestExtensions { members: request.request_extensions });
+		}
+
+		Ok(Self {
+			jsonrpc: request.jsonrpc,
+			id: request.id,
+			method: request.method,
+			params: request.params,
+			extensions,
+		})
+	}
 }
 
 /// JSON-RPC Invalid request as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
@@ -116,17 +251,15 @@ pub struct InvalidRequest<'a> {
 
 /// JSON-RPC notification (a request object without a request ID) as defined in the
 /// [spec](https://www.jsonrpc.org/specification#request-object).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Notification<'a, T> {
 	/// JSON-RPC version.
 	pub jsonrpc: TwoPointZero,
 	/// Name of the method to be invoked.
-	#[serde(borrow)]
 	pub method: Cow<'a, str>,
 	/// Parameter values of the request.
 	pub params: T,
 	/// Extensions of the notification.
-	#[serde(skip)]
 	pub extensions: Extensions,
 }
 
@@ -155,18 +288,84 @@ impl<'a, T> Notification<'a, T> {
 	pub fn extensions_mut(&mut self) -> &mut Extensions {
 		&mut self.extensions
 	}
+
+	/// Returns the additional top-level JSON-RPC request members, when present.
+	pub fn request_extensions(&self) -> Option<&RequestExtensions> {
+		self.extensions.get()
+	}
+
+	/// Returns the additional top-level JSON-RPC request members for mutation.
+	pub fn request_extensions_mut(&mut self) -> &mut RequestExtensions {
+		self.extensions.get_or_insert_default()
+	}
+}
+
+#[derive(Serialize)]
+struct NotificationRef<'a, 'request, T> {
+	jsonrpc: &'a TwoPointZero,
+	method: &'a Cow<'request, str>,
+	params: &'a T,
+	#[serde(flatten)]
+	request_extensions: Option<&'a BTreeMap<String, Value>>,
+}
+
+#[derive(Deserialize)]
+struct NotificationDe<'a, T> {
+	jsonrpc: TwoPointZero,
+	#[serde(borrow)]
+	method: Cow<'a, str>,
+	params: T,
+	#[serde(flatten)]
+	request_extensions: BTreeMap<String, Value>,
+}
+
+impl<T> Serialize for Notification<'_, T>
+where
+	T: Serialize,
+{
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		NotificationRef {
+			jsonrpc: &self.jsonrpc,
+			method: &self.method,
+			params: &self.params,
+			request_extensions: self.request_extensions().map(|extensions| &extensions.members),
+		}
+		.serialize(serializer)
+	}
+}
+
+impl<'de: 'a, 'a, T> Deserialize<'de> for Notification<'a, T>
+where
+	T: Deserialize<'de>,
+{
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let notification = NotificationDe::deserialize(deserializer)?;
+		let mut extensions = Extensions::new();
+		if !notification.request_extensions.is_empty() {
+			extensions.insert(RequestExtensions { members: notification.request_extensions });
+		}
+
+		Ok(Self { jsonrpc: notification.jsonrpc, method: notification.method, params: notification.params, extensions })
+	}
 }
 
 #[cfg(test)]
 mod test {
 	use super::{Id, InvalidRequest, Notification, Request, TwoPointZero};
-	use serde_json::value::RawValue;
+	use serde_json::{Value, value::RawValue};
 
 	fn assert_request<'a>(request: Request<'a>, id: Id<'a>, method: &str, params: Option<&str>) {
 		assert_eq!(request.jsonrpc, TwoPointZero);
 		assert_eq!(request.id, id);
 		assert_eq!(request.method, method);
 		assert_eq!(request.params.as_ref().map(|p| RawValue::get(p)), params);
+		assert!(request.request_extensions().is_none());
 	}
 
 	/// Checks that we can deserialize the object with or without non-mandatory fields.
@@ -203,6 +402,19 @@ mod test {
 	}
 
 	#[test]
+	fn deserialize_call_with_request_extensions() {
+		let serialized = r#"{"jsonrpc":"2.0","method":"subtract","params":[42,23],"id":1,"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01","vendor":{"sampled":true}}"#;
+		let request: Request = serde_json::from_str(serialized).unwrap();
+		let extensions = request.request_extensions().unwrap();
+
+		assert_eq!(
+			extensions.get("traceparent").and_then(Value::as_str),
+			Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+		);
+		assert_eq!(extensions.get("vendor").and_then(|value| value.get("sampled")), Some(&Value::Bool(true)));
+	}
+
+	#[test]
 	fn deserialize_valid_notif_works() {
 		let ser = r#"{"jsonrpc":"2.0","method":"say_hello","params":[]}"#;
 		let dsr: Notification<&RawValue> = serde_json::from_str(ser).unwrap();
@@ -216,6 +428,19 @@ mod test {
 		let dsr: Notification<&RawValue> = serde_json::from_str(ser).unwrap();
 		assert_eq!(dsr.method, "\"m\"");
 		assert_eq!(dsr.jsonrpc, TwoPointZero);
+	}
+
+	#[test]
+	fn deserialize_notification_with_request_extensions() {
+		let serialized = r#"{"jsonrpc":"2.0","method":"say_hello","params":[],"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01","vendor":{"sampled":true}}"#;
+		let notification: Notification<&RawValue> = serde_json::from_str(serialized).unwrap();
+		let extensions = notification.request_extensions().unwrap();
+
+		assert_eq!(
+			extensions.get("traceparent").and_then(Value::as_str),
+			Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+		);
+		assert_eq!(extensions.get("vendor").and_then(|value| value.get("sampled")), Some(&Value::Bool(true)));
 	}
 
 	#[test]
@@ -261,6 +486,51 @@ mod test {
 				serde_json::to_string(&Request::borrowed(method, params.as_deref(), id.unwrap_or(Id::Null))).unwrap();
 
 			assert_eq!(&request, ser);
+		}
+	}
+
+	#[test]
+	fn serialize_call_with_request_extensions() {
+		let mut request = Request::borrowed("subtract", None, Id::Number(1));
+		request
+			.request_extensions_mut()
+			.insert("traceparent", Value::String("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into()))
+			.unwrap();
+		request.request_extensions_mut().insert("vendor", serde_json::json!({ "sampled": true })).unwrap();
+
+		let serialized = serde_json::to_string(&request).unwrap();
+
+		assert_eq!(
+			serialized,
+			r#"{"jsonrpc":"2.0","id":1,"method":"subtract","traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01","vendor":{"sampled":true}}"#
+		);
+	}
+
+	#[test]
+	fn serialize_notification_with_request_extensions() {
+		let params = serde_json::value::to_raw_value(&Vec::<u8>::new()).unwrap();
+		let mut notification = Notification::new("say_hello".into(), params.as_ref());
+		notification
+			.request_extensions_mut()
+			.insert("traceparent", Value::String("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into()))
+			.unwrap();
+		notification.request_extensions_mut().insert("vendor", serde_json::json!({ "sampled": true })).unwrap();
+
+		let serialized = serde_json::to_string(&notification).unwrap();
+
+		assert_eq!(
+			serialized,
+			r#"{"jsonrpc":"2.0","method":"say_hello","params":[],"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01","vendor":{"sampled":true}}"#
+		);
+	}
+
+	#[test]
+	fn reserved_request_extension_names_are_rejected() {
+		let mut request = Request::borrowed("subtract", None, Id::Number(1));
+
+		for name in ["jsonrpc", "id", "method", "params"] {
+			let error = request.request_extensions_mut().insert(name, Value::Null).unwrap_err();
+			assert_eq!(error.name(), name);
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

jsonrpsee RPC middleware receives already-deserialized calls and notifications. Unknown top-level request members are currently discarded before middleware can inspect them, so middleware cannot implement per-request protocol extensions without putting metadata in method params.

Distributed tracing is the immediate use case: HTTP can carry W3C Trace Context in headers, but a long-lived WebSocket needs per-message metadata. The type-level support should remain generic rather than making jsonrpsee own W3C or OpenTelemetry policy.

## Changes

- Add `RequestExtensions`, a typed map of additional top-level JSON-RPC request members stored inside the existing `http::Extensions`.
- Preserve unknown top-level members while deserializing calls and notifications and serialize them back when present.
- Expose `request_extensions()` and `request_extensions_mut()` on `Request` and `Notification`.
- Reject insertion of the reserved `jsonrpc`, `id`, `method`, and `params` members.
- Merge transport extensions into deserialized server requests instead of replacing wire extensions.
- Keep serialized output unchanged when no request extensions are present.

## Scope

The values are generic `serde_json::Value` entries. jsonrpsee does not create spans, validate trace context, or depend on an observability library. User middleware owns the meaning of each extension.

The API supports tracing fields such as `traceparent` and `tracestate`, but is not specific to them.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p jsonrpsee-types`
- `cargo test -p jsonrpsee-server utils::tests`
- `cargo test --workspace --all-features`
- Focused clippy for the changed crates passes; a full newer-nightly run reports existing warnings in untouched files.
