### PR TITLE
ci: fix benchmarks job

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,11 +17,17 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
       - name: run benchmarks
-        run: cargo bench -p jsonrpsee-benchmarks -- --output-format bencher | tee output.txt
+        shell: bash
+        run: |
+          ulimit -n "$(ulimit -Hn)"
+          cargo bench -p jsonrpsee-benchmarks -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00 # v1.20.5


### PR DESCRIPTION
Fixes the Benchmarks job, which has failed on every run since the `parity-benchmark` runner was reprovisioned 