### PR TITLE
fix(server): do not close subscription when a cloned sink is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+### [Fixed]
+
+- fix(server): dropping a cloned `SubscriptionSink` no longer closes the remaining subscription ([#1622](https://github.com/paritytech/jsonrpsee/issues/1622))
+
 ### [Added]
 
 - feat(http-client): expose connect timeout option ([#1643](https://github.com/paritytech/jsonrpsee/pull/1643))

--- a/core/src/server/subscription.rs
+++ b/core/src/server/subscription.rs
@@ -292,7 +292,11 @@ impl PendingSubscriptionSink {
 	}
 }
 
-/// Represents a single subscription that hasn't been processed yet.
+/// Represents a single subscription.
+///
+/// This type is cheap to clone; clones share the same subscription. The subscription is
+/// removed from the server only when the last clone is dropped, or when the client
+/// unsubscribes or disconnects.
 #[derive(Debug, Clone)]
 pub struct SubscriptionSink {
 	/// Sink.
@@ -413,7 +417,9 @@ impl SubscriptionSink {
 
 impl Drop for SubscriptionSink {
 	fn drop(&mut self) {
-		if self.is_active_subscription() {
+		// Clones share the same subscription. Only the last sink should tear it down;
+		// otherwise dropping a clone closes the remaining sink (see #1622).
+		if self.is_active_subscription() && Arc::strong_count(&self._permit) == 1 {
 			self.subscribers.lock().remove(&self.uniq_sub);
 		}
 	}

--- a/tests/tests/rpc_module.rs
+++ b/tests/tests/rpc_module.rs
@@ -267,6 +267,29 @@ async fn subscribing_without_server() {
 }
 
 #[tokio::test]
+async fn subscription_sink_clone_drop_keeps_subscription_alive() {
+	init_logger();
+
+	let mut module = RpcModule::new(());
+	module
+		.register_subscription("my_sub", "my_sub", "my_unsub", |_, pending, _, _| async move {
+			let sink = pending.accept().await?;
+			drop(sink.clone());
+
+			assert!(!sink.is_closed(), "dropping a cloned SubscriptionSink must not close the remaining sink");
+
+			let msg = serde_json::value::to_raw_value("still-alive")?;
+			sink.send(msg).await?;
+			Ok(())
+		})
+		.unwrap();
+
+	let mut my_sub = module.subscribe_unbounded("my_sub", EmptyServerParams::new()).await.unwrap();
+	let (val, _) = my_sub.next::<String>().await.unwrap().unwrap();
+	assert_eq!(val, "still-alive");
+}
+
+#[tokio::test]
 async fn close_test_subscribing_without_server() {
 	init_logger();
 


### PR DESCRIPTION
## Problem

`SubscriptionSink` is `Clone`, but `Drop` treated every dropped clone as the end of the subscription.

Dropping a clone removed the shared subscriber entry, which dropped the unsubscribe receiver and marked the remaining sink as closed. The client then stopped receiving notifications even though another `SubscriptionSink` was still alive.

Reported in https://github.com/paritytech/jsonrpsee/issues/1622. Maintainer confirmed the current `Drop` behaviour is wrong.

## Root Cause

`SubscriptionSink::drop` always did:

```rust
self.subscribers.lock().remove(&self.uniq_sub);
```

when `is_active_subscription()` was true. That map entry owns the `mpsc::Receiver` used to track liveness, so removing it closed the subscription for every clone.

## Fix

Keep `Clone`. Tear the subscription down only when the last `SubscriptionSink` is dropped, using the existing `Arc` around the subscription permit (`Arc::strong_count == 1`), as suggested on the issue.

## Regression Test

`subscription_sink_clone_drop_keeps_subscription_alive` in `tests/tests/rpc_module.rs`:

1. Accept a subscription
2. Clone the sink and drop the clone
3. Assert the original sink is still open and can send
4. Assert the client receives the notification

On `master` this test fails (`is_closed() == true`, client gets `None`). After the fix it passes.

## Verification

On this machine (`stable-x86_64-pc-windows-gnu`):

- `cargo test -p jsonrpsee-integration-tests --test rpc_module subscription_sink_clone_drop_keeps_subscription_alive` — fail before fix, pass after
- `cargo test -p jsonrpsee-integration-tests --test rpc_module` — 20 passed
- `cargo fmt --all -- --check` — pass
- `cargo clippy -p jsonrpsee-core --all-targets --all-features` — pass (no new warnings)

## Scope

Intentionally unchanged:

- `Clone` remains available (removing it would be a breaking API change)
- Unsubscribe / disconnect still close the subscription
- Dropping the last remaining sink still removes the subscriber entry

Fixes #1622
